### PR TITLE
fix(setup): build mynah-ui during vscode extension setup

### DIFF
--- a/setup/src/vscode.rs
+++ b/setup/src/vscode.rs
@@ -150,6 +150,23 @@ fn install_vendor_dependencies(repo_root: &Path) -> Result<()> {
         ));
     }
 
+    // Build mynah-ui (generates dist/ with type declarations)
+    println!("🔨 Building vendor dependencies (mynah-ui)...");
+
+    let output = Command::new("npm")
+        .args(["run", "build"])
+        .current_dir(&mynah_dir)
+        .output()
+        .context("Failed to execute npm run build in vendor/mynah-ui")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!(
+            "❌ Failed to build vendor dependencies:\n   Error: {}",
+            stderr.trim()
+        ));
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
The setup script ran `npm install` in vendor/mynah-ui but didn't build it. TypeScript compilation failed because the dist/ folder with type declarations didn't exist.