### PR TITLE
Expand hooks functionality

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ e.g., closes #issue-number
 
 <!-- Remove the items that do not apply. -->
 
-* I used an AI tool for research, autocomplete, or in other minimal ways agent
+* I used an AI tool for research, autocomplete, or in other minimal ways
 * The AI tool authored small parts of the code (e.g., autocomplete, comments)
 * The AI tool authored large parts of the code
 * The AI tool authored and opened this PR autonomously

--- a/md/adding-plugin.md
+++ b/md/adding-plugin.md
@@ -33,7 +33,13 @@ matcher = "Bash"
 command = "./scripts/check-tool.sh"
 ```
 
-When `symposium hook pre-tool-use` receives a matching payload, the command is started with the payload JSON on stdin.
+When `symposium hook <agent> pre-tool-use` receives a matching payload, the command is started with the payload JSON on stdin.
+
+Supported agent names: `claude`, `copilot`, `gemini`. Invoke the hook runner with the agent and event, for example:
+
+```
+symposium hook claude pre-tool-use
+```
 
 ## Validation
 

--- a/md/crate-authors/publishing-hooks.md
+++ b/md/crate-authors/publishing-hooks.md
@@ -44,8 +44,10 @@ The script receives the full event JSON on stdin and can:
 
 ## Testing hooks
 
-Use the CLI to test a hook with sample input:
+Use the CLI to test a hook with sample input (specify the agent):
 
 ```bash
-echo '{"tool": "Bash", "input": "cargo test"}' | symposium hook pre-tool-use
+echo '{"tool": "Bash", "input": "cargo test"}' | symposium hook claude pre-tool-use
 ```
+
+You can also use `copilot` or `gemini` as the agent name, e.g. `symposium hook copilot pre-tool-use`.

--- a/md/crate-authors/publishing-hooks.md
+++ b/md/crate-authors/publishing-hooks.md
@@ -51,3 +51,31 @@ echo '{"tool": "Bash", "input": "cargo test"}' | symposium hook claude pre-tool-
 ```
 
 You can also use `copilot` or `gemini` as the agent name, e.g. `symposium hook copilot pre-tool-use`.
+
+## Supported hooks
+
+| Hook event | Description | CLI usage |
+|------------|-------------|-----------|
+| `PreToolUse` | Triggered before a tool (for example, `Bash`) is invoked by the agent. The hook receives the event payload on stdin. | `pre-tool-use` |
+
+## Agent → hook name mapping
+
+The table below lists tool events as rows and agents as columns. Each cell is the hook event name the agent uses for that tool event.
+
+| Tool / Event | Claude (`claude`) | Copilot (`copilot`) | Gemini (`gemini`) |
+|--------------|------------------------------------:|-------------------:|------------------:|
+| `PreToolUse` | `PreToolUse` | `PreToolUse` | `BeforeTool` |
+
+## Hook semantics
+
+- Exit codes:
+	- `0` — success: the hook's stdout is parsed as JSON and merged into the overall hook result.
+	- `2` (or no reported exit code) — treated as a failure: dispatch stops immediately and the hook's stderr is returned to the caller.
+	- any other non-zero code — treated as success for dispatching purposes; stdout is still parsed and merged when possible.
+
+- Stdout handling:
+	- Hooks SHOULD write a JSON object to stdout to contribute structured data back to the caller. Valid JSON objects are merged together across successful hooks; keys from later hooks overwrite earlier keys.
+	- If a hook writes non-JSON to stdout, the output will be ignored and a warning is logged.
+
+- Stderr handling:
+	- If a hook exits with code `2` (or no exit code), dispatch returns immediately with the hook's stderr as the error message. Otherwise stderr is captured but not returned on success.

--- a/md/design/cargo-workflow-flow.md
+++ b/md/design/cargo-workflow-flow.md
@@ -14,7 +14,7 @@ sequenceDiagram
     participant Session as Session State
     
     Note over Agent: Agent is about to use a tool
-    Agent->>Symposium: symposium hook pre-tool-use (JSON on stdin)
+    Agent->>Symposium: symposium hook <agent> pre-tool-use (JSON on stdin)
     Symposium->>Symposium: dispatch to plugin-defined hook commands
     Note over Symposium: plugin hooks can allow (exit 0) or block (exit non-zero)
     Symposium-->>Agent: allow/block + optional guidance

--- a/md/design/cargo-workflow-flow.md
+++ b/md/design/cargo-workflow-flow.md
@@ -11,13 +11,16 @@ Hooks let Symposium react to what the agent is doing. The Claude Code plugin reg
 sequenceDiagram
     participant Agent
     participant Symposium
+    participant Plugin as Plugin Hooks
     participant Session as Session State
-    
+
     Note over Agent: Agent is about to use a tool
