### PR TITLE
Add kiro-cli as conditional built-in agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,6 +1080,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "env_logger"
 version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3817,6 +3823,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "which 8.0.0",
  "zip",
 ]
 
@@ -4826,6 +4833,17 @@ dependencies = [
  "either",
  "home",
  "rustix 0.38.44",
+ "winsafe",
+]
+
+[[package]]
+name = "which"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+dependencies = [
+ "env_home",
+ "rustix 1.1.3",
  "winsafe",
 ]
 

--- a/src/symposium-acp-agent/Cargo.toml
+++ b/src/symposium-acp-agent/Cargo.toml
@@ -53,6 +53,7 @@ zip = "2"
 fxhash.workspace = true
 regex = "1.12.2"
 cargo_metadata = "0.23"
+which = "8"
 
 [[example]]
 name = "vscodelm_cli"


### PR DESCRIPTION
Replace zed-claude-code with kiro-cli in built-in agent registry. Uses which crate to detect if kiro-cli is available on PATH. If found, registers it with 'kiro-cli acp' as the command.

This is required until the kiro-cli makes its way onto the main registry.