### PR TITLE
fix(vscode-extension): show ACP tool calls in chat

### DIFF
--- a/md/design/vscode-extension/implementation-status.md
+++ b/md/design/vscode-extension/implementation-status.md
@@ -50,13 +50,13 @@ This chapter tracks what's been implemented, what's in progress, and what's plan
 The client receives `sessionUpdate` notifications from the agent. Current support:
 
 - [x] `agent_message_chunk` - Display streaming text in chat UI
-- [x] `tool_call` - Logged to console (not displayed in UI)
-- [x] `tool_call_update` - Logged to console (not displayed in UI)
+- [x] `tool_call` - Display as a tool card in the chat UI
+- [x] `tool_call_update` - Update the existing tool card in the chat UI
 - [ ] Execution plans - Not implemented
 - [ ] Thinking steps - Not implemented
 - [ ] Custom update types - Not implemented
 
-**Gap:** Tool calls are logged but not visually displayed. Users don't see which tools are being executed or their progress.
+**Known limitation:** The webview currently renders tool cards using `title` plus `rawInput`/`rawOutput`. Other fields like `content` and `locations` are not yet surfaced in the UI.
 
 ### File System Capabilities
 

--- a/vscode-extension/src/symposium-webview.ts
+++ b/vscode-extension/src/symposium-webview.ts
@@ -30,7 +30,12 @@ const tabCurrentStreamType: { [tabId: string]: "text" | "tool" } = {};
 const tabToolCalls: { [tabId: string]: { [toolCallId: string]: string } } = {};
 
 // Tool call status type (matches ACP)
-type ToolCallStatus = "pending" | "running" | "completed" | "failed";
+type ToolCallStatus =
+  | "pending"
+  | "running"
+  | "in_progress"
+  | "completed"
+  | "failed";
 
 // Tool call info from extension
 interface ToolCallInfo {
@@ -166,6 +171,7 @@ function getToolStatusIcon(status: ToolCallStatus): string {
     case "pending":
       return "⏳";
     case "running":
+    case "in_progress":
       return "⚙️";
     case "completed":
       return "✓";
@@ -186,6 +192,7 @@ function getToolStatus(
     case "failed":
       return "error";
     case "running":
+    case "in_progress":
       return "info";
     default:
       return undefined;
@@ -279,7 +286,9 @@ function updateToolCallCard(
 ) {
   const icon = getToolStatusIcon(toolCall.status);
   const shimmer =
-    toolCall.status === "running" || toolCall.status === "pending";
+    toolCall.status === "running" ||
+    toolCall.status === "in_progress" ||
+    toolCall.status === "pending";
   const details = buildToolDetails(toolCall);
 
   // Replace backticks with single quotes for display

--- a/vscode-extension/src/test/tool-updates.test.ts
+++ b/vscode-extension/src/test/tool-updates.test.ts
@@ -1,0 +1,75 @@
+import * as assert from "assert";
+import { SymposiumClient, ToolCallInfo } from "../acpAgentActor";
+
+suite("Tool Update Forwarding", () => {
+  test("Should forward tool_call even when status is omitted", async () => {
+    const toolCalls: ToolCallInfo[] = [];
+
+    const client = new SymposiumClient({
+      onAgentText: () => {},
+      onUserText: () => {},
+      onAgentComplete: () => {},
+      onToolCall: (_sessionId, toolCall) => {
+        toolCalls.push(toolCall);
+      },
+    });
+
+    await client.sessionUpdate({
+      sessionId: "test-session",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tool-1",
+        title: "Read src/main.rs",
+        // status intentionally omitted
+      },
+    } as any);
+
+    assert.strictEqual(toolCalls.length, 1);
+    assert.strictEqual(toolCalls[0].toolCallId, "tool-1");
+    assert.strictEqual(toolCalls[0].title, "Read src/main.rs");
+    assert.strictEqual(toolCalls[0].status, "in_progress");
+  });
+
+  test("Should forward tool_call_update even when status is omitted", async () => {
+    const toolCallUpdates: ToolCallInfo[] = [];
+
+    const client = new SymposiumClient({
+      onAgentText: () => {},
+      onUserText: () => {},
+      onAgentComplete: () => {},
+      onToolCall: () => {},
+      onToolCallUpdate: (_sessionId, toolCall) => {
+        toolCallUpdates.push(toolCall);
+      },
+    });
+
+    // Initial tool call establishes title/status.
+    await client.sessionUpdate({
+      sessionId: "test-session",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tool-2",
+        title: "Search for replace_goal_chapters",
+        status: "in_progress",
+      },
+    } as any);
+
+    // Update with output only (status omitted).
+    await client.sessionUpdate({
+      sessionId: "test-session",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tool-2",
+        rawOutput: { matches: 3 },
+        // status intentionally omitted
+      },
+    } as any);
+
+    assert.strictEqual(toolCallUpdates.length, 1);
+    assert.strictEqual(toolCallUpdates[0].toolCallId, "tool-2");
+    assert.strictEqual(toolCallUpdates[0].title, "Search for replace_goal_chapters");
+    assert.strictEqual(toolCallUpdates[0].status, "in_progress");
+    assert.deepStrictEqual(toolCallUpdates[0].rawOutput, { matches: 3 });
+  });
+});
+


### PR DESCRIPTION
Why
- Make ACP tool execution visible and understandable in the chat UI.

How
- Forward tool_call/tool_call_update even when status is omitted by caching tool call state.
- Render/update tool cards in the webview and treat in_progress as a running state.