### PR TITLE
chore: release v1.0.0-alpha.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3158,7 +3158,7 @@ dependencies = [
 
 [[package]]
 name = "symposium-ferris"
-version = "1.0.0-alpha.3"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/src/symposium-acp-agent/CHANGELOG.md
+++ b/src/symposium-acp-agent/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium/compare/symposium-acp-agent-v1.0.0-alpha.2...symposium-acp-agent-v1.0.0-alpha.3) - 2025-12-30
+## [1.0.0](https://github.com/symposium-dev/symposium/compare/symposium-acp-agent-v1.0.0-alpha.2...symposium-acp-agent-v1.0.0) - 2025-12-30
 
 ### Other
 

--- a/src/symposium-acp-agent/Cargo.toml
+++ b/src/symposium-acp-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symposium-acp-agent"
-version = "1.0.0-alpha.3"
+version = "1.0.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Symposium-enriched ACP agent that wraps downstream agents with enhanced capabilities"
@@ -23,5 +23,5 @@ tracing-subscriber = { workspace = true }
 clap = { workspace = true }
 
 # Symposium components
-symposium-acp-proxy = { path = "../symposium-acp-proxy", version = "1.0.0-alpha.3" }
-symposium-ferris = { path = "../symposium-ferris", version = "1.0.0-alpha.3" }
+symposium-acp-proxy = { path = "../symposium-acp-proxy", version = "1.0.0" }
+symposium-ferris = { path = "../symposium-ferris", version = "1.0.0" }

--- a/src/symposium-acp-proxy/CHANGELOG.md
+++ b/src/symposium-acp-proxy/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium/compare/symposium-acp-proxy-v1.0.0-alpha.2...symposium-acp-proxy-v1.0.0-alpha.3) - 2025-12-30
+## [1.0.0](https://github.com/symposium-dev/symposium/compare/symposium-acp-proxy-v1.0.0-alpha.2...symposium-acp-proxy-v1.0.0) - 2025-12-30
 
 ### Other
 

--- a/src/symposium-acp-proxy/Cargo.toml
+++ b/src/symposium-acp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symposium-acp-proxy"
-version = "1.0.0-alpha.3"
+version = "1.0.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Symposium ACP proxy - orchestrates component chains to enrich agent capabilities"
@@ -34,6 +34,6 @@ chrono = "0.4"
 tokio-util = { version = "0.7", features = ["compat"] }
 
 # Proxy components
-symposium-ferris = { path = "../symposium-ferris", version = "1.0.0-alpha.3" }
+symposium-ferris = { path = "../symposium-ferris", version = "1.0.0" }
 sacp-tee.workspace = true
 sparkle.workspace = true

--- a/src/symposium-ferris/CHANGELOG.md
+++ b/src/symposium-ferris/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium/compare/symposium-ferris-v1.0.0-alpha.2...symposium-ferris-v1.0.0-alpha.3) - 2025-12-30
+## [1.0.0](https://github.com/symposium-dev/symposium/compare/symposium-ferris-v1.0.0-alpha.2...symposium-ferris-v1.0.0) - 2025-12-30
 
 ### Other
 

--- a/src/symposium-ferris/Cargo.toml
+++ b/src/symposium-ferris/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symposium-ferris"
-version = "1.0.0-alpha.3"
+version = "1.0.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Ferris MCP server - helpful tools for Rust development"


### PR DESCRIPTION



## 🤖 New release

* `symposium-ferris`: 1.0.0-alpha.2 -> 1.0.0-alpha.3 (✓ API compatible changes)
* `symposium-acp-proxy`: 1.0.0-alpha.2 -> 1.0.0-alpha.3 (✓ API compatible changes)
* `symposium-acp-agent`: 1.0.0-alpha.2 -> 1.0.0-alpha.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `symposium-ferris`

<blockquote>

## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium/compare/symposium-ferris-v1.0.0-alpha.2...symposium-ferris-v1.0.0-alpha.3) - 2025-12-30

### Other

- update Cargo.toml dependencies
</blockquote>

## `symposium-acp-proxy`

<blockquote>

## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium/compare/symposium-acp-proxy-v1.0.0-alpha.2...symposium-acp-proxy-v1.0.0-alpha.3) - 2025-12-30

### Other

- update Cargo.toml dependencies
</blockquote>

## `symposium-acp-agent`

<blockquote>

## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium/compare/symposium-acp-agent-v1.0.0-alpha.2...symposium-acp-agent-v1.0.0-alpha.3) - 2025-12-30

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).