### PR TITLE
fix: make VSCode PID optional in MCP server

### DIFF
--- a/symposium/mcp-server/src/actor/dispatch.rs
+++ b/symposium/mcp-server/src/actor/dispatch.rs
@@ -278,13 +278,13 @@ impl DispatchHandle {
     pub fn new(
         client_rx: mpsc::Receiver<IPCMessage>,
         client_tx: mpsc::Sender<IPCMessage>,
-        shell_pid: u32,
+        shell_pid: Option<u32>,
         reference_handle: crate::actor::ReferenceHandle,
     ) -> Self {
         let (actor_tx, actor_rx) = mpsc::channel(32);
 
         let sender = create_sender(shell_pid);
-        info!("MCP server sender with PID {shell_pid} sender info: {sender:?}");
+        info!("MCP server sender with PID {shell_pid:?} sender info: {sender:?}");
 
         let actor = DispatchActor::new(
             actor_rx,
@@ -375,7 +375,7 @@ impl DispatchHandle {
 
 }
 
-fn create_sender(shell_pid: u32) -> crate::types::MessageSender {
+fn create_sender(shell_pid: Option<u32>) -> crate::types::MessageSender {
     // Try to extract taskspace UUID from directory structure
     let taskspace_uuid = crate::ipc::extract_project_info()
         .map(|(_, uuid)| uuid)
@@ -383,7 +383,7 @@ fn create_sender(shell_pid: u32) -> crate::types::MessageSender {
     crate::types::MessageSender {
         working_directory: working_directory(),
         taskspace_uuid,
-        shell_pid: Some(shell_pid),
+        shell_pid,
     }
 }
 

--- a/symposium/mcp-server/src/types.rs
+++ b/symposium/mcp-server/src/types.rs
@@ -110,8 +110,6 @@ impl IpcPayload for PresentWalkthroughMessage {
 /// Polo discovery message - announces presence with shell PID
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PoloMessage {
-    #[serde(rename = "terminalShellPid")]
-    pub terminal_shell_pid: u32,
 }
 
 impl IpcPayload for PoloMessage {

--- a/symposium/mcp-server/tests/reference_integration_test.rs
+++ b/symposium/mcp-server/tests/reference_integration_test.rs
@@ -57,7 +57,7 @@ async fn test_reference_integration_via_dispatch_actor() {
     let reference_handle = ReferenceHandle::new();
 
     // Create dispatch handle with the reference handle
-    let _dispatch_handle = DispatchHandle::new(mock_rx, client_tx, 12345, reference_handle.clone());
+    let _dispatch_handle = DispatchHandle::new(mock_rx, client_tx, Some(12345), reference_handle.clone());
 
     // Test data
     let test_context = json!({


### PR DESCRIPTION
The MCP server now gracefully handles cases where VSCode PID discovery fails. This enables the server to work with persistent agents and other scenarios where it's not running from a VSCode terminal.

Changes:
- Made shell_pid Option<u32> throughout the codebase
- Updated DispatchHandle::new to accept Option<u32>
- Updated IPCCommunicator to store Option<u32> for terminal_shell_pid
- Server::new now logs a warning instead of bailing when PID discovery fails
- PoloMessage payload is now empty (shell_pid goes in MessageSender)
- Updated send_polo and send_goodbye to not take shell_pid parameter
- Fixed test to use Some(12345) for shell_pid

The TypeScript and Swift codebases already had shell_pid as optional, so no changes were needed there.