### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,119 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/symposium-dev/symposium/compare/symposium-v0.1.0...symposium-v0.2.0) - 2026-04-21
+
+### Added
+
+- add Gemini BeforeAgent hook and cross-agent event mapping
+- filter to direct dependencies only
+- crate predicate system with wildcard, plugin-level filtering, and MCP server filtering
+- directory-based plugins with SYMPOSIUM.toml and plugin source discovery
+- dual-mode agent integration test infrastructure
+- add hook-scope config (global vs project)
+- wire plugin MCP servers through sync_agent
+- add MCP server registration and unregistration for all agents
+- add McpServerEntry type and mcp_servers field to plugin manifest
+- add plugin format routing via HookFormat
+- add support for Codex CLI, Kiro, OpenCode, and Goose agents
+- add --remove-agent flag to init and sync
+- support multiple agents via [[agent]] config entries
+- support project-level plugin sources and self-contained mode
+- add SessionStart hook with plugin session-start-context
+- reframe install, about page
+- implement cargo-agents CLI with init, sync, and hook flows
+
+### Fixed
+
+- fixup! WIP--merge into 1: refactor: restructure documentation navigation and consolidate pages
+- fixup! docs: expand install guide and agent MCP server documentation
+- fixup! fix: auto-sync cwd resolution falls back to process cwd
+- fixup! feat: crate predicate system with wildcard, plugin-level filtering, and MCP server filtering
+- fixup! feat: directory-based plugins with SYMPOSIUM.toml and plugin source discovery
+- fixup! feat: directory-based plugins with SYMPOSIUM.toml and plugin source discovery
+- fixup! feat: directory-based plugins with SYMPOSIUM.toml and plugin source discovery
+- fixup! feat: crate predicate system with wildcard, plugin-level filtering, and MCP server filtering
+- fixup! feat: crate predicate system with wildcard, plugin-level filtering, and MCP server filtering
+- fixup! feat: crate predicate system with wildcard, plugin-level filtering, and MCP server filtering
+- auto-sync cwd resolution falls back to process cwd
+- use XDG_STATE_HOME for logs directory
+- Kiro agent config needs tools and resources fields
+- handle events without agent-specific handlers gracefully
+- make --add-agent additive and fix project agent resolution
+- pre-select existing agents in prompt and remove hooks on unconfig
+- split Copilot hook registration for global vs project paths
+- use Symposium.home_dir for global hook registration instead of dirs::home_dir
+
+### Other
+
+- update the anem of the book
+- fmt
+- Support cargo subcommand convention for 'cargo agents'
+- fmt
+- Keep 'symposium' as the agent/server identity name
+- Rename binary from symposium to cargo-agents
+- hide agent-facing CLI commands and rename `crate` to `crate-info`
+- fixup warning
+- cargo fmt
+- WIP--merge into 1: refactor: restructure documentation navigation and consolidate pages
+- WIP--merge into 6: feat: crate predicate system with wildcard, plugin-level filtering, and MCP server filtering
+- WIP--merge into 5: feat: directory-based plugins with SYMPOSIUM.toml and plugin source discovery
+- WIP--merge into 1: refactor: restructure documentation navigation and consolidate pages
+- remove session_start_context from plugins
+- remove activation field from skills
+- expand install guide and agent MCP server documentation
+- restructure documentation navigation and consolidate pages
+- pacify the merciless cargo fmt
+- simplify configuration: remove per-project config
+- Simplify CLI: remove start command, crate --list, and skills output
+- Remove built-in MCP server
+- Remove start command from MCP server, inline dispatch into CLI
+- Merge pull request #175 from nikomatsakis/azure-range
+- pacify the merciless cargo fmt
+- Add test for non-object container recovery in JSON MCP registration
+- Fix Goose stale-entry updates and add YAML quoting tests
+- Clarify Copilot MCP registration format in design doc
+- Strengthen Codex stale-entry update test
+- Replace deprecated serde_yaml with serde_yaml_ng
+- Document Goose stale-entry limitation
+- Quote command and args in Goose YAML snippet
+- Include env/headers in server_to_json when non-empty
+- Harden register_json_mcp_servers against non-object container
+- Panic on unknown McpServer variants instead of silent fallback
+- Remove builtin MCP server variant
+- Add MCP server documentation and use type = "builtin" for builtin entries
+- add MCP server registration docs to all agent detail files
+- move symposium binary resolution to Symposium struct
+- convert agents module to directory structure
+- Remove skill nudging and activation tracking
+- pacify the merciless fmt
+- minor fixes — Output::is_quiet, non-interactive init, docs
+- update test harness and integration tests for new hook API
+- replace generic hook dispatch with agent-owned wire formats and plugin format routing
+- introduce canonical symposium hook types
+- Fmt and add CI check
+- rename agent detail docs, add disclaimers and primary source links
+- rename reference/ to agent-details/ and add cross-agent comparison
+- document session-start-context in plugin definition reference
+- verify hook removal when switching agents
+- revert CLI naming from cargo-agents back to symposium
+- verify self-contained excludes user skills from sync
+- use fixtures for project plugin source tests
+- add integration tests for project plugin sources and self-contained mode
+- add command flow docs, agent details, and misc reference updates
+- the heck
+- rewrite getting-started guide for cargo-agents
+- Review comments
+- Allow calling hooks with other agents. Fix claude output.
+- Add copilot
+- Add Gemini BeforeTool hook
+- Typo in PR template
+- Add adapter skeleton for hooks
+- Rewiew nits. Add merge docs and cfg out tests using sh
+- Forward hooks output

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symposium"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symposium"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "AI the Rust Way"


