### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3789,7 +3789,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symposium-acp-agent"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "symposium-ferris"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/src/symposium-acp-agent/CHANGELOG.md
+++ b/src/symposium-acp-agent/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.3.0](https://github.com/symposium-dev/symposium/compare/symposium-acp-agent-v1.2.0...symposium-acp-agent-v1.3.0) - 2026-01-08
+
+### Added
+
+- add cargo distribution type for extensions
+
+### Fixed
+
+- use rustls instead of native-tls for reqwest
+
+### Other
+
+- include claude code and do not block
+- Rename CLI commands: act-as-configured -> run, run -> run-with
+- Unify CLI to 'run' command and centralize registry access
+
 ## [1.2.0](https://github.com/symposium-dev/symposium/compare/symposium-acp-agent-v1.1.1...symposium-acp-agent-v1.2.0) - 2026-01-08
 
 ### Added

--- a/src/symposium-acp-agent/Cargo.toml
+++ b/src/symposium-acp-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symposium-acp-agent"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Symposium-enriched ACP agent that wraps downstream agents with enhanced capabilities"
@@ -28,7 +28,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 # Symposium proxy components
-symposium-ferris = { path = "../symposium-ferris", version = "1.0.1" }
+symposium-ferris = { path = "../symposium-ferris", version = "1.0.2" }
 symposium-cargo = "0.2.0"
 sparkle.workspace = true
 

--- a/src/symposium-ferris/CHANGELOG.md
+++ b/src/symposium-ferris/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2](https://github.com/symposium-dev/symposium/compare/symposium-ferris-v1.0.1...symposium-ferris-v1.0.2) - 2026-01-08
+
+### Other
+
+- include claude code and do not block
+
 ## [1.0.1](https://github.com/symposium-dev/symposium/compare/symposium-ferris-v1.0.0...symposium-ferris-v1.0.1) - 2025-12-31
 
 ### Other

--- a/src/symposium-ferris/Cargo.toml
+++ b/src/symposium-ferris/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symposium-ferris"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2024"
 license = "Apache-2.0"
 description = "Ferris MCP server - helpful tools for Rust development"


### PR DESCRIPTION



## 🤖 New release

* `symposium-ferris`: 1.0.1 -> 1.0.2 (✓ API compatible changes)
* `symposium-acp-agent`: 1.2.0 -> 1.3.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `symposium-ferris`

<blockquote>

## [1.0.2](https://github.com/symposium-dev/symposium/compare/symposium-ferris-v1.0.1...symposium-ferris-v1.0.2) - 2026-01-08

### Other

- include claude code and do not block
</blockquote>

## `symposium-acp-agent`

<blockquote>

## [1.3.0](https://github.com/symposium-dev/symposium/compare/symposium-acp-agent-v1.2.0...symposium-acp-agent-v1.3.0) - 2026-01-08

### Added

- add cargo distribution type for extensions

### Fixed

- use rustls instead of native-tls for reqwest

### Other

- include claude code and do not block
- Rename CLI commands: act-as-configured -> run, run -> run-with
- Unify CLI to 'run' command and centralize registry access
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).