-    Agent->>Symposium: symposium hook <agent> pre-tool-use (JSON on stdin)
-    Symposium->>Symposium: dispatch to plugin-defined hook commands
-    Note over Symposium: plugin hooks can allow (exit 0) or block (exit non-zero)
-    Symposium-->>Agent: allow/block + optional guidance
+    Agent->>Symposium: symposium hook pre-tool-use (JSON on stdin)
+    Symposium->>Symposium: dispatch to builtin hook handlers
+    Symposium->>Plugin: run plugin hook commands
+    Plugin-->>Symposium: plugin output, allow with json (exit 0) or block (exit 2)
+    Symposium->>Symposium: merge output structs
+    Symposium-->>Agent: merged output
 ```
 
 **PreToolUse** has no built-in logic — it dispatches to plugin-defined hook commands, which receive the event JSON on stdin and can allow or block the action.

--- a/md/design/skill-nudge-flow.md
+++ b/md/design/skill-nudge-flow.md
@@ -14,21 +14,21 @@ sequenceDiagram
     participant Session as Session State
 
     Note over Agent: Agent runs `symposium crate tokio`
-    Agent->>Symposium: symposium hook post-tool-use (JSON on stdin)
+    Agent->>Symposium: symposium hook <agent> post-tool-use (JSON on stdin)
     Symposium->>Session: load session
     Symposium->>Symposium: detect that this was a skill activation for `tokio`
     Symposium->>Session: record `tokio` activation
     Symposium-->>Agent: (empty response)
 
     Note over Agent: User sends a prompt talking about `tokio::spawn`
-    Agent->>Symposium: symposium hook user-prompt-submit (JSON on stdin)
+    Agent->>Symposium: symposium hook <agent> user-prompt-submit (JSON on stdin)
     Symposium->>Session: load session
     Symposium->>Symposium: scan prompt for crate mentions, find `tokio`
     Symposium->>Symposium: observe that `tokio` was activated recently
     Symposium-->>Agent: (empty response)
   
     Note over Agent: User sends a prompt talking about `serde_json`
-    Agent->>Symposium: symposium hook user-prompt-submit (JSON on stdin)
+    Agent->>Symposium: symposium hook <agent> user-prompt-submit (JSON on stdin)
     Symposium->>Session: load session
     Symposium->>Symposium: scan prompt for crate mentions, find `serde_json`
     Symposium->>Symposium: observe that `serde_json` has not been activated

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -19,7 +19,6 @@ pub use crate::hook_schema::{
 pub async fn run(sym: &Symposium, agent: HookAgent, event: HookEvent) -> ExitCode {
     tracing::debug!("Running hook listener for agent {agent:?} and event {event:?}");
 
-    let agent = agent.agent();
     let event_handler = agent.event(event).unwrap();
 
     let mut input = String::new();
@@ -604,10 +603,10 @@ mod tests {
             tool_name: "Bash".to_string(),
             rest: serde_json::Map::new(),
         };
-        let _ = event_handler.dispatch_plugin_hooks(
+            let _ = event_handler.dispatch_plugin_hooks(
             &sym,
             Box::new(payload),
-            Box::new(ClaudeCodePreToolUseOutput::new()),
+            Box::new(ClaudeCodePreToolUseOutput::default()),
         );
 
         // Verify files were created and contain expected contents.
@@ -923,7 +922,7 @@ mod tests {
         let out = event_handler.dispatch_plugin_hooks(
             &sym,
             Box::new(payload),
-            Box::new(ClaudeCodePreToolUseOutput::new()),
+            Box::new(ClaudeCodePreToolUseOutput::default()),
         );
 
         // Expect overall success and merged JSON containing both keys
@@ -982,7 +981,7 @@ mod tests {
         let out = event_handler.dispatch_plugin_hooks(
             &sym,
             Box::new(payload),
-            Box::new(ClaudeCodePreToolUseOutput::new()),
+            Box::new(ClaudeCodePreToolUseOutput::default()),
         );
 
         // Expect failure and stderr containing our message

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1,9 +1,13 @@
-use std::{io::{Read, Write}, process::{ExitCode, Stdio}};
+use std::{
+    io::{Read, Write},
+    process::{Command, ExitCode, Stdio},
+};
 
-use tokio::{io::AsyncWriteExt, process::Command};
-
-use crate::config::Symposium;
 use crate::plugins::ParsedPlugin;
+use crate::{
+    config::Symposium,
+    hook_schema::{Agent, AgentHookEvent, AgentHookOutput, AgentHookPayload, claude::ClaudeCode},
+};
 
 // Re-export hook schema types for convenience.
 pub use crate::hook_schema::{
@@ -12,14 +16,17 @@ pub use crate::hook_schema::{
 };
 
 /// CLI entry point: read payload from stdin, dispatch, print output.
-pub async fn run(sym: &Symposium, event: HookEvent) -> ExitCode {
+pub async fn run_claude(sym: &Symposium, event: HookEvent) -> ExitCode {
+    let agent = ClaudeCode;
+    let event_handler = agent.event(event).unwrap();
+
     let mut input = String::new();
     if let Err(e) = std::io::stdin().read_to_string(&mut input) {
         tracing::warn!(?event, error = %e, "failed to read hook stdin");
         return ExitCode::SUCCESS;
     }
 
-    let payload = serde_json::from_str::<HookPayload>(&input);
+    let payload = event_handler.parse_payload(&input);
     let Ok(payload) = payload else {
         tracing::warn!(
             ?event,
@@ -29,22 +36,28 @@ pub async fn run(sym: &Symposium, event: HookEvent) -> ExitCode {
         return ExitCode::FAILURE;
     };
 
-    if payload.sub_payload.hook_event() != event {
-        tracing::warn!(?event, payload_event = ?payload.sub_payload.hook_event(), "hook event mismatch between CLI arg and payload");
+    let builtin_payload = payload.to_hook_payload();
+
+    if builtin_payload.sub_payload.hook_event() != event {
+        tracing::warn!(?event, payload_event = ?builtin_payload.sub_payload.hook_event(), "hook event mismatch between CLI arg and payload");
         return ExitCode::FAILURE;
     }
 
     // Run built-in hook logic
-    let hook_output = dispatch_builtin(sym, &payload).await;
+    let hook_output = dispatch_builtin(sym, &builtin_payload).await;
+    let hook_output = event_handler.from_hook_output(&hook_output);
+    let Ok(hook_output) = hook_output else {
+        tracing::warn!(?event, error = "invalid hook output",);
+        return ExitCode::FAILURE;
+    };
 
-    // Run plugin hooks (for PreToolUse only, for now)
-    let plugin_output = dispatch_plugin_hooks(sym, &payload).await;
+    let plugin_output = event_handler.dispatch_plugin_hooks(sym, payload, hook_output);
 
     match plugin_output {
         PluginHookOutput::Success(plugin_json) => {
-            let mut hook_output_json = serde_json::to_value(&hook_output).unwrap();
-            merge(&mut hook_output_json, plugin_json);
-            std::io::stdout().write_all(&serde_json::to_vec(&hook_output_json).unwrap()).unwrap();
+            std::io::stdout()
+                .write_all(&serde_json::to_vec(&plugin_json).unwrap())
+                .unwrap();
 
             ExitCode::SUCCESS
         }
@@ -63,12 +76,8 @@ pub async fn dispatch_builtin(sym: &Symposium, payload: &HookPayload) -> HookOut
             // No built-in logic for PreToolUse — plugin hooks only.
             HookOutput::empty()
         }
-        HookSubPayload::PostToolUse(post) => {
-            handle_post_tool_use(sym, post).await
-        }
-        HookSubPayload::UserPromptSubmit(prompt) => {
-            handle_user_prompt_submit(sym, prompt).await
-        }
+        HookSubPayload::PostToolUse(post) => handle_post_tool_use(sym, post).await,
+        HookSubPayload::UserPromptSubmit(prompt) => handle_user_prompt_submit(sym, prompt).await,
     }
 }
 
@@ -204,7 +213,6 @@ fn detect_path_activation(
     }
 }
 
-
 /// Handle UserPromptSubmit: scan for crate mentions and nudge about unloaded skills.
 async fn handle_user_prompt_submit(
     sym: &Symposium,
@@ -267,7 +275,6 @@ async fn handle_user_prompt_submit(
 
     HookOutput::with_context("UserPromptSubmit", context.trim_end().to_string())
 }
-
 
 /// Extract crate names mentioned in code-like contexts within the prompt.
 ///
@@ -369,13 +376,18 @@ pub enum PluginHookOutput {
 }
 
 /// Dispatch plugin hooks (spawn subprocesses).
-async fn dispatch_plugin_hooks(sym: &Symposium, payload: &HookPayload) -> PluginHookOutput {
+pub(crate) fn dispatch_plugin_hooks<E: AgentHookEvent>(
+    sym: &Symposium,
+    event: &E,
+    payload: &E::Payload,
+    prior_output: E::Output,
+) -> PluginHookOutput {
     tracing::info!(?payload, "hook invoked (builtin)");
 
     let plugins = crate::plugins::load_all_plugins(sym);
-    let hooks = hooks_for_payload(&plugins, payload);
+    let hooks = hooks_for_payload(&plugins, &payload.to_hook_payload());
 
-    let mut output_json = serde_json::Value::Object(serde_json::Map::new());
+    let mut output_json = prior_output;
 
     for (plugin_name, hook) in hooks {
         tracing::info!(?plugin_name, hook = %hook.name, cmd = %hook.command, "running plugin hook");
@@ -390,14 +402,12 @@ async fn dispatch_plugin_hooks(sym: &Symposium, payload: &HookPayload) -> Plugin
         match spawn_res {
             Ok(mut child) => {
                 if let Some(mut stdin) = child.stdin.take() {
-                    if let Err(e) =
-                        stdin.write_all(serde_json::to_string(&payload).unwrap().as_bytes()).await
-                    {
+                    if let Err(e) = stdin.write_all(payload.to_string().unwrap().as_bytes()) {
                         tracing::warn!(error = %e, "failed to write hook stdin");
                     }
                 }
 
-                let output = match child.wait_with_output().await {
+                let output = match child.wait_with_output() {
                     Ok(output) => output,
                     Err(e) => {
                         tracing::warn!(error = %e, "failed waiting for hook process");
@@ -415,10 +425,14 @@ async fn dispatch_plugin_hooks(sym: &Symposium, payload: &HookPayload) -> Plugin
                     }
                     Some(0 | _) => {
                         let stdout = output.stdout;
-                        let json_res = serde_json::from_slice::<serde_json::Value>(&stdout);
-                        match json_res {
-                            Ok(json) => merge(&mut output_json, json),
-                            Err(e) => tracing::warn!(error = %e, "failed to parse hook output as JSON"),
+                        let plugin_output = event.parse_output(&stdout);
+                        match plugin_output {
+                            Ok(plugin_output) => {
+                                output_json = E::merge_outputs(output_json, plugin_output);
+                            }
+                            Err(e) => {
+                                tracing::warn!(error = %e, "failed to parse hook output as JSON")
+                            }
                         }
                     }
                 }
@@ -427,23 +441,22 @@ async fn dispatch_plugin_hooks(sym: &Symposium, payload: &HookPayload) -> Plugin
         }
     }
 
-    PluginHookOutput::Success(output_json)
+    PluginHookOutput::Success(output_json.to_hook_output())
 }
 
 /// Recursively merge two JSON objects, with `b` taking precedence over `a`.
 /// Fields with null values in `b` will delete the corresponding field in `a`.
 /// Fields not present in `b` will be left unchanged in `a`.
-fn merge(a: &mut serde_json::Value, b: serde_json::Value) {
+pub fn merge(a: &mut serde_json::Value, b: serde_json::Value) {
     if let serde_json::Value::Object(a) = a {
         if let serde_json::Value::Object(b) = b {
             for (k, v) in b {
                 if v.is_null() {
                     a.remove(&k);
-                }
-                else {
+                } else {
                     merge(a.entry(k).or_insert(serde_json::Value::Null), v);
                 }
-            } 
+            }
 
             return;
         }
@@ -487,6 +500,10 @@ fn hooks_for_payload(
 
 #[cfg(test)]
 mod tests {
+    use crate::hook_schema::claude::{
+        ClaudeCodeHookCommonPayload, ClaudeCodePreToolUseOutput, ClaudeCodePreToolUsePayload,
+    };
+
     use super::*;
     use std::fs;
 
@@ -570,14 +587,22 @@ mod tests {
         fs::write(plugins_dir.join("plugin-one.toml"), p1).expect("write plugin1");
         fs::write(plugins_dir.join("plugin-two.toml"), p2).expect("write plugin2");
 
+        let agent = ClaudeCode;
+        let event_handler = agent.event(HookEvent::PreToolUse).unwrap();
+
         // Run the hook event via dispatch_plugin_hooks.
-        let payload = HookPayload {
-            sub_payload: HookSubPayload::PreToolUse(PreToolUsePayload {
-                tool_name: "Bash".to_string(),
-            }),
+        let payload = ClaudeCodePreToolUsePayload {
+            common_payload: ClaudeCodeHookCommonPayload {
+                hook_event_name: "PreToolUse".to_string(),
+            },
+            tool_name: "Bash".to_string(),
             rest: serde_json::Map::new(),
         };
-        dispatch_plugin_hooks(&sym, &payload).await;
+        let _ = event_handler.dispatch_plugin_hooks(
+            &sym,
+            Box::new(payload),
+            Box::new(ClaudeCodePreToolUseOutput::new()),
+        );
 
         // Verify files were created and contain expected contents.
         let got1 = fs::read_to_string(&out1).expect("read out1");
@@ -644,7 +669,8 @@ mod tests {
 
     #[test]
     fn hook_output_serializes_with_additional_context() {
-        let output = HookOutput::with_context("UserPromptSubmit", "Load tokio guidance".to_string());
+        let output =
+            HookOutput::with_context("UserPromptSubmit", "Load tokio guidance".to_string());
         let json = serde_json::to_value(&output).unwrap();
         assert_eq!(
             json["hookSpecificOutput"]["hookEventName"],
@@ -674,7 +700,10 @@ mod tests {
             session_id: Some("s1".to_string()),
             cwd: Some("/tmp".to_string()),
         };
-        assert_eq!(detect_crate_activation_bash(&post), Some("tokio".to_string()));
+        assert_eq!(
+            detect_crate_activation_bash(&post),
+            Some("tokio".to_string())
+        );
     }
 
     #[test]
@@ -686,7 +715,10 @@ mod tests {
             session_id: Some("s1".to_string()),
             cwd: Some("/tmp".to_string()),
         };
-        assert_eq!(detect_crate_activation_bash(&post), Some("serde".to_string()));
+        assert_eq!(
+            detect_crate_activation_bash(&post),
+            Some("serde".to_string())
+        );
     }
 
     #[test]
@@ -722,7 +754,10 @@ mod tests {
             session_id: Some("s1".to_string()),
             cwd: Some("/tmp".to_string()),
         };
-        assert_eq!(detect_crate_activation_bash(&post), Some("tokio".to_string()));
+        assert_eq!(
+            detect_crate_activation_bash(&post),
+            Some("tokio".to_string())
+        );
     }
 
     #[test]
@@ -734,7 +769,10 @@ mod tests {
             session_id: Some("s1".to_string()),
             cwd: Some("/tmp".to_string()),
         };
-        assert_eq!(detect_crate_activation_bash(&post), Some("serde".to_string()));
+        assert_eq!(
+            detect_crate_activation_bash(&post),
+            Some("serde".to_string())
+        );
     }
 
     #[test]
@@ -746,7 +784,10 @@ mod tests {
             session_id: Some("s1".to_string()),
             cwd: Some("/tmp".to_string()),
         };
-        assert_eq!(detect_crate_activation_mcp(&post), Some("tokio".to_string()));
+        assert_eq!(
+            detect_crate_activation_mcp(&post),
+            Some("tokio".to_string())
+        );
     }
 
     #[test]
@@ -847,7 +888,7 @@ mod tests {
             [[hooks]]
             name = "json-a"
             event = "PreToolUse"
-            command = "sh -c 'echo \"{{\\\"a\\\":1}}\"'"
+            command = "sh -c 'echo \"{{ \\\"hookEventName\\\": \\\"PreToolUse\\\", \\\"a\\\":1}}\"'"
         "#};
 
         let p2 = formatdoc! {r#"
@@ -856,18 +897,28 @@ mod tests {
             [[hooks]]
             name = "json-b"
             event = "PreToolUse"
-            command = "sh -c 'echo \"{{\\\"b\\\":2}}\"'"
+            command = "sh -c 'echo \"{{ \\\"hookEventName\\\": \\\"PreToolUse\\\", \\\"b\\\":2}}\"'"
         "#};
 
         fs::write(plugins_dir.join("plugin-json-a.toml"), p1).expect("write p1");
         fs::write(plugins_dir.join("plugin-json-b.toml"), p2).expect("write p2");
 
-        let payload = HookPayload {
-            sub_payload: HookSubPayload::PreToolUse(PreToolUsePayload { tool_name: "Bash".to_string() }),
+        let agent = ClaudeCode;
+        let event_handler = agent.event(HookEvent::PreToolUse).unwrap();
+
+        // Run the hook event via dispatch_plugin_hooks.
+        let payload = ClaudeCodePreToolUsePayload {
+            common_payload: ClaudeCodeHookCommonPayload {
+                hook_event_name: "PreToolUse".to_string(),
+            },
+            tool_name: "Bash".to_string(),
             rest: serde_json::Map::new(),
         };
-
-        let out = dispatch_plugin_hooks(&sym, &payload).await;
+        let out = event_handler.dispatch_plugin_hooks(
+            &sym,
+            Box::new(payload),
+            Box::new(ClaudeCodePreToolUseOutput::new()),
+        );
 
         // Expect overall success and merged JSON containing both keys
         let PluginHookOutput::Success(val) = out else {
@@ -911,12 +962,22 @@ mod tests {
         fs::write(plugins_dir.join("plugin-good.toml"), good).expect("write good");
         fs::write(plugins_dir.join("plugin-bad.toml"), bad).expect("write bad");
 
-        let payload = HookPayload {
-            sub_payload: HookSubPayload::PreToolUse(PreToolUsePayload { tool_name: "Bash".to_string() }),
+        let agent = ClaudeCode;
+        let event_handler = agent.event(HookEvent::PreToolUse).unwrap();
+
+        // Run the hook event via dispatch_plugin_hooks.
+        let payload = ClaudeCodePreToolUsePayload {
+            common_payload: ClaudeCodeHookCommonPayload {
+                hook_event_name: "PreToolUse".to_string(),
+            },
+            tool_name: "Bash".to_string(),
             rest: serde_json::Map::new(),
         };
-
-        let out = dispatch_plugin_hooks(&sym, &payload).await;
+        let out = event_handler.dispatch_plugin_hooks(
+            &sym,
+            Box::new(payload),
+            Box::new(ClaudeCodePreToolUseOutput::new()),
+        );
 
         // Expect failure and stderr containing our message
         let PluginHookOutput::Failure(stderr) = out else {

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -6,18 +6,20 @@ use std::{
 use crate::plugins::ParsedPlugin;
 use crate::{
     config::Symposium,
-    hook_schema::{Agent, AgentHookEvent, AgentHookOutput, AgentHookPayload, claude::ClaudeCode},
+    hook_schema::{AgentHookEvent, AgentHookOutput, AgentHookPayload},
 };
 
 // Re-export hook schema types for convenience.
 pub use crate::hook_schema::{
-    HookEvent, HookOutput, HookPayload, HookSpecificOutput, HookSubPayload, PostToolUsePayload,
+    HookAgent, HookEvent, HookOutput, HookPayload, HookSpecificOutput, HookSubPayload, PostToolUsePayload,
     PreToolUsePayload, UserPromptSubmitPayload,
 };
 
 /// CLI entry point: read payload from stdin, dispatch, print output.
-pub async fn run_claude(sym: &Symposium, event: HookEvent) -> ExitCode {
-    let agent = ClaudeCode;
+pub async fn run(sym: &Symposium, agent: HookAgent, event: HookEvent) -> ExitCode {
+    tracing::debug!("Running hook listener for agent {agent:?} and event {event:?}");
+
+    let agent = agent.agent();
     let event_handler = agent.event(event).unwrap();
 
     let mut input = String::new();
@@ -25,15 +27,15 @@ pub async fn run_claude(sym: &Symposium, event: HookEvent) -> ExitCode {
         tracing::warn!(?event, error = %e, "failed to read hook stdin");
         return ExitCode::SUCCESS;
     }
+    tracing::debug!(?input);
 
     let payload = event_handler.parse_payload(&input);
-    let Ok(payload) = payload else {
-        tracing::warn!(
-            ?event,
-            error = "invalid hook payload",
-            "failed to parse hook stdin as JSON"
-        );
-        return ExitCode::FAILURE;
+    let payload = match payload {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(?event, error = %e, "invalid hook payload");
+            return ExitCode::FAILURE;
+        }
     };
 
     let builtin_payload = payload.to_hook_payload();
@@ -46,9 +48,12 @@ pub async fn run_claude(sym: &Symposium, event: HookEvent) -> ExitCode {
     // Run built-in hook logic
     let hook_output = dispatch_builtin(sym, &builtin_payload).await;
     let hook_output = event_handler.from_hook_output(&hook_output);
-    let Ok(hook_output) = hook_output else {
-        tracing::warn!(?event, error = "invalid hook output",);
-        return ExitCode::FAILURE;
+    let hook_output = match hook_output {
+        Ok(o) => o,
+        Err(e) => {
+            tracing::warn!(?event, error = %e, "invalid hook output from builtin dispatch");
+            return ExitCode::FAILURE;
+        }
     };
 
     let plugin_output = event_handler.dispatch_plugin_hooks(sym, payload, hook_output);
@@ -503,6 +508,7 @@ mod tests {
     use crate::hook_schema::claude::{
         ClaudeCodeHookCommonPayload, ClaudeCodePreToolUseOutput, ClaudeCodePreToolUsePayload,
     };
+    use crate::hook_schema::{Agent, claude::ClaudeCode};
 
     use super::*;
     use std::fs;

--- a/src/hook_schema.rs
+++ b/src/hook_schema.rs
@@ -26,11 +26,11 @@ pub enum HookAgent {
 }
 
 impl HookAgent {
-    pub fn agent(&self) -> Box<dyn Agent> {
+    pub fn event(&self, event: HookEvent) -> Option<Box<dyn ErasedAgentHookEvent>> {
         match self {
-            HookAgent::Claude => Box::new(claude::ClaudeCode),
-            HookAgent::Copilot => Box::new(copilot::Copilot),
-            HookAgent::Gemini => Box::new(gemini::Gemini),
+            HookAgent::Claude => claude::ClaudeCode.event(event),
+            HookAgent::Copilot => copilot::Copilot.event(event),
+            HookAgent::Gemini => gemini::Gemini.event(event),
         }
     }
 }
@@ -195,34 +195,53 @@ impl HookOutput {
     }
 }
 
+/// Represents the data sent *from* an agent *to* a hook.
 pub trait AgentHookPayload: Debug {
+    /// Parse an incoming JSON payload string into a concrete payload struct.
     fn parse_payload(payload: &str) -> Result<Self>
     where
         Self: Sized;
+    /// Convert this payload into the generic `HookPayload` for builtin hook handlers.
     fn to_hook_payload(&self) -> HookPayload;
+    /// Convert this payload into a JSON string for forwarding to plugins.
     fn to_string(&self) -> Result<String>;
 
     fn into_any(self: Box<Self>) -> Box<dyn Any>;
 }
 
+/// Represents the data sent *from* a hook *to* an agent.
 pub trait AgentHookOutput: Debug {
+    /// Parse raw stdout bytes from a hook handler into a concrete output struct.
     fn parse_output(output: &[u8]) -> anyhow::Result<Self>
     where
         Self: Sized;
+    /// Convert a generic `HookOutput` from builtin hook handlers into this output struct.
     fn from_hook_output(output: &HookOutput) -> anyhow::Result<Self>
     where
         Self: Sized;
+    /// Convert this output into a JSON value to return to the agent.
     fn to_hook_output(&self) -> serde_json::Value;
 
     fn into_any(self: Box<Self>) -> Box<dyn Any>;
 }
 
+/// Represents some hook event-handler for a specific agent
 pub trait AgentHookEvent {
     type Payload: AgentHookPayload;
     type Output: AgentHookOutput;
-    fn parse_payload(&self, payload: &str) -> anyhow::Result<Self::Payload>;
-    fn parse_output(&self, output: &[u8]) -> anyhow::Result<Self::Output>;
-    fn from_hook_output(&self, output: &HookOutput) -> anyhow::Result<Self::Output>;
+
+    /// Parse an incoming JSON payload string into a concrete payload struct.
+    fn parse_payload(&self, payload: &str) -> anyhow::Result<Self::Payload> {
+        Self::Payload::parse_payload(payload)
+    }
+    /// Parse raw stdout bytes from a hook handler into a concrete output struct.
+    fn parse_output(&self, output: &[u8]) -> anyhow::Result<Self::Output> {
+        Self::Output::parse_output(output)
+    }
+    /// Convert a generic `HookOutput` from builtin hook handlers into this output struct.
+    fn from_hook_output(&self, output: &HookOutput) -> anyhow::Result<Self::Output> {
+        Self::Output::from_hook_output(output)
+    }
     fn merge_outputs(first: Self::Output, second: Self::Output) -> Self::Output;
     fn dispatch_plugin_hooks(
         &self,
@@ -237,6 +256,7 @@ pub trait AgentHookEvent {
     }
 }
 
+/// Represents an agent that can handle hook events.
 pub trait Agent {
     fn event(&self, event: HookEvent) -> Option<Box<dyn ErasedAgentHookEvent>>;
 }

--- a/src/hook_schema.rs
+++ b/src/hook_schema.rs
@@ -2,15 +2,15 @@
 
 use serde::{Deserialize, Serialize};
 
-// FIXME: We really need a "core" set of hook events and expected data. But then
-// have "adapters" for each different agent. The interesting bit is connecting
-// builtin hooks (which should handle the core set of events) to the agent-specific
-// formats.
-// 
-/// For now, this is very much designed around Claude Code's expected hook payloads.
+use anyhow::{Result, anyhow};
+use std::{any::Any, fmt::Debug};
+
+use crate::config::Symposium;
+
+pub mod claude;
 
 /// Hook event types supported by Symposium.
-#[derive(Debug, Clone, clap::ValueEnum, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, clap::ValueEnum, Serialize, Deserialize, PartialEq, Eq)]
 pub enum HookEvent {
     #[value(name = "pre-tool-use")]
     #[serde(rename = "PreToolUse")]
@@ -133,6 +133,8 @@ pub struct HookOutput {
     /// If set, injected into the LLM conversation as additional context.
     #[serde(rename = "hookSpecificOutput", skip_serializing_if = "Option::is_none")]
     pub hook_specific_output: Option<HookSpecificOutput>,
+    #[serde(flatten)]
+    pub rest: serde_json::Map<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -141,6 +143,8 @@ pub struct HookSpecificOutput {
     pub hook_event_name: String,
     #[serde(rename = "additionalContext", skip_serializing_if = "Option::is_none")]
     pub additional_context: Option<String>,
+    #[serde(flatten)]
+    pub rest: serde_json::Map<String, serde_json::Value>,
 }
 
 impl HookOutput {
@@ -150,7 +154,9 @@ impl HookOutput {
             hook_specific_output: Some(HookSpecificOutput {
                 hook_event_name: event_name.to_string(),
                 additional_context: Some(context),
+                rest: serde_json::Map::new(),
             }),
+            rest: serde_json::Map::new(),
         }
     }
 
@@ -158,4 +164,123 @@ impl HookOutput {
     pub fn empty() -> Self {
         Self::default()
     }
+}
+
+pub trait AgentHookPayload: Debug {
+    fn parse_payload(payload: &str) -> Result<Self>
+    where
+        Self: Sized;
+    fn to_hook_payload(&self) -> HookPayload;
+    fn to_string(&self) -> Result<String>;
+
+    fn into_any(self: Box<Self>) -> Box<dyn Any>;
+}
+
+pub trait AgentHookOutput: Debug {
+    fn parse_output(output: &[u8]) -> anyhow::Result<Self>
+    where
+        Self: Sized;
+    fn from_hook_output(output: &HookOutput) -> anyhow::Result<Self>
+    where
+        Self: Sized;
+    fn to_hook_output(&self) -> serde_json::Value;
+
+    fn into_any(self: Box<Self>) -> Box<dyn Any>;
+}
+
+pub trait AgentHookEvent {
+    type Payload: AgentHookPayload;
+    type Output: AgentHookOutput;
+    fn parse_payload(&self, payload: &str) -> anyhow::Result<Self::Payload>;
+    fn parse_output(&self, output: &[u8]) -> anyhow::Result<Self::Output>;
+    fn from_hook_output(&self, output: &HookOutput) -> anyhow::Result<Self::Output>;
+    fn merge_outputs(first: Self::Output, second: Self::Output) -> Self::Output;
+    fn dispatch_plugin_hooks(
+        &self,
+        sym: &Symposium,
+        payload: &Self::Payload,
+        prior_output: Self::Output,
+    ) -> crate::hook::PluginHookOutput
+    where
+        Self: Sized,
+    {
+        crate::hook::dispatch_plugin_hooks::<Self>(sym, self, payload, prior_output)
+    }
+}
+
+pub trait Agent {
+    fn event(&self, event: HookEvent) -> Option<Box<dyn ErasedAgentHookEvent>>;
+}
+
+pub trait ErasedAgentHookEvent {
+    /// Parse an incoming JSON payload into a boxed `AgentHookPayload`.
+    fn parse_payload(&self, payload: &str) -> Result<Box<dyn AgentHookPayload>>;
+
+    /// Parses a stdout into a boxed `AgentHookOutput`.
+    fn parse_output(&self, output: &[u8]) -> Result<Box<dyn AgentHookOutput>>;
+
+    /// Parse a builtin `HookOutput` into a boxed `AgentHookOutput`.
+    fn from_hook_output(&self, output: &HookOutput) -> Result<Box<dyn AgentHookOutput>>;
+
+    fn dispatch_plugin_hooks(
+        &self,
+        _sym: &Symposium,
+        payload: Box<dyn AgentHookPayload>,
+        prior_output: Box<dyn AgentHookOutput>,
+    ) -> crate::hook::PluginHookOutput;
+}
+
+struct ErasedAgentHookEventImpl<E: AgentHookEvent + 'static>(E);
+
+impl<E> ErasedAgentHookEvent for ErasedAgentHookEventImpl<E>
+where
+    E: AgentHookEvent + 'static,
+    E::Payload: AgentHookPayload + 'static,
+    E::Output: AgentHookOutput + 'static,
+{
+    fn parse_payload(&self, payload: &str) -> Result<Box<dyn AgentHookPayload>> {
+        let p = self.0.parse_payload(payload)?;
+        Ok(Box::new(p))
+    }
+
+    fn parse_output(&self, output: &[u8]) -> Result<Box<dyn AgentHookOutput>> {
+        let o = self.0.parse_output(output)?;
+        Ok(Box::new(o))
+    }
+    fn from_hook_output(&self, output: &HookOutput) -> Result<Box<dyn AgentHookOutput>> {
+        let o = self.0.from_hook_output(output)?;
+        Ok(Box::new(o))
+    }
+
+    fn dispatch_plugin_hooks(
+        &self,
+        _sym: &Symposium,
+        payload: Box<dyn AgentHookPayload>,
+        prior_output: Box<dyn AgentHookOutput>,
+    ) -> crate::hook::PluginHookOutput {
+        let payload_any = payload.into_any();
+        let payload_concrete = payload_any
+            .downcast::<E::Payload>()
+            .map_err(|_| anyhow!("failed to downcast payload"))
+            .unwrap();
+        let output_any = prior_output.into_any();
+        let output_concrete = output_any
+            .downcast::<E::Output>()
+            .map_err(|_| anyhow!("failed to downcast output"))
+            .unwrap();
+        let output = self
+            .0
+            .dispatch_plugin_hooks(_sym, &payload_concrete, *output_concrete);
+        output
+    }
+}
+
+/// Helper to erase a concrete `AgentHookEvent` into a trait object.
+pub fn erase_agent_hook_event<E>(e: E) -> Box<dyn ErasedAgentHookEvent>
+where
+    E: AgentHookEvent + 'static,
+    E::Payload: AgentHookPayload + 'static,
+    E::Output: AgentHookOutput + 'static,
+{
+    Box::new(ErasedAgentHookEventImpl(e))
 }

--- a/src/hook_schema.rs
+++ b/src/hook_schema.rs
@@ -8,6 +8,7 @@ use std::{any::Any, fmt::Debug};
 use crate::config::Symposium;
 
 pub mod claude;
+pub mod gemini;
 
 /// Hook event types supported by Symposium.
 #[derive(Debug, Copy, Clone, clap::ValueEnum, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/hook_schema.rs
+++ b/src/hook_schema.rs
@@ -11,6 +11,30 @@ pub mod claude;
 pub mod copilot;
 pub mod gemini;
 
+/// Agents supported by Symposium hooks.
+#[derive(Debug, Copy, Clone, clap::ValueEnum, Serialize, Deserialize, PartialEq, Eq)]
+pub enum HookAgent {
+    #[value(name = "claude")]
+    #[serde(rename = "claude")]
+    Claude,
+    #[value(name = "copilot")]
+    #[serde(rename = "copilot")]
+    Copilot,
+    #[value(name = "gemini")]
+    #[serde(rename = "gemini")]
+    Gemini,
+}
+
+impl HookAgent {
+    pub fn agent(&self) -> Box<dyn Agent> {
+        match self {
+            HookAgent::Claude => Box::new(claude::ClaudeCode),
+            HookAgent::Copilot => Box::new(copilot::Copilot),
+            HookAgent::Gemini => Box::new(gemini::Gemini),
+        }
+    }
+}
+
 /// Hook event types supported by Symposium.
 #[derive(Debug, Copy, Clone, clap::ValueEnum, Serialize, Deserialize, PartialEq, Eq)]
 pub enum HookEvent {
@@ -145,6 +169,8 @@ pub struct HookSpecificOutput {
     pub hook_event_name: String,
     #[serde(rename = "additionalContext", skip_serializing_if = "Option::is_none")]
     pub additional_context: Option<String>,
+    #[serde(rename = "updatedInput", skip_serializing_if = "Option::is_none")]
+    pub updated_input: Option<String>,
     #[serde(flatten)]
     pub rest: serde_json::Map<String, serde_json::Value>,
 }
@@ -156,6 +182,7 @@ impl HookOutput {
             hook_specific_output: Some(HookSpecificOutput {
                 hook_event_name: event_name.to_string(),
                 additional_context: Some(context),
+                updated_input: None,
                 rest: serde_json::Map::new(),
             }),
             rest: serde_json::Map::new(),

--- a/src/hook_schema.rs
+++ b/src/hook_schema.rs
@@ -8,6 +8,7 @@ use std::{any::Any, fmt::Debug};
 use crate::config::Symposium;
 
 pub mod claude;
+pub mod copilot;
 pub mod gemini;
 
 /// Hook event types supported by Symposium.

--- a/src/hook_schema/claude.rs
+++ b/src/hook_schema/claude.rs
@@ -82,10 +82,36 @@ impl AgentHookPayload for ClaudeCodePreToolUsePayload {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClaudeCodePreToolUseOutput {
+    #[serde(rename = "continue", skip_serializing_if = "Option::is_none")]
+    pub do_continue: Option<bool>,
+    #[serde(rename = "stopReason", skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<String>,
+    #[serde(rename = "suppressOutput", skip_serializing_if = "Option::is_none")]
+    pub suppress_output: Option<bool>,
+    #[serde(rename = "systemMessage", skip_serializing_if = "Option::is_none")]
+    pub system_message: Option<String>,
+
+    #[serde(rename = "hookSpecificOutput", skip_serializing_if = "Option::is_none")]
+    pub hook_specific_output: Option<ClaudeHookSpecificOutput>,
+
+    #[serde(flatten)]
+    pub rest: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClaudeHookSpecificOutput {
     #[serde(rename = "hookEventName")]
     pub hook_event_name: String,
+
+    #[serde(rename = "permissionDecision", skip_serializing_if = "Option::is_none")]
+    pub permission_decision: Option<String>,
+    #[serde(rename = "permissionDecisionReason", skip_serializing_if = "Option::is_none")]
+    pub permission_decision_reason: Option<String>,
+    #[serde(rename = "updatedInput", skip_serializing_if = "Option::is_none")]
+    pub updated_input: Option<String>,
     #[serde(rename = "additionalContext", skip_serializing_if = "Option::is_none")]
     pub additional_context: Option<String>,
+
     #[serde(flatten)]
     pub rest: serde_json::Map<String, serde_json::Value>,
 }
@@ -93,8 +119,18 @@ pub struct ClaudeCodePreToolUseOutput {
 impl ClaudeCodePreToolUseOutput {
     pub fn new() -> Self {
         Self {
-            hook_event_name: "PreToolUse".to_string(),
-            additional_context: None,
+            do_continue: None,
+            stop_reason: None,
+            suppress_output: None,
+            system_message: None,
+            hook_specific_output: Some(ClaudeHookSpecificOutput {
+                hook_event_name: "PreToolUse".to_string(),
+                permission_decision: None,
+                permission_decision_reason: None,
+                updated_input: None,
+                additional_context: None,
+                rest: serde_json::Map::new(),
+            }),
             rest: serde_json::Map::new(),
         }
     }
@@ -109,17 +145,25 @@ impl AgentHookOutput for ClaudeCodePreToolUseOutput {
     }
 
     fn from_hook_output(payload: &HookOutput) -> anyhow::Result<Self> {
-        let Some(hook_specific_output) = &payload.hook_specific_output else {
-            return Err(anyhow!("missing hook specific output"));
-        };
-        if hook_specific_output.hook_event_name != "PreToolUse" {
-            return Err(anyhow!("unexpected hook event name"));
+        let mut out = Self::new();
+        out.rest = payload.rest.clone();
+        if let Some(hook_specific) = &payload.hook_specific_output {
+            if hook_specific.hook_event_name != "PreToolUse" {
+                return Err(anyhow!(
+                    "unexpected hook event name: {}",
+                    hook_specific.hook_event_name
+                ));
+            }
+            out.hook_specific_output = Some(ClaudeHookSpecificOutput {
+                hook_event_name: hook_specific.hook_event_name.clone(),
+                permission_decision: None,
+                permission_decision_reason: None,
+                updated_input: hook_specific.updated_input.clone(),
+                additional_context: hook_specific.additional_context.clone(),
+                rest: hook_specific.rest.clone(),
+            });
         }
-        Ok(Self {
-            hook_event_name: hook_specific_output.hook_event_name.clone(),
-            additional_context: hook_specific_output.additional_context.clone(),
-            rest: hook_specific_output.rest.clone(),
-        })
+        Ok(out)
     }
 
     fn to_hook_output(&self) -> serde_json::Value {

--- a/src/hook_schema/claude.rs
+++ b/src/hook_schema/claude.rs
@@ -22,18 +22,6 @@ impl AgentHookEvent for ClaudePreToolUseEvent {
     type Payload = ClaudeCodePreToolUsePayload;
     type Output = ClaudeCodePreToolUseOutput;
 
-    fn parse_payload(&self, payload: &str) -> anyhow::Result<Self::Payload> {
-        ClaudeCodePreToolUsePayload::parse_payload(payload)
-    }
-
-    fn parse_output(&self, output: &[u8]) -> anyhow::Result<Self::Output> {
-        ClaudeCodePreToolUseOutput::parse_output(output)
-    }
-
-    fn from_hook_output(&self, output: &HookOutput) -> anyhow::Result<Self::Output> {
-        ClaudeCodePreToolUseOutput::from_hook_output(output)
-    }
-
     fn merge_outputs(first: Self::Output, second: Self::Output) -> Self::Output {
         let mut first = serde_json::to_value(first).unwrap();
         let second = serde_json::to_value(second).unwrap();
@@ -116,8 +104,8 @@ pub struct ClaudeHookSpecificOutput {
     pub rest: serde_json::Map<String, serde_json::Value>,
 }
 
-impl ClaudeCodePreToolUseOutput {
-    pub fn new() -> Self {
+impl Default for ClaudeCodePreToolUseOutput {
+    fn default() -> Self {
         Self {
             do_continue: None,
             stop_reason: None,
@@ -145,7 +133,7 @@ impl AgentHookOutput for ClaudeCodePreToolUseOutput {
     }
 
     fn from_hook_output(payload: &HookOutput) -> anyhow::Result<Self> {
-        let mut out = Self::new();
+        let mut out = Self::default();
         out.rest = payload.rest.clone();
         if let Some(hook_specific) = &payload.hook_specific_output {
             if hook_specific.hook_event_name != "PreToolUse" {

--- a/src/hook_schema/claude.rs
+++ b/src/hook_schema/claude.rs
@@ -1,0 +1,132 @@
+use anyhow::anyhow;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    hook::{HookOutput, HookPayload, HookSubPayload, PreToolUsePayload, merge},
+    hook_schema::{
+        Agent, AgentHookEvent, AgentHookOutput, AgentHookPayload, erase_agent_hook_event,
+    },
+};
+
+pub struct ClaudeCode;
+impl Agent for ClaudeCode {
+    fn event(&self, event: super::HookEvent) -> Option<Box<dyn super::ErasedAgentHookEvent>> {
+        match event {
+            super::HookEvent::PreToolUse => Some(erase_agent_hook_event(ClaudePreToolUseEvent)),
+            _ => None,
+        }
+    }
+}
+pub struct ClaudePreToolUseEvent;
+impl AgentHookEvent for ClaudePreToolUseEvent {
+    type Payload = ClaudeCodePreToolUsePayload;
+    type Output = ClaudeCodePreToolUseOutput;
+
+    fn parse_payload(&self, payload: &str) -> anyhow::Result<Self::Payload> {
+        ClaudeCodePreToolUsePayload::parse_payload(payload)
+    }
+
+    fn parse_output(&self, output: &[u8]) -> anyhow::Result<Self::Output> {
+        ClaudeCodePreToolUseOutput::parse_output(output)
+    }
+
+    fn from_hook_output(&self, output: &HookOutput) -> anyhow::Result<Self::Output> {
+        ClaudeCodePreToolUseOutput::from_hook_output(output)
+    }
+
+    fn merge_outputs(first: Self::Output, second: Self::Output) -> Self::Output {
+        let mut first = serde_json::to_value(first).unwrap();
+        let second = serde_json::to_value(second).unwrap();
+        merge(&mut first, second);
+        serde_json::from_value(first).unwrap()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClaudeCodeHookCommonPayload {
+    pub(crate) hook_event_name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClaudeCodePreToolUsePayload {
+    #[serde(flatten)]
+    pub common_payload: ClaudeCodeHookCommonPayload,
+    pub(crate) tool_name: String,
+    #[serde(flatten)]
+    pub rest: serde_json::Map<String, serde_json::Value>,
+}
+
+impl AgentHookPayload for ClaudeCodePreToolUsePayload {
+    fn parse_payload(payload: &str) -> anyhow::Result<Self> {
+        Ok(serde_json::from_str(payload)?)
+    }
+
+    fn to_hook_payload(&self) -> HookPayload {
+        let sub_payload = HookSubPayload::PreToolUse(PreToolUsePayload {
+            tool_name: self.tool_name.clone(),
+        });
+        HookPayload {
+            sub_payload,
+            rest: self.rest.clone(),
+        }
+    }
+
+    fn to_string(&self) -> anyhow::Result<String> {
+        serde_json::to_string(self).map_err(Into::into)
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClaudeCodePreToolUseOutput {
+    #[serde(rename = "hookEventName")]
+    pub hook_event_name: String,
+    #[serde(rename = "additionalContext", skip_serializing_if = "Option::is_none")]
+    pub additional_context: Option<String>,
+    #[serde(flatten)]
+    pub rest: serde_json::Map<String, serde_json::Value>,
+}
+
+impl ClaudeCodePreToolUseOutput {
+    pub fn new() -> Self {
+        Self {
+            hook_event_name: "PreToolUse".to_string(),
+            additional_context: None,
+            rest: serde_json::Map::new(),
+        }
+    }
+}
+
+impl AgentHookOutput for ClaudeCodePreToolUseOutput {
+    fn parse_output(output: &[u8]) -> anyhow::Result<Self>
+    where
+        Self: Sized,
+    {
+        Ok(serde_json::from_slice(output)?)
+    }
+
+    fn from_hook_output(payload: &HookOutput) -> anyhow::Result<Self> {
+        let Some(hook_specific_output) = &payload.hook_specific_output else {
+            return Err(anyhow!("missing hook specific output"));
+        };
+        if hook_specific_output.hook_event_name != "PreToolUse" {
+            return Err(anyhow!("unexpected hook event name"));
+        }
+        Ok(Self {
+            hook_event_name: hook_specific_output.hook_event_name.clone(),
+            additional_context: hook_specific_output.additional_context.clone(),
+            rest: hook_specific_output.rest.clone(),
+        })
+    }
+
+    fn to_hook_output(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap()
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+        self
+    }
+}

--- a/src/hook_schema/copilot.rs
+++ b/src/hook_schema/copilot.rs
@@ -22,18 +22,6 @@ impl AgentHookEvent for CopilotPreToolUseEvent {
     type Payload = CopilotPreToolUsePayload;
     type Output = CopilotPreToolUseOutput;
 
-    fn parse_payload(&self, payload: &str) -> anyhow::Result<Self::Payload> {
-        CopilotPreToolUsePayload::parse_payload(payload)
-    }
-
-    fn parse_output(&self, output: &[u8]) -> anyhow::Result<Self::Output> {
-        CopilotPreToolUseOutput::parse_output(output)
-    }
-
-    fn from_hook_output(&self, output: &HookOutput) -> anyhow::Result<Self::Output> {
-        CopilotPreToolUseOutput::from_hook_output(output)
-    }
-
     fn merge_outputs(first: Self::Output, second: Self::Output) -> Self::Output {
         let mut first = serde_json::to_value(first).unwrap();
         let second = serde_json::to_value(second).unwrap();
@@ -103,8 +91,8 @@ pub struct CopilotPreToolUseOutput {
     pub rest: serde_json::Map<String, serde_json::Value>,
 }
 
-impl CopilotPreToolUseOutput {
-    pub fn new() -> Self {
+impl Default for CopilotPreToolUseOutput {
+    fn default() -> Self {
         Self {
             permission_decision: None,
             permission_decision_reason: None,
@@ -126,7 +114,7 @@ impl AgentHookOutput for CopilotPreToolUseOutput {
 
     fn from_hook_output(payload: &HookOutput) -> anyhow::Result<Self> {
         // Map our internal HookOutput to the Copilot output shape.
-        let mut out = CopilotPreToolUseOutput::new();
+        let mut out = CopilotPreToolUseOutput::default();
         if let Some(ref hook_specific) = payload.hook_specific_output {
             out.additional_context = hook_specific.additional_context.clone();
             // merge any hookSpecific.rest into out.rest

--- a/src/hook_schema/copilot.rs
+++ b/src/hook_schema/copilot.rs
@@ -1,0 +1,151 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    hook::{HookOutput, HookPayload, HookSubPayload, PreToolUsePayload, merge},
+    hook_schema::{
+        Agent, AgentHookEvent, AgentHookOutput, AgentHookPayload, erase_agent_hook_event,
+    },
+};
+
+pub struct Copilot;
+impl Agent for Copilot {
+    fn event(&self, event: super::HookEvent) -> Option<Box<dyn super::ErasedAgentHookEvent>> {
+        match event {
+            super::HookEvent::PreToolUse => Some(erase_agent_hook_event(CopilotPreToolUseEvent)),
+            _ => None,
+        }
+    }
+}
+
+pub struct CopilotPreToolUseEvent;
+impl AgentHookEvent for CopilotPreToolUseEvent {
+    type Payload = CopilotPreToolUsePayload;
+    type Output = CopilotPreToolUseOutput;
+
+    fn parse_payload(&self, payload: &str) -> anyhow::Result<Self::Payload> {
+        CopilotPreToolUsePayload::parse_payload(payload)
+    }
+
+    fn parse_output(&self, output: &[u8]) -> anyhow::Result<Self::Output> {
+        CopilotPreToolUseOutput::parse_output(output)
+    }
+
+    fn from_hook_output(&self, output: &HookOutput) -> anyhow::Result<Self::Output> {
+        CopilotPreToolUseOutput::from_hook_output(output)
+    }
+
+    fn merge_outputs(first: Self::Output, second: Self::Output) -> Self::Output {
+        let mut first = serde_json::to_value(first).unwrap();
+        let second = serde_json::to_value(second).unwrap();
+        merge(&mut first, second);
+        serde_json::from_value(first).unwrap()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CopilotPreToolUsePayload {
+    #[serde(rename = "timestamp")]
+    pub timestamp: Option<i64>,
+    #[serde(rename = "cwd")]
+    pub cwd: Option<String>,
+    #[serde(rename = "toolName")]
+    pub tool_name: String,
+    #[serde(rename = "toolArgs")]
+    pub tool_args: serde_json::Value,
+    #[serde(flatten)]
+    pub rest: serde_json::Map<String, serde_json::Value>,
+}
+
+impl AgentHookPayload for CopilotPreToolUsePayload {
+    fn parse_payload(payload: &str) -> anyhow::Result<Self> {
+        Ok(serde_json::from_str(payload)?)
+    }
+
+    fn to_hook_payload(&self) -> HookPayload {
+        let sub_payload = HookSubPayload::PreToolUse(PreToolUsePayload {
+            tool_name: self.tool_name.clone(),
+        });
+
+        let mut rest = self.rest.clone();
+        rest.insert("tool_args".to_string(), self.tool_args.clone());
+        if let Some(ts) = self.timestamp {
+            rest.insert("timestamp".to_string(), serde_json::Value::Number(ts.into()));
+        }
+        if let Some(ref c) = self.cwd {
+            rest.insert("cwd".to_string(), serde_json::Value::String(c.clone()));
+        }
+
+        HookPayload { sub_payload, rest }
+    }
+
+    fn to_string(&self) -> anyhow::Result<String> {
+        serde_json::to_string(self).map_err(Into::into)
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CopilotPreToolUseOutput {
+    #[serde(rename = "permissionDecision", skip_serializing_if = "Option::is_none")]
+    pub permission_decision: Option<String>,
+    #[serde(rename = "permissionDecisionReason", skip_serializing_if = "Option::is_none")]
+    pub permission_decision_reason: Option<String>,
+    #[serde(rename = "modifiedArgs", skip_serializing_if = "Option::is_none")]
+    pub modified_args: Option<serde_json::Value>,
+    #[serde(rename = "additionalContext", skip_serializing_if = "Option::is_none")]
+    pub additional_context: Option<String>,
+    #[serde(rename = "suppressOutput", skip_serializing_if = "Option::is_none")]
+    pub suppress_output: Option<bool>,
+    #[serde(flatten)]
+    pub rest: serde_json::Map<String, serde_json::Value>,
+}
+
+impl CopilotPreToolUseOutput {
+    pub fn new() -> Self {
+        Self {
+            permission_decision: None,
+            permission_decision_reason: None,
+            modified_args: None,
+            additional_context: None,
+            suppress_output: None,
+            rest: serde_json::Map::new(),
+        }
+    }
+}
+
+impl AgentHookOutput for CopilotPreToolUseOutput {
+    fn parse_output(output: &[u8]) -> anyhow::Result<Self>
+    where
+        Self: Sized,
+    {
+        Ok(serde_json::from_slice(output)?)
+    }
+
+    fn from_hook_output(payload: &HookOutput) -> anyhow::Result<Self> {
+        // Map our internal HookOutput to the Copilot output shape.
+        let mut out = CopilotPreToolUseOutput::new();
+        if let Some(ref hook_specific) = payload.hook_specific_output {
+            out.additional_context = hook_specific.additional_context.clone();
+            // merge any hookSpecific.rest into out.rest
+            for (k, v) in hook_specific.rest.iter() {
+                out.rest.insert(k.clone(), v.clone());
+            }
+        }
+        // copy other top-level rest fields
+        for (k, v) in payload.rest.iter() {
+            out.rest.insert(k.clone(), v.clone());
+        }
+        Ok(out)
+    }
+
+    fn to_hook_output(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap()
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+        self
+    }
+}

--- a/src/hook_schema/gemini.rs
+++ b/src/hook_schema/gemini.rs
@@ -1,0 +1,196 @@
+use anyhow::anyhow;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    hook::{HookOutput, HookPayload, HookSubPayload, PreToolUsePayload, merge},
+    hook_schema::{
+        Agent, AgentHookEvent, AgentHookOutput, AgentHookPayload, erase_agent_hook_event,
+    },
+};
+
+pub struct GeminiCode;
+impl Agent for GeminiCode {
+    fn event(&self, event: super::HookEvent) -> Option<Box<dyn super::ErasedAgentHookEvent>> {
+        match event {
+            super::HookEvent::PreToolUse => Some(erase_agent_hook_event(GeminiPreToolUseEvent)),
+            _ => None,
+        }
+    }
+}
+pub struct GeminiPreToolUseEvent;
+impl AgentHookEvent for GeminiPreToolUseEvent {
+    type Payload = GeminiBeforeToolPayload;
+    type Output = GeminiBeforeToolUseOutput;
+
+    fn parse_payload(&self, payload: &str) -> anyhow::Result<Self::Payload> {
+        GeminiBeforeToolPayload::parse_payload(payload)
+    }
+
+    fn parse_output(&self, output: &[u8]) -> anyhow::Result<Self::Output> {
+        GeminiBeforeToolUseOutput::parse_output(output)
+    }
+
+    fn from_hook_output(&self, output: &HookOutput) -> anyhow::Result<Self::Output> {
+        GeminiBeforeToolUseOutput::from_hook_output(output)
+    }
+
+    fn merge_outputs(first: Self::Output, second: Self::Output) -> Self::Output {
+        let mut first = serde_json::to_value(first).unwrap();
+        let second = serde_json::to_value(second).unwrap();
+        merge(&mut first, second);
+        serde_json::from_value(first).unwrap()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GeminiHookCommonPayload {
+    pub(crate) hook_event_name: String,
+    #[serde(default)]
+    pub(crate) session_id: Option<String>,
+    #[serde(default)]
+    pub(crate) cwd: Option<String>,
+    #[serde(default)]
+    pub(crate) transcript_path: Option<String>,
+    #[serde(default)]
+    pub(crate) timestamp: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GeminiBeforeToolPayload {
+    #[serde(flatten)]
+    pub common_payload: GeminiHookCommonPayload,
+    pub(crate) tool_name: String,
+    pub(crate) tool_input: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) mcp_context: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) original_request_name: Option<String>,
+    #[serde(flatten)]
+    pub rest: serde_json::Map<String, serde_json::Value>,
+}
+
+impl AgentHookPayload for GeminiBeforeToolPayload {
+    fn parse_payload(payload: &str) -> anyhow::Result<Self> {
+        Ok(serde_json::from_str(payload)?)
+    }
+
+    fn to_hook_payload(&self) -> HookPayload {
+        let sub_payload = HookSubPayload::PreToolUse(PreToolUsePayload {
+            tool_name: self.tool_name.clone(),
+        });
+        // Forward Gemini fields to the internal HookPayload.rest so plugin
+        // hooks can access `tool_input`, `mcp_context`, and other metadata.
+        let mut rest = self.rest.clone();
+        rest.insert("tool_input".to_string(), self.tool_input.clone());
+        if let Some(ref mcp) = self.mcp_context {
+            rest.insert("mcp_context".to_string(), mcp.clone());
+        }
+        if let Some(ref name) = self.original_request_name {
+            rest.insert("original_request_name".to_string(), serde_json::Value::String(name.clone()));
+        }
+        if let Some(ref s) = self.common_payload.session_id {
+            rest.insert("session_id".to_string(), serde_json::Value::String(s.clone()));
+        }
+        if let Some(ref c) = self.common_payload.cwd {
+            rest.insert("cwd".to_string(), serde_json::Value::String(c.clone()));
+        }
+        if let Some(ref t) = self.common_payload.transcript_path {
+            rest.insert("transcript_path".to_string(), serde_json::Value::String(t.clone()));
+        }
+        if let Some(ref ts) = self.common_payload.timestamp {
+            rest.insert("timestamp".to_string(), serde_json::Value::String(ts.clone()));
+        }
+
+        HookPayload { sub_payload, rest }
+    }
+
+    fn to_string(&self) -> anyhow::Result<String> {
+        serde_json::to_string(self).map_err(Into::into)
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GeminiBeforeToolUseOutput {
+    #[serde(rename = "decision", skip_serializing_if = "Option::is_none")]
+    pub decision: Option<String>,
+    #[serde(rename = "reason", skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(rename = "systemMessage", skip_serializing_if = "Option::is_none")]
+    pub system_message: Option<String>,
+    #[serde(rename = "suppressOutput", skip_serializing_if = "Option::is_none")]
+    pub suppress_output: Option<bool>,
+    #[serde(rename = "continue", skip_serializing_if = "Option::is_none")]
+    pub continue_: Option<bool>,
+    #[serde(rename = "stopReason", skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<String>,
+    #[serde(rename = "hookSpecificOutput", skip_serializing_if = "Option::is_none")]
+    pub hook_specific_output: Option<InnerHookSpecificOutput>,
+    #[serde(flatten)]
+    pub rest: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InnerHookSpecificOutput {
+    #[serde(rename = "hookEventName")]
+    pub hook_event_name: String,
+    #[serde(rename = "additionalContext", skip_serializing_if = "Option::is_none")]
+    pub additional_context: Option<String>,
+    #[serde(rename = "tool_input", skip_serializing_if = "Option::is_none")]
+    pub tool_input: Option<serde_json::Value>,
+    #[serde(flatten)]
+    pub rest: serde_json::Map<String, serde_json::Value>,
+}
+
+impl GeminiBeforeToolUseOutput {
+    pub fn new() -> Self {
+        Self {
+            decision: None,
+            reason: None,
+            system_message: None,
+            suppress_output: None,
+            continue_: None,
+            stop_reason: None,
+            hook_specific_output: Some(InnerHookSpecificOutput {
+                hook_event_name: "BeforeTool".to_string(),
+                additional_context: None,
+                tool_input: None,
+                rest: serde_json::Map::new(),
+            }),
+            rest: serde_json::Map::new(),
+        }
+    }
+}
+
+impl AgentHookOutput for GeminiBeforeToolUseOutput {
+    fn parse_output(output: &[u8]) -> anyhow::Result<Self>
+    where
+        Self: Sized,
+    {
+        Ok(serde_json::from_slice(output)?)
+    }
+
+    fn from_hook_output(payload: &HookOutput) -> anyhow::Result<Self> {
+        let Some(hook_specific_output) = &payload.hook_specific_output else {
+            return Err(anyhow!("missing hook specific output"));
+        };
+        if hook_specific_output.hook_event_name != "BeforeTool" {
+            return Err(anyhow!("unexpected hook event name"));
+        }
+
+        // Convert the entire HookOutput to JSON and deserialize into the Gemini output
+        let value = serde_json::to_value(payload).unwrap();
+        Ok(serde_json::from_value(value).unwrap())
+    }
+
+    fn to_hook_output(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap()
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+        self
+    }
+}

--- a/src/hook_schema/gemini.rs
+++ b/src/hook_schema/gemini.rs
@@ -8,8 +8,8 @@ use crate::{
     },
 };
 
-pub struct GeminiCode;
-impl Agent for GeminiCode {
+pub struct Gemini;
+impl Agent for Gemini {
     fn event(&self, event: super::HookEvent) -> Option<Box<dyn super::ErasedAgentHookEvent>> {
         match event {
             super::HookEvent::PreToolUse => Some(erase_agent_hook_event(GeminiPreToolUseEvent)),

--- a/src/hook_schema/gemini.rs
+++ b/src/hook_schema/gemini.rs
@@ -22,18 +22,6 @@ impl AgentHookEvent for GeminiPreToolUseEvent {
     type Payload = GeminiBeforeToolPayload;
     type Output = GeminiBeforeToolUseOutput;
 
-    fn parse_payload(&self, payload: &str) -> anyhow::Result<Self::Payload> {
-        GeminiBeforeToolPayload::parse_payload(payload)
-    }
-
-    fn parse_output(&self, output: &[u8]) -> anyhow::Result<Self::Output> {
-        GeminiBeforeToolUseOutput::parse_output(output)
-    }
-
-    fn from_hook_output(&self, output: &HookOutput) -> anyhow::Result<Self::Output> {
-        GeminiBeforeToolUseOutput::from_hook_output(output)
-    }
-
     fn merge_outputs(first: Self::Output, second: Self::Output) -> Self::Output {
         let mut first = serde_json::to_value(first).unwrap();
         let second = serde_json::to_value(second).unwrap();
@@ -145,8 +133,8 @@ pub struct InnerHookSpecificOutput {
     pub rest: serde_json::Map<String, serde_json::Value>,
 }
 
-impl GeminiBeforeToolUseOutput {
-    pub fn new() -> Self {
+impl Default for GeminiBeforeToolUseOutput {
+    fn default() -> Self {
         Self {
             decision: None,
             reason: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ async fn main() -> ExitCode {
                 ExitCode::FAILURE
             }
         },
-        Some(Commands::Hook { event }) => hook::run(&sym, event).await,
+        Some(Commands::Hook { event }) => hook::run_claude(&sym, event).await,
         Some(Commands::Plugin { command }) => handle_plugin_command(&sym, command).await,
         None => {
             use clap::CommandFactory;
@@ -103,11 +103,7 @@ async fn main() -> ExitCode {
     }
 }
 
-async fn dispatch_and_print(
-    sym: &config::Symposium,
-    cmd: SharedCommand,
-    cwd: &Path,
-) -> ExitCode {
+async fn dispatch_and_print(sym: &config::Symposium, cmd: SharedCommand, cwd: &Path) -> ExitCode {
     match dispatch::dispatch(sym, cmd, cwd, dispatch::RenderMode::Cli).await {
         dispatch::DispatchResult::Ok(output) => {
             print!("{output}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ enum Commands {
 
     /// Handle a hook event (invoked by editor plugins)
     Hook {
+        agent: hook::HookAgent,
         /// The hook event (e.g., claude:pre-tool)
         event: hook::HookEvent,
     },
@@ -92,7 +93,7 @@ async fn main() -> ExitCode {
                 ExitCode::FAILURE
             }
         },
-        Some(Commands::Hook { event }) => hook::run_claude(&sym, event).await,
+        Some(Commands::Hook { agent, event }) => hook::run(&sym, agent, event).await,
         Some(Commands::Plugin { command }) => handle_plugin_command(&sym, command).await,
         None => {
             use clap::CommandFactory;

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -327,7 +327,10 @@ fn resolve_plugin_source_dirs(sym: &Symposium) -> Vec<PathBuf> {
     dirs
 }
 
-fn resolve_plugin_source_dir(sym: &Symposium, source: &crate::config::PluginSourceConfig) -> Option<PathBuf> {
+fn resolve_plugin_source_dir(
+    sym: &Symposium,
+    source: &crate::config::PluginSourceConfig,
+) -> Option<PathBuf> {
     let config_dir = sym.config_dir();
     let cache_base = sym.cache_dir().join("plugin-sources");
 
@@ -350,7 +353,11 @@ fn resolve_plugin_source_dir(sym: &Symposium, source: &crate::config::PluginSour
 }
 
 /// Fetch a plugin source repository, returning the cached directory path.
-async fn fetch_plugin_source(sym: &Symposium, git_url: &str, update: UpdateLevel) -> Result<PathBuf> {
+async fn fetch_plugin_source(
+    sym: &Symposium,
+    git_url: &str,
+    update: UpdateLevel,
+) -> Result<PathBuf> {
     use crate::git_source;
 
     let source = git_source::parse_github_url(git_url)?;


### PR DESCRIPTION
## What does this PR do?

* Add some adapter code to parse agent-specific payload and output, and convert between that and the "core" payload and output.
* Add agent-specific "pretooluse" hooks for claude, gemini, and copilot
* Updates `symposium hook <event>` to be `symposium hook <agent> <event>`

<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

<!-- Symposium is an AI project. We encourage the use of agentic tooling! We do however require disclosure. The disclosure helps us to calibrate our reviews. See our [PR disclosure policy](https://symposium-dev.github.io/symposium/design/governance.html#pr-disclosure-policy). -->

<!-- Remove the items that do not apply. -->

* The AI tool authored small parts of the code (e.g., autocomplete, comments) - First commit
* The AI tool authored large parts of the code - Subsequent commits

**Confidence level.**

<!-- Remove the items that do not apply. -->

* I am very happy with it

**Questions for reviewers.**

<!-- Any specific areas of uncertainty or things you'd like reviewers to look at? -->

</details>