### PR DESCRIPTION



## 🤖 New release

* `symposium`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `symposium` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ValidationResult.warning in /tmp/.tmpoBPblt/symposium/src/plugins.rs:586
  field ValidationResult.children in /tmp/.tmpoBPblt/symposium/src/plugins.rs:588
  field Installation.summary in /tmp/.tmpoBPblt/symposium/src/plugins.rs:118
  field Plugin.crates in /tmp/.tmpoBPblt/symposium/src/plugins.rs:77
  field Plugin.mcp_servers in /tmp/.tmpoBPblt/symposium/src/plugins.rs:83
  field Hook.format in /tmp/.tmpoBPblt/symposium/src/plugins.rs:130
  field Config.auto_sync in /tmp/.tmpoBPblt/symposium/src/config.rs:32
  field Config.hook_scope in /tmp/.tmpoBPblt/symposium/src/config.rs:40
  field Config.agents in /tmp/.tmpoBPblt/symposium/src/config.rs:44

--- failure copy_impl_added: type now implements Copy ---

Description:
A public type now implements Copy, causing non-move closures to capture it by reference instead of moving it.
        ref: https://github.com/rust-lang/rust/issues/100905
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/copy_impl_added.ron

Failed in:
  symposium::hook::HookEvent in /tmp/.tmpoBPblt/symposium/src/hook_schema.rs:59
  symposium::hook_schema::HookEvent in /tmp/.tmpoBPblt/symposium/src/hook_schema.rs:59

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum symposium::dispatch::SharedCommand, previously in file /tmp/.tmpTivQ9K/symposium/src/dispatch.rs:19
  enum symposium::dispatch::DispatchResult, previously in file /tmp/.tmpTivQ9K/symposium/src/dispatch.rs:39
  enum symposium::hook::HookSubPayload, previously in file /tmp/.tmpTivQ9K/symposium/src/hook_schema.rs:36
  enum symposium::hook_schema::HookSubPayload, previously in file /tmp/.tmpTivQ9K/symposium/src/hook_schema.rs:36
  enum symposium::dispatch::RenderMode, previously in file /tmp/.tmpTivQ9K/symposium/src/start.rs:7
  enum symposium::start::RenderMode, previously in file /tmp/.tmpTivQ9K/symposium/src/start.rs:7

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant HookEvent:SessionStart in /tmp/.tmpoBPblt/symposium/src/hook_schema.rs:74
  variant HookEvent:SessionStart in /tmp/.tmpoBPblt/symposium/src/hook_schema.rs:74

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function symposium::mcp::serve, previously in file /tmp/.tmpTivQ9K/symposium/src/mcp.rs:21
  function symposium::hook::extract_crate_mentions, previously in file /tmp/.tmpTivQ9K/symposium/src/hook.rs:273
  function symposium::start::render, previously in file /tmp/.tmpTivQ9K/symposium/src/start.rs:14
  function symposium::dispatch::dispatch, previously in file /tmp/.tmpTivQ9K/symposium/src/dispatch.rs:47

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  symposium::hook::run now takes 3 parameters instead of 2, in /tmp/.tmpoBPblt/symposium/src/hook.rs:60

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod symposium::start, previously in file /tmp/.tmpTivQ9K/symposium/src/start.rs:1
  mod symposium::dispatch, previously in file /tmp/.tmpTivQ9K/symposium/src/dispatch.rs:1
  mod symposium::mcp, previously in file /tmp/.tmpTivQ9K/symposium/src/mcp.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct symposium::config::HooksConfig, previously in file /tmp/.tmpTivQ9K/symposium/src/config.rs:30
  struct symposium::hook::PreToolUsePayload, previously in file /tmp/.tmpTivQ9K/symposium/src/hook_schema.rs:69
  struct symposium::hook_schema::PreToolUsePayload, previously in file /tmp/.tmpTivQ9K/symposium/src/hook_schema.rs:69
  struct symposium::hook::HookPayload, previously in file /tmp/.tmpTivQ9K/symposium/src/hook_schema.rs:26
  struct symposium::hook_schema::HookPayload, previously in file /tmp/.tmpTivQ9K/symposium/src/hook_schema.rs:26
  struct symposium::hook::PostToolUsePayload, previously in file /tmp/.tmpTivQ9K/symposium/src/hook_schema.rs:74
  struct symposium::hook_schema::PostToolUsePayload, previously in file /tmp/.tmpTivQ9K/symposium/src/hook_schema.rs:74
  struct symposium::hook::HookOutput, previously in file /tmp/.tmpTivQ9K/symposium/src/hook_schema.rs:125
  struct symposium::hook_schema::HookOutput, previously in file /tmp/.tmpTivQ9K/symposium/src/hook_schema.rs:125
  struct symposium::mcp::McpArgs, previously in file /tmp/.tmpTivQ9K/symposium/src/mcp.rs:16
  struct symposium::hook::UserPromptSubmitPayload, previously in file /tmp/.tmpTivQ9K/symposium/src/hook_schema.rs:85
  struct symposium::hook_schema::UserPromptSubmitPayload, previously in file /tmp/.tmpTivQ9K/symposium/src/hook_schema.rs:85
  struct symposium::hook::HookSpecificOutput, previously in file /tmp/.tmpTivQ9K/symposium/src/hook_schema.rs:132
  struct symposium::hook_schema::HookSpecificOutput, previously in file /tmp/.tmpTivQ9K/symposium/src/hook_schema.rs:132

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field cache_dir of struct Config, previously in file /tmp/.tmpTivQ9K/symposium/src/config.rs:13
  field hooks of struct Config, previously in file /tmp/.tmpTivQ9K/symposium/src/config.rs:25
  field activation of struct SkillGroup, previously in file /tmp/.tmpTivQ9K/symposium/src/plugins.rs:32
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/symposium-dev/symposium/compare/symposium-v0.1.0...symposium-v0.2.0) - 2026-04-21

