### PR TITLE
Fix: Add Windows .cmd extension for npm/npx/code commands

### DIFF
--- a/setup/src/vscode.rs
+++ b/setup/src/vscode.rs
@@ -4,6 +4,14 @@ use anyhow::{Context, Result, anyhow};
 use std::path::Path;
 use std::process::Command;
 
+fn platform_command(base: &str) -> String {
+    if cfg!(target_os = "windows") {
+        format!("{}.cmd", base)
+    } else {
+        base.to_string()
+    }
+}
+
 /// Build and install the VSCode extension
 pub fn build_and_install_extension(repo_root: &Path, dry_run: bool) -> Result<()> {
     let extension_dir = repo_root.join("vscode-extension");
@@ -136,7 +144,7 @@ fn install_vendor_dependencies(repo_root: &Path) -> Result<()> {
 
     println!("📥 Installing vendor dependencies (mynah-ui)...");
 
-    let output = Command::new("npm")
+    let output = Command::new(platform_command("npm"))
         .args(["install"])
         .current_dir(&mynah_dir)
         .output()
@@ -153,7 +161,7 @@ fn install_vendor_dependencies(repo_root: &Path) -> Result<()> {
     // Build mynah-ui (generates dist/ with type declarations)
     println!("🔨 Building vendor dependencies (mynah-ui)...");
 
-    let output = Command::new("npm")
+    let output = Command::new(platform_command("npm"))
         .args(["run", "build"])
         .current_dir(&mynah_dir)
         .output()
@@ -174,7 +182,7 @@ fn install_vendor_dependencies(repo_root: &Path) -> Result<()> {
 fn install_dependencies(extension_dir: &Path) -> Result<()> {
     println!("📥 Installing extension dependencies...");
 
-    let output = Command::new("npm")
+    let output = Command::new(platform_command("npm"))
         .args(["install"])
         .current_dir(extension_dir)
         .output()
@@ -195,7 +203,7 @@ fn install_dependencies(extension_dir: &Path) -> Result<()> {
 fn build_extension(extension_dir: &Path) -> Result<()> {
     println!("🔨 Building extension...");
 
-    let output = Command::new("npm")
+    let output = Command::new(platform_command("npm"))
         .args(["run", "webpack-dev"])
         .current_dir(extension_dir)
         .output()
@@ -219,7 +227,7 @@ fn package_extension(extension_dir: &Path) -> Result<()> {
     // Clean up any old .vsix files first to avoid ambiguity
     clean_old_vsix_files(extension_dir)?;
 
-    let output = Command::new("npx")
+    let output = Command::new(platform_command("npx"))
         .args(["vsce", "package", "--no-dependencies"])
         .current_dir(extension_dir)
         .output()
@@ -243,7 +251,7 @@ fn install_extension(extension_dir: &Path) -> Result<()> {
 
     println!("📥 Installing VSCode extension: {}", vsix_file);
 
-    let output = Command::new("code")
+    let output = Command::new(platform_command("code"))
         .args(["--install-extension", &vsix_file])
         .current_dir(extension_dir)
         .output()

--- a/vendor/mynah-ui/package-lock.json
+++ b/vendor/mynah-ui/package-lock.json
@@ -117,6 +117,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.7.tgz",
             "integrity": "sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.23.5",
@@ -1754,6 +1755,7 @@
             "integrity": "sha512-y1dMvuvJspJiPSDZUQ+WMBvF7dpnEqN4x9DDC9ie5Fs/HUZJA3wFp7EhHoVaKX/iI0cRoECV8X2jL8zi0xrHCg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~7.12.0"
             }
@@ -1872,6 +1874,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
             "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "5.62.0",
                 "@typescript-eslint/types": "5.62.0",
@@ -2305,6 +2308,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
             "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2366,6 +2370,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -2787,6 +2792,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001565",
                 "electron-to-chromium": "^1.4.601",
@@ -3888,6 +3894,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
             "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -4085,6 +4092,7 @@
             "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
             "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "array-includes": "^3.1.4",
                 "array.prototype.flat": "^1.2.5",
@@ -4139,6 +4147,7 @@
             "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.2.5.tgz",
             "integrity": "sha512-8+BYsqiyZfpu6NXmdLOXVUfk8IocpCjpd8nMRRH0A9ulrcemhb2VI9RSJMEy5udx++A/YcVPD11zT8hpFq368g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "builtins": "^5.0.1",
                 "eslint-plugin-es": "^4.1.0",
@@ -4239,6 +4248,7 @@
             "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz",
             "integrity": "sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
@@ -5847,6 +5857,7 @@
             "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
             "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -7738,7 +7749,6 @@
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
             },
@@ -8455,6 +8465,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.7",
                 "picocolors": "^1.0.0",
@@ -8556,6 +8567,7 @@
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
             "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -8990,6 +9002,7 @@
             "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.8.tgz",
             "integrity": "sha512-NoGOjvDDOU9og9oAxhRnap71QaTjjlzrvLnKecUJ3GxhaQBrV6e7gPuSPF28u1OcVAArVojPAe4ZhOXwwC4tGw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
                 "immutable": "^4.0.0",
@@ -9914,6 +9927,7 @@
             "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
             "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -10181,6 +10195,7 @@
             "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -10376,6 +10391,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
             "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/estree": "^1.0.5",
                 "@webassemblyjs/ast": "^1.12.1",
@@ -10422,6 +10438,7 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.7.2.tgz",
             "integrity": "sha512-mEoLmnmOIZQNiRl0ebnjzQ74Hk0iKS5SiEEnpq3dRezoyR3yPaeQZCMCe+db4524pj1Pd5ghZXjT41KLzIhSLw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^1.0.4",

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -604,6 +604,7 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -1067,6 +1068,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1303,6 +1305,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -1804,6 +1807,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3598,6 +3602,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3988,6 +3993,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4483,6 +4489,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4594,6 +4601,7 @@
       "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -4643,6 +4651,7 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",


### PR DESCRIPTION
## Fix: setup script failing on Windows

## Problem
The setup script fails on Windows with "program not found" errors when trying to run npm, npx, and code.
This happens because on Windows, these are batch scripts (.cmd files), not executables. Rust's Command::new("npm") doesn't automatically add the .cmd extension, so it can't find them.

## Solution
Added a helper function that appends `.cmd` on Windows:

```rust
fn platform_command(base: &str) -> String {
    if cfg!(target_os = "windows") {
        format!("{}.cmd", base)
    } else {
        base.to_string()
    }
}
```

Then replaced:
- `Command::new("npm")` → `Command::new(platform_command("npm"))`
- `Command::new("npx")` → `Command::new(platform_command("npx"))`
- `Command::new("code")` → `Command::new(platform_command("code"))`