### Added

- add Gemini BeforeAgent hook and cross-agent event mapping
- filter to direct dependencies only
- crate predicate system with wildcard, plugin-level filtering, and MCP server filtering
- directory-based plugins with SYMPOSIUM.toml and plugin source discovery
- dual-mode agent integration test infrastructure
- add hook-scope config (global vs project)
- wire plugin MCP servers through sync_agent
- add MCP server registration and unregistration for all agents
- add McpServerEntry type and mcp_servers field to plugin manifest
- add plugin format routing via HookFormat
- add support for Codex CLI, Kiro, OpenCode, and Goose agents
- add --remove-agent flag to init and sync
- support multiple agents via [[agent]] config entries
- support project-level plugin sources and self-contained mode
- add SessionStart hook with plugin session-start-context
- reframe install, about page
- implement cargo-agents CLI with init, sync, and hook flows

### Fixed

- fixup! WIP--merge into 1: refactor: restructure documentation navigation and consolidate pages
- fixup! docs: expand install guide and agent MCP server documentation
- fixup! fix: auto-sync cwd resolution falls back to process cwd
- fixup! feat: crate predicate system with wildcard, plugin-level filtering, and MCP server filtering
- fixup! feat: directory-based plugins with SYMPOSIUM.toml and plugin source discovery
- fixup! feat: directory-based plugins with SYMPOSIUM.toml and plugin source discovery
- fixup! feat: directory-based plugins with SYMPOSIUM.toml and plugin source discovery
- fixup! feat: crate predicate system with wildcard, plugin-level filtering, and MCP server filtering
- fixup! feat: crate predicate system with wildcard, plugin-level filtering, and MCP server filtering
- fixup! feat: crate predicate system with wildcard, plugin-level filtering, and MCP server filtering
- auto-sync cwd resolution falls back to process cwd
- use XDG_STATE_HOME for logs directory
- Kiro agent config needs tools and resources fields
- handle events without agent-specific handlers gracefully
- make --add-agent additive and fix project agent resolution
- pre-select existing agents in prompt and remove hooks on unconfig
- split Copilot hook registration for global vs project paths
- use Symposium.home_dir for global hook registration instead of dirs::home_dir

### Other

- update the anem of the book
- fmt
- Support cargo subcommand convention for 'cargo agents'
- fmt
- Keep 'symposium' as the agent/server identity name
- Rename binary from symposium to cargo-agents
- hide agent-facing CLI commands and rename `crate` to `crate-info`
- fixup warning
- cargo fmt
- WIP--merge into 1: refactor: restructure documentation navigation and consolidate pages
- WIP--merge into 6: feat: crate predicate system with wildcard, plugin-level filtering, and MCP server filtering
- WIP--merge into 5: feat: directory-based plugins with SYMPOSIUM.toml and plugin source discovery
- WIP--merge into 1: refactor: restructure documentation navigation and consolidate pages
- remove session_start_context from plugins
- remove activation field from skills
- expand install guide and agent MCP server documentation
- restructure documentation navigation and consolidate pages
- pacify the merciless cargo fmt
- simplify configuration: remove per-project config
- Simplify CLI: remove start command, crate --list, and skills output
- Remove built-in MCP server
- Remove start command from MCP server, inline dispatch into CLI
- Merge pull request #175 from nikomatsakis/azure-range
- pacify the merciless cargo fmt
- Add test for non-object container recovery in JSON MCP registration
- Fix Goose stale-entry updates and add YAML quoting tests
- Clarify Copilot MCP registration format in design doc
- Strengthen Codex stale-entry update test
- Replace deprecated serde_yaml with serde_yaml_ng
- Document Goose stale-entry limitation
- Quote command and args in Goose YAML snippet
- Include env/headers in server_to_json when non-empty
- Harden register_json_mcp_servers against non-object container
- Panic on unknown McpServer variants instead of silent fallback
- Remove builtin MCP server variant
- Add MCP server documentation and use type = "builtin" for builtin entries
- add MCP server registration docs to all agent detail files
- move symposium binary resolution to Symposium struct
- convert agents module to directory structure
- Remove skill nudging and activation tracking
- pacify the merciless fmt
- minor fixes — Output::is_quiet, non-interactive init, docs
- update test harness and integration tests for new hook API
- replace generic hook dispatch with agent-owned wire formats and plugin format routing
- introduce canonical symposium hook types
- Fmt and add CI check
- rename agent detail docs, add disclaimers and primary source links
- rename reference/ to agent-details/ and add cross-agent comparison
- document session-start-context in plugin definition reference
- verify hook removal when switching agents
- revert CLI naming from cargo-agents back to symposium
- verify self-contained excludes user skills from sync
- use fixtures for project plugin source tests
- add integration tests for project plugin sources and self-contained mode
- add command flow docs, agent details, and misc reference updates
- the heck
- rewrite getting-started guide for cargo-agents
- Review comments
- Allow calling hooks with other agents. Fix claude output.
- Add copilot
- Add Gemini BeforeTool hook
- Typo in PR template
- Add adapter skeleton for hooks
- Rewiew nits. Add merge docs and cfg out tests using sh
- Forward hooks output
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).