### PR TITLE
Add MCP server registration for all supported agents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,6 +1790,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,6 +1925,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_yaml",
  "symposium-testlib",
  "tar",
  "tempfile",
@@ -2329,6 +2343,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,10 +1790,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1925,7 +1925,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
  "symposium-testlib",
  "tar",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ toml_edit = "0.25.11"
 assert_matches = "1.5"
 expect-test = "1.5.1"
 indoc = "2.0.7"
-serde_yaml = "0.9"
+serde_yaml_ng = "0.10"
 symposium-testlib = { path = "symposium-testlib" }
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ toml_edit = "0.25.11"
 assert_matches = "1.5"
 expect-test = "1.5.1"
 indoc = "2.0.7"
+serde_yaml = "0.9"
 symposium-testlib = { path = "symposium-testlib" }
 
 [workspace]

--- a/md/SUMMARY.md
+++ b/md/SUMMARY.md
@@ -24,6 +24,7 @@
 - [Publishing skills](./crate-authors/publishing-skills.md)
 - [Creating a plugin](./crate-authors/creating-a-plugin.md)
 - [Publishing hooks](./crate-authors/publishing-hooks.md)
+- [Publishing MCP servers](./crate-authors/publishing-mcp-servers.md)
 
 # Reference
 

--- a/md/crate-authors/publishing-mcp-servers.md
+++ b/md/crate-authors/publishing-mcp-servers.md
@@ -4,24 +4,7 @@ MCP servers let your plugin expose tools and resources to AI agents via the [Mod
 
 ## Declaring an MCP server
 
-MCP servers are declared in your plugin's TOML manifest with `[[mcp_servers]]` entries.
-
-### Builtin servers
-
-If your MCP server is built into the `symposium` binary, use the `builtin` form:
-
-```toml
-[[mcp_servers]]
-name = "symposium"
-type = "builtin"
-args = ["mcp"]
-```
-
-The `args` array becomes the arguments passed to the `symposium` binary. Symposium resolves the binary path at sync time, so users don't need to hardcode it.
-
-### Custom servers
-
-For a standalone MCP server, declare it with the appropriate transport:
+MCP servers are declared in your plugin's TOML manifest with `[[mcp_servers]]` entries:
 
 ```toml
 # Stdio transport (no type field needed)
@@ -29,18 +12,21 @@ For a standalone MCP server, declare it with the appropriate transport:
 name = "widgetlib-mcp"
 command = "/usr/local/bin/widgetlib-mcp"
 args = ["--stdio"]
+env = []
 
 # HTTP transport
 [[mcp_servers]]
 type = "http"
 name = "widgetlib-remote"
 url = "http://localhost:8080/mcp"
+headers = []
 
 # SSE transport
 [[mcp_servers]]
 type = "sse"
 name = "widgetlib-sse"
 url = "http://localhost:8080/sse"
+headers = []
 ```
 
 HTTP and SSE entries require a `type` field to distinguish them. Stdio entries don't need one.
@@ -50,8 +36,7 @@ HTTP and SSE entries require a `type` field to distinguish them. Stdio entries d
 When a user runs `symposium sync` (or the hook triggers it automatically), Symposium:
 
 1. Collects `[[mcp_servers]]` entries from all enabled plugins.
-2. Resolves builtin entries to the local `symposium` binary path.
-3. Writes each server into the agent's MCP configuration file.
+2. Writes each server into the agent's MCP configuration file.
 
 Registration is idempotent. If the entry already exists with the correct values, it's left untouched. Stale entries are updated in place.
 
@@ -74,6 +59,7 @@ source.path = "skills"
 name = "widgetlib-mcp"
 command = "widgetlib-mcp"
 args = ["--stdio"]
+env = []
 ```
 
 ## Reference

--- a/md/crate-authors/publishing-mcp-servers.md
+++ b/md/crate-authors/publishing-mcp-servers.md
@@ -1,0 +1,81 @@
+# Publishing MCP servers
+
+MCP servers let your plugin expose tools and resources to AI agents via the [Model Context Protocol](https://modelcontextprotocol.io/). When a user syncs their project, Symposium registers your MCP server into the agent's configuration automatically.
+
+## Declaring an MCP server
+
+MCP servers are declared in your plugin's TOML manifest with `[[mcp_servers]]` entries.
+
+### Builtin servers
+
+If your MCP server is built into the `symposium` binary, use the `builtin` form:
+
+```toml
+[[mcp_servers]]
+name = "symposium"
+type = "builtin"
+args = ["mcp"]
+```
+
+The `args` array becomes the arguments passed to the `symposium` binary. Symposium resolves the binary path at sync time, so users don't need to hardcode it.
+
+### Custom servers
+
+For a standalone MCP server, declare it with the appropriate transport:
+
+```toml
+# Stdio transport (no type field needed)
+[[mcp_servers]]
+name = "widgetlib-mcp"
+command = "/usr/local/bin/widgetlib-mcp"
+args = ["--stdio"]
+
+# HTTP transport
+[[mcp_servers]]
+type = "http"
+name = "widgetlib-remote"
+url = "http://localhost:8080/mcp"
+
+# SSE transport
+[[mcp_servers]]
+type = "sse"
+name = "widgetlib-sse"
+url = "http://localhost:8080/sse"
+```
+
+HTTP and SSE entries require a `type` field to distinguish them. Stdio entries don't need one.
+
+## How it works
+
+When a user runs `symposium sync` (or the hook triggers it automatically), Symposium:
+
+1. Collects `[[mcp_servers]]` entries from all enabled plugins.
+2. Resolves builtin entries to the local `symposium` binary path.
+3. Writes each server into the agent's MCP configuration file.
+
+Registration is idempotent. If the entry already exists with the correct values, it's left untouched. Stale entries are updated in place.
+
+## Agent support
+
+All supported agents have MCP server configuration. Symposium handles the format differences — you declare the server once and it works across agents.
+
+See the [per-agent registration table](../reference/plugin-definition.md#how-registration-works) for where each agent stores MCP config.
+
+## Example: plugin with skills and an MCP server
+
+```toml
+name = "widgetlib"
+
+[[skills]]
+crates = ["widgetlib"]
+source.path = "skills"
+
+[[mcp_servers]]
+name = "widgetlib-mcp"
+command = "widgetlib-mcp"
+args = ["--stdio"]
+```
+
+## Reference
+
+See the [`[[mcp_servers]]` section](../reference/plugin-definition.md#mcp_servers) in the plugin definition reference for the full field listing.

--- a/md/crate-authors/supporting-your-crate.md
+++ b/md/crate-authors/supporting-your-crate.md
@@ -4,10 +4,11 @@ If you maintain a Rust crate, you can teach AI assistants how to use your librar
 
 ## What you can provide
 
-There are two kinds of extensions you can publish:
+There are three kinds of extensions you can publish:
 
 - **Skills** — guidance documents that AI assistants receive automatically when a user's project depends on your crate.
 - **Hooks** — checks and transformations that run when the AI performs certain actions, like writing code or running commands.
+- **MCP servers** — tools and resources exposed to agents via the Model Context Protocol.
 
 ## Just want to add a skill?
 
@@ -20,3 +21,9 @@ See [Publishing skills](./publishing-skills.md) for the details.
 If you want to publish hooks — or a combination of hooks and skills — you'll need to create a plugin. A plugin is a TOML manifest that ties everything together.
 
 See [Creating a plugin](./creating-a-plugin.md) for how to set one up.
+
+## Want to expose tools via MCP?
+
+If your crate has an MCP server, you can register it through a plugin so agents discover it automatically.
+
+See [Publishing MCP servers](./publishing-mcp-servers.md) for details.

--- a/md/design/agent-details/claude-code.md
+++ b/md/design/agent-details/claude-code.md
@@ -177,3 +177,32 @@ Decision precedence across parallel hooks: **deny > defer > ask > allow**. The `
 - **`allowedHttpHookUrls`** — restricts HTTP hook destinations.
 - **`disableAllHooks: true`** — disables everything.
 - PreToolUse deny blocks even in `bypassPermissions` mode.
+
+## MCP Server Registration
+
+In addition to hooks, symposium registers itself as an MCP server in the
+agent's settings file. This provides an alternative integration path
+alongside the hook-based approach.
+
+### Configuration structure
+
+The MCP server entry is added under `mcpServers` in the same settings
+file used for hooks:
+
+```json
+{
+  "mcpServers": {
+    "symposium": {
+      "command": "/path/to/symposium",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+- **Project-level**: `.claude/settings.json`
+- **User-level**: `~/.claude/settings.json`
+
+Registration is idempotent — if the entry already exists with the
+correct values, no changes are made. If the entry exists but has stale
+values (e.g. the binary moved), it is updated in place.

--- a/md/design/agent-details/codex-cli.md
+++ b/md/design/agent-details/codex-cli.md
@@ -210,6 +210,29 @@ tool_timeout_sec = 60
 
 Supports stdio (`command`/`args`) and streamable HTTP (`url`/`bearer_token_env_var`). CLI management: `codex mcp add <name> ...`.
 
+## MCP Server Registration
+
+In addition to hooks, symposium registers itself as an MCP server in the
+agent's config file. This provides an alternative integration path
+alongside the hook-based approach.
+
+### Configuration structure
+
+The MCP server entry is added under `[mcp_servers]` in the TOML config:
+
+```toml
+[mcp_servers.symposium]
+command = "/path/to/symposium"
+args = ["mcp"]
+```
+
+- **Project-level**: `.codex/config.toml`
+- **User-level**: `~/.codex/config.toml`
+
+Registration is idempotent — if the entry already exists with the
+correct values, no changes are made. If the entry exists but has stale
+values (e.g. the binary moved), it is updated in place.
+
 ## Other Extensibility
 
 - `notify` in config.toml (fire-and-forget on agent-turn-complete)

--- a/md/design/agent-details/copilot.md
+++ b/md/design/agent-details/copilot.md
@@ -165,6 +165,30 @@ Priority: Personal (user) > Repository (workspace) > Organization.
 
 Note: VS Code uses `"servers"` as root key while the CLI uses `"mcpServers"`. MCP tools only work in Copilot's Agent mode. Supported transports: `local`/`stdio`, `http`/`sse`.
 
+### MCP Server Registration
+
+In addition to hooks, symposium registers itself as an MCP server in the
+agent's config file. This provides an alternative integration path
+alongside the hook-based approach.
+
+The MCP server entry is added as a top-level key:
+
+```json
+{
+  "symposium": {
+    "command": "/path/to/symposium",
+    "args": ["mcp"]
+  }
+}
+```
+
+- **Project-level**: `.vscode/mcp.json`
+- **User-level**: `~/.copilot/mcp-config.json`
+
+Registration is idempotent — if the entry already exists with the
+correct values, no changes are made. If the entry exists but has stale
+values (e.g. the binary moved), it is updated in place.
+
 ### Copilot SDK (programmatic hooks)
 
 The `@github/copilot-sdk` (Node.js, Python, Go, .NET, Java) provides callback-style hooks for applications embedding the Copilot runtime:

--- a/md/design/agent-details/copilot.md
+++ b/md/design/agent-details/copilot.md
@@ -167,11 +167,8 @@ Note: VS Code uses `"servers"` as root key while the CLI uses `"mcpServers"`. MC
 
 ### MCP Server Registration
 
-In addition to hooks, symposium registers itself as an MCP server in the
-agent's config file. This provides an alternative integration path
-alongside the hook-based approach.
-
-The MCP server entry is added as a top-level key:
+Symposium registers MCP servers in the Copilot config as top-level keys
+(matching the CLI's `mcpServers` format, not VS Code's `servers` format):
 
 ```json
 {

--- a/md/design/agent-details/gemini-cli.md
+++ b/md/design/agent-details/gemini-cli.md
@@ -222,3 +222,32 @@ Configured under `mcpServers` in `.gemini/settings.json` or `~/.gemini/settings.
 ```
 
 Transport is auto-selected by key: `command`+`args` (stdio), `url` (SSE), `httpUrl` (streamable HTTP).
+
+## MCP Server Registration
+
+In addition to hooks, symposium registers itself as an MCP server in the
+agent's settings file. This provides an alternative integration path
+alongside the hook-based approach.
+
+### Configuration structure
+
+The MCP server entry is added under `mcpServers` in the same settings
+file used for hooks:
+
+```json
+{
+  "mcpServers": {
+    "symposium": {
+      "command": "/path/to/symposium",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+- **Project-level**: `.gemini/settings.json`
+- **User-level**: `~/.gemini/settings.json`
+
+Registration is idempotent — if the entry already exists with the
+correct values, no changes are made. If the entry exists but has stale
+values (e.g. the binary moved), it is updated in place.

--- a/md/design/agent-details/goose.md
+++ b/md/design/agent-details/goose.md
@@ -75,6 +75,5 @@ extensions:
 - **Project-level**: `.goose/config.yaml`
 - **User-level**: `~/.config/goose/config.yaml`
 
-Registration is idempotent — if the entry already exists, no changes
-are made. Unlike JSON/TOML-based agents, stale entries are not updated
-in place due to the string-based YAML manipulation approach.
+Registration is idempotent — if the entry already exists with the correct
+values, no changes are made. Stale entries are updated in place.

--- a/md/design/agent-details/goose.md
+++ b/md/design/agent-details/goose.md
@@ -76,4 +76,5 @@ extensions:
 - **User-level**: `~/.config/goose/config.yaml`
 
 Registration is idempotent — if the entry already exists, no changes
-are made.
+are made. Unlike JSON/TOML-based agents, stale entries are not updated
+in place due to the string-based YAML manipulation approach.

--- a/md/design/agent-details/goose.md
+++ b/md/design/agent-details/goose.md
@@ -52,3 +52,28 @@ Shell scripts can detect whether they're running under Goose and alter behavior 
 - Subagents
 - ACP integration
 - Tool Router — internal optimization for tool selection
+
+## MCP Server Registration
+
+Since Goose has no lifecycle hooks, symposium integrates exclusively via
+MCP server registration. Symposium registers itself as an extension in
+the Goose config file.
+
+### Configuration structure
+
+The MCP server entry is added under `extensions` in the YAML config:
+
+```yaml
+extensions:
+  symposium:
+    provider: mcp
+    config:
+      command: /path/to/symposium
+      args: [mcp]
+```
+
+- **Project-level**: `.goose/config.yaml`
+- **User-level**: `~/.config/goose/config.yaml`
+
+Registration is idempotent — if the entry already exists, no changes
+are made.

--- a/md/design/agent-details/kiro.md
+++ b/md/design/agent-details/kiro.md
@@ -227,3 +227,31 @@ Workspace skills take precedence over global skills with the same name. The defa
 | Agent-level | `mcpServers` field in `.kiro/agents/*.json` |
 
 Priority: Agent config > Workspace > Global. Format is JSON with `mcpServers` key, supporting `command`/`args`/`env` for stdio and `url`/`headers` for remote servers.
+
+## MCP Server Registration
+
+In addition to hooks, symposium registers itself as an MCP server in the
+agent's MCP config file. This provides an alternative integration path
+alongside the hook-based approach.
+
+### Configuration structure
+
+The MCP server entry is added under `mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "symposium": {
+      "command": "/path/to/symposium",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+- **Project-level**: `.kiro/settings/mcp.json`
+- **User-level**: `~/.kiro/settings/mcp.json`
+
+Registration is idempotent — if the entry already exists with the
+correct values, no changes are made. If the entry exists but has stale
+values (e.g. the binary moved), it is updated in place.

--- a/md/design/agent-details/opencode.md
+++ b/md/design/agent-details/opencode.md
@@ -155,3 +155,31 @@ OpenCode walks up from CWD to the git worktree root, loading matching skill defi
 ## Additional Events (Plugin System)
 
 The full event list includes: `session.created`, `session.idle`, `session.compacted`, `message.updated`, `file.edited`, `file.watcher.updated`, `permission.asked`, `permission.replied`, `tool.execute.before`, `tool.execute.after`, `shell.env`, `tui.prompt.append`, `tui.command.execute`, and others (~30 total). The `message.updated` event (filtered by `role === "user"`) is the closest equivalent to a user-prompt-submit hook. The `session.created` event is the session-start equivalent.
+
+## MCP Server Registration
+
+In addition to hooks, symposium registers itself as an MCP server in the
+agent's config file. This provides an alternative integration path
+alongside the hook-based approach.
+
+### Configuration structure
+
+The MCP server entry is added under `mcp` in the JSON config:
+
+```json
+{
+  "mcp": {
+    "symposium": {
+      "command": "/path/to/symposium",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+- **Project-level**: `opencode.json`
+- **User-level**: `~/.config/opencode/opencode.json`
+
+Registration is idempotent — if the entry already exists with the
+correct values, no changes are made. If the entry exists but has stale
+values (e.g. the binary moved), it is updated in place.

--- a/md/reference/plugin-definition.md
+++ b/md/reference/plugin-definition.md
@@ -114,23 +114,6 @@ headers = []
 | `url` | string | SSE endpoint URL. |
 | `headers` | array of objects | HTTP headers to set when making requests. |
 
-### Builtin
-
-The `builtin` type invokes the `symposium` binary itself as an MCP server. Symposium resolves the binary path at sync time.
-
-```toml
-[[mcp_servers]]
-name = "symposium"
-type = "builtin"
-args = ["mcp"]
-```
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `type` | string | Must be `"builtin"`. |
-| `name` | string | Server name as it appears in the agent's MCP config. |
-| `args` | array of strings | Arguments passed to the `symposium` binary. |
-
 ### How registration works
 
 During `symposium sync --agent`, each MCP server entry is written into the agent's config file in the format that agent expects. Registration is idempotent — existing entries with correct values are left untouched, stale entries are updated in place.
@@ -165,9 +148,10 @@ matcher = "Bash"
 command = "./scripts/check-widget.sh"
 
 [[mcp_servers]]
-name = "symposium"
-type = "builtin"
-args = ["mcp"]
+name = "widgetlib-mcp"
+command = "/usr/local/bin/widgetlib-mcp"
+args = ["--stdio"]
+env = []
 ```
 
 ## Validation

--- a/md/reference/plugin-definition.md
+++ b/md/reference/plugin-definition.md
@@ -118,8 +118,6 @@ headers = []
 
 During `symposium sync --agent`, each MCP server entry is written into the agent's config file in the format that agent expects. Registration is idempotent — existing entries with correct values are left untouched, stale entries are updated in place.
 
-**Caveat:** Goose uses string-based YAML manipulation to preserve comments. Existing entries are detected but not updated — if the server command or args change, remove the old entry manually.
-
 | Agent | Config location | Key |
 |-------|----------------|-----|
 | Claude Code | `.claude/settings.json` | `mcpServers.<name>` |

--- a/md/reference/plugin-definition.md
+++ b/md/reference/plugin-definition.md
@@ -118,6 +118,8 @@ headers = []
 
 During `symposium sync --agent`, each MCP server entry is written into the agent's config file in the format that agent expects. Registration is idempotent — existing entries with correct values are left untouched, stale entries are updated in place.
 
+**Caveat:** Goose uses string-based YAML manipulation to preserve comments. Existing entries are detected but not updated — if the server command or args change, remove the old entry manually.
+
 | Agent | Config location | Key |
 |-------|----------------|-----|
 | Claude Code | `.claude/settings.json` | `mcpServers.<name>` |

--- a/md/reference/plugin-definition.md
+++ b/md/reference/plugin-definition.md
@@ -55,6 +55,96 @@ When multiple plugins provide `session-start-context`, all of their texts are co
 
 This works via the `SessionStart` hook event. When the agent starts a session, symposium collects `session-start-context` from all loaded plugins — including both user-level and project-level plugin sources — and returns the combined text.
 
+## `[[mcp_servers]]`
+
+Each `[[mcp_servers]]` entry declares an MCP server that Symposium registers into the agent's configuration during `sync --agent`.
+
+There are multiple MCP transports:
+
+### Stdio
+
+```toml
+[[mcp_servers]]
+name = "my-server"
+command = "/usr/local/bin/my-server"
+args = ["--stdio"]
+env = []
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Server name as it appears in the agent's MCP config. |
+| `command` | string | Path to the server binary. |
+| `args` | array of strings | Arguments passed to the binary. |
+| `env` | array of objects | Environment variables to set when launching the server. |
+
+Stdio entries do not need a `type` field.
+
+### HTTP
+
+```toml
+[[mcp_servers]]
+type = "http"
+name = "my-server"
+url = "http://localhost:8080/mcp"
+headers = []
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | string | Must be `"http"`. |
+| `name` | string | Server name as it appears in the agent's MCP config. |
+| `url` | string | HTTP endpoint URL. |
+| `headers` | array of objects | HTTP headers to set when making requests. |
+
+### SSE
+
+```toml
+[[mcp_servers]]
+type = "sse"
+name = "my-server"
+url = "http://localhost:8080/sse"
+headers = []
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | string | Must be `"sse"`. |
+| `name` | string | Server name as it appears in the agent's MCP config. |
+| `url` | string | SSE endpoint URL. |
+| `headers` | array of objects | HTTP headers to set when making requests. |
+
+### Builtin
+
+The `builtin` type invokes the `symposium` binary itself as an MCP server. Symposium resolves the binary path at sync time.
+
+```toml
+[[mcp_servers]]
+name = "symposium"
+type = "builtin"
+args = ["mcp"]
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | string | Must be `"builtin"`. |
+| `name` | string | Server name as it appears in the agent's MCP config. |
+| `args` | array of strings | Arguments passed to the `symposium` binary. |
+
+### How registration works
+
+During `symposium sync --agent`, each MCP server entry is written into the agent's config file in the format that agent expects. Registration is idempotent — existing entries with correct values are left untouched, stale entries are updated in place.
+
+| Agent | Config location | Key |
+|-------|----------------|-----|
+| Claude Code | `.claude/settings.json` | `mcpServers.<name>` |
+| GitHub Copilot | `.vscode/mcp.json` | `<name>` (top-level) |
+| Gemini CLI | `.gemini/settings.json` | `mcpServers.<name>` |
+| Codex CLI | `.codex/config.toml` | `[mcp_servers.<name>]` |
+| Kiro | `.kiro/settings/mcp.json` | `mcpServers.<name>` |
+| OpenCode | `opencode.json` | `mcp.<name>` |
+| Goose | `~/.config/goose/config.yaml` | `extensions.<name>` |
+
 ## Example: full manifest
 
 ```toml
@@ -73,6 +163,11 @@ name = "check-widget-usage"
 event = "PreToolUse"
 matcher = "Bash"
 command = "./scripts/check-widget.sh"
+
+[[mcp_servers]]
+name = "symposium"
+type = "builtin"
+args = ["mcp"]
 ```
 
 ## Validation

--- a/src/agents/mcp_server_registration.rs
+++ b/src/agents/mcp_server_registration.rs
@@ -192,16 +192,28 @@ fn unregister_json_mcp_servers(
 // ---------------------------------------------------------------------------
 
 /// Claude Code: `mcpServers.<name>` in settings.json
-pub(super) fn register_claude_mcp_servers(path: &Path, servers: &[McpServer], out: &Output) -> Result<()> {
+pub(super) fn register_claude_mcp_servers(
+    path: &Path,
+    servers: &[McpServer],
+    out: &Output,
+) -> Result<()> {
     register_json_mcp_servers(path, servers, Some("mcpServers"), out)
 }
 
-pub(super) fn unregister_claude_mcp_servers(path: &Path, names: &[&str], out: &Output) -> Result<()> {
+pub(super) fn unregister_claude_mcp_servers(
+    path: &Path,
+    names: &[&str],
+    out: &Output,
+) -> Result<()> {
     unregister_json_mcp_servers(path, names, Some("mcpServers"), out)
 }
 
 /// Codex CLI: `[mcp_servers.<name>]` in config.toml
-pub(super) fn register_codex_mcp_servers(config_path: &Path, servers: &[McpServer], out: &Output) -> Result<()> {
+pub(super) fn register_codex_mcp_servers(
+    config_path: &Path,
+    servers: &[McpServer],
+    out: &Output,
+) -> Result<()> {
     let display = display_path(config_path);
 
     let content = if config_path.exists() {
@@ -222,7 +234,9 @@ pub(super) fn register_codex_mcp_servers(config_path: &Path, servers: &[McpServe
     for server in servers {
         let name = server_name(server);
         let McpServer::Stdio(stdio) = server else {
-            out.info(format!("{display}: skipping non-stdio MCP server {name} (Codex only supports stdio)"));
+            out.info(format!(
+                "{display}: skipping non-stdio MCP server {name} (Codex only supports stdio)"
+            ));
             continue;
         };
 
@@ -273,7 +287,11 @@ pub(super) fn register_codex_mcp_servers(config_path: &Path, servers: &[McpServe
     Ok(())
 }
 
-pub(super) fn unregister_codex_mcp_servers(config_path: &Path, names: &[&str], out: &Output) -> Result<()> {
+pub(super) fn unregister_codex_mcp_servers(
+    config_path: &Path,
+    names: &[&str],
+    out: &Output,
+) -> Result<()> {
     let display = display_path(config_path);
     if !config_path.exists() {
         return Ok(());
@@ -301,25 +319,45 @@ pub(super) fn unregister_codex_mcp_servers(config_path: &Path, names: &[&str], o
 }
 
 /// Copilot: top-level `<name>` in mcp.json
-pub(super) fn register_copilot_mcp_servers(path: &Path, servers: &[McpServer], out: &Output) -> Result<()> {
+pub(super) fn register_copilot_mcp_servers(
+    path: &Path,
+    servers: &[McpServer],
+    out: &Output,
+) -> Result<()> {
     register_json_mcp_servers(path, servers, None, out)
 }
 
-pub(super) fn unregister_copilot_mcp_servers(path: &Path, names: &[&str], out: &Output) -> Result<()> {
+pub(super) fn unregister_copilot_mcp_servers(
+    path: &Path,
+    names: &[&str],
+    out: &Output,
+) -> Result<()> {
     unregister_json_mcp_servers(path, names, None, out)
 }
 
 /// Gemini CLI: same format as Claude (`mcpServers.<name>`)
-pub(super) fn register_gemini_mcp_servers(path: &Path, servers: &[McpServer], out: &Output) -> Result<()> {
+pub(super) fn register_gemini_mcp_servers(
+    path: &Path,
+    servers: &[McpServer],
+    out: &Output,
+) -> Result<()> {
     register_claude_mcp_servers(path, servers, out)
 }
 
-pub(super) fn unregister_gemini_mcp_servers(path: &Path, names: &[&str], out: &Output) -> Result<()> {
+pub(super) fn unregister_gemini_mcp_servers(
+    path: &Path,
+    names: &[&str],
+    out: &Output,
+) -> Result<()> {
     unregister_claude_mcp_servers(path, names, out)
 }
 
 /// Kiro: `mcpServers.<name>` in mcp.json
-pub(super) fn register_kiro_mcp_servers(path: &Path, servers: &[McpServer], out: &Output) -> Result<()> {
+pub(super) fn register_kiro_mcp_servers(
+    path: &Path,
+    servers: &[McpServer],
+    out: &Output,
+) -> Result<()> {
     register_claude_mcp_servers(path, servers, out)
 }
 
@@ -328,7 +366,11 @@ pub(super) fn unregister_kiro_mcp_servers(path: &Path, names: &[&str], out: &Out
 }
 
 /// Goose: `extensions.<name>` in config.yaml (string manipulation to preserve comments)
-pub(super) fn register_goose_mcp_servers(config_path: &Path, servers: &[McpServer], out: &Output) -> Result<()> {
+pub(super) fn register_goose_mcp_servers(
+    config_path: &Path,
+    servers: &[McpServer],
+    out: &Output,
+) -> Result<()> {
     let display = display_path(config_path);
 
     let mut content = if config_path.exists() {
@@ -341,12 +383,18 @@ pub(super) fn register_goose_mcp_servers(config_path: &Path, servers: &[McpServe
     for server in servers {
         let name = server_name(server);
         let McpServer::Stdio(stdio) = server else {
-            out.info(format!("{display}: skipping non-stdio MCP server {name} (Goose extensions use stdio)"));
+            out.info(format!(
+                "{display}: skipping non-stdio MCP server {name} (Goose extensions use stdio)"
+            ));
             continue;
         };
 
         let cmd = stdio.command.to_string_lossy();
-        let quoted_args: Vec<_> = stdio.args.iter().map(|a| format!("\"{}\"", a.replace('"', "\\\""))).collect();
+        let quoted_args: Vec<_> = stdio
+            .args
+            .iter()
+            .map(|a| format!("\"{}\"", a.replace('"', "\\\"")))
+            .collect();
         let args_yaml = format!("[{}]", quoted_args.join(", "));
 
         let snippet = formatdoc! {"
@@ -426,7 +474,11 @@ pub(super) fn register_goose_mcp_servers(config_path: &Path, servers: &[McpServe
     Ok(())
 }
 
-pub(super) fn unregister_goose_mcp_servers(config_path: &Path, names: &[&str], out: &Output) -> Result<()> {
+pub(super) fn unregister_goose_mcp_servers(
+    config_path: &Path,
+    names: &[&str],
+    out: &Output,
+) -> Result<()> {
     let display = display_path(config_path);
     if !config_path.exists() {
         return Ok(());
@@ -467,11 +519,19 @@ pub(super) fn unregister_goose_mcp_servers(config_path: &Path, names: &[&str], o
 }
 
 /// OpenCode: `mcp.<name>` in opencode.json
-pub(super) fn register_opencode_mcp_servers(path: &Path, servers: &[McpServer], out: &Output) -> Result<()> {
+pub(super) fn register_opencode_mcp_servers(
+    path: &Path,
+    servers: &[McpServer],
+    out: &Output,
+) -> Result<()> {
     register_json_mcp_servers(path, servers, Some("mcp"), out)
 }
 
-pub(super) fn unregister_opencode_mcp_servers(path: &Path, names: &[&str], out: &Output) -> Result<()> {
+pub(super) fn unregister_opencode_mcp_servers(
+    path: &Path,
+    names: &[&str],
+    out: &Output,
+) -> Result<()> {
     unregister_json_mcp_servers(path, names, Some("mcp"), out)
 }
 
@@ -482,8 +542,7 @@ mod tests {
 
     fn test_servers() -> Vec<McpServer> {
         vec![McpServer::Stdio(
-            McpServerStdio::new("symposium", "/usr/local/bin/symposium")
-                .args(vec!["mcp".into()]),
+            McpServerStdio::new("symposium", "/usr/local/bin/symposium").args(vec!["mcp".into()]),
         )]
     }
 
@@ -501,7 +560,10 @@ mod tests {
 
         let settings: serde_json::Value =
             serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
-        assert_eq!(settings["mcpServers"]["symposium"]["command"], "/usr/local/bin/symposium");
+        assert_eq!(
+            settings["mcpServers"]["symposium"]["command"],
+            "/usr/local/bin/symposium"
+        );
         assert_eq!(settings["mcpServers"]["symposium"]["args"][0], "mcp");
     }
 
@@ -528,7 +590,10 @@ mod tests {
 
         let settings: serde_json::Value =
             serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
-        assert_eq!(settings["mcpServers"]["symposium"]["command"], "/usr/local/bin/symposium");
+        assert_eq!(
+            settings["mcpServers"]["symposium"]["command"],
+            "/usr/local/bin/symposium"
+        );
     }
 
     #[test]
@@ -542,7 +607,10 @@ mod tests {
 
         let settings: serde_json::Value =
             serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
-        assert_eq!(settings["mcpServers"]["symposium"]["command"], "/usr/local/bin/symposium");
+        assert_eq!(
+            settings["mcpServers"]["symposium"]["command"],
+            "/usr/local/bin/symposium"
+        );
     }
 
     #[test]
@@ -567,8 +635,16 @@ mod tests {
 
         let content = fs::read_to_string(&path).unwrap();
         let doc: toml::Value = content.parse().unwrap();
-        assert_eq!(doc["mcp_servers"]["symposium"]["command"].as_str().unwrap(), "/usr/local/bin/symposium");
-        assert_eq!(doc["mcp_servers"]["symposium"]["args"].as_array().unwrap()[0].as_str().unwrap(), "mcp");
+        assert_eq!(
+            doc["mcp_servers"]["symposium"]["command"].as_str().unwrap(),
+            "/usr/local/bin/symposium"
+        );
+        assert_eq!(
+            doc["mcp_servers"]["symposium"]["args"].as_array().unwrap()[0]
+                .as_str()
+                .unwrap(),
+            "mcp"
+        );
     }
 
     #[test]
@@ -587,15 +663,25 @@ mod tests {
     fn register_codex_updates_stale() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("config.toml");
-        fs::write(&path, "[mcp_servers.symposium]\ncommand = \"/old/path\"\nargs = [\"old-arg\"]\n").unwrap();
+        fs::write(
+            &path,
+            "[mcp_servers.symposium]\ncommand = \"/old/path\"\nargs = [\"old-arg\"]\n",
+        )
+        .unwrap();
 
         register_codex_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
 
         let content = fs::read_to_string(&path).unwrap();
         let doc: toml::Value = content.parse().unwrap();
         let entry = &doc["mcp_servers"]["symposium"];
-        assert_eq!(entry["command"].as_str().unwrap(), "/usr/local/bin/symposium");
-        assert_eq!(entry["args"].as_array().unwrap()[0].as_str().unwrap(), "mcp");
+        assert_eq!(
+            entry["command"].as_str().unwrap(),
+            "/usr/local/bin/symposium"
+        );
+        assert_eq!(
+            entry["args"].as_array().unwrap()[0].as_str().unwrap(),
+            "mcp"
+        );
         // Ensure no duplicate — still exactly one server entry
         assert_eq!(doc["mcp_servers"].as_table().unwrap().len(), 1);
     }
@@ -609,7 +695,11 @@ mod tests {
 
         let content = fs::read_to_string(&path).unwrap();
         let doc: toml::Value = content.parse().unwrap();
-        assert!(doc.get("mcp_servers").and_then(|s| s.get("symposium")).is_none());
+        assert!(
+            doc.get("mcp_servers")
+                .and_then(|s| s.get("symposium"))
+                .is_none()
+        );
     }
 
     // -- Copilot MCP --
@@ -676,7 +766,10 @@ mod tests {
         let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&content).unwrap();
         let ext = &doc["extensions"]["symposium"];
         assert_eq!(ext["provider"].as_str().unwrap(), "mcp");
-        assert_eq!(ext["config"]["command"].as_str().unwrap(), "/usr/local/bin/symposium");
+        assert_eq!(
+            ext["config"]["command"].as_str().unwrap(),
+            "/usr/local/bin/symposium"
+        );
     }
 
     #[test]
@@ -701,7 +794,11 @@ mod tests {
         let content = fs::read_to_string(&path).unwrap();
         if !content.trim().is_empty() {
             let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&content).unwrap();
-            assert!(doc.get("extensions").and_then(|e| e.get("symposium")).is_none());
+            assert!(
+                doc.get("extensions")
+                    .and_then(|e| e.get("symposium"))
+                    .is_none()
+            );
         }
     }
 
@@ -717,7 +814,9 @@ mod tests {
         let content = fs::read_to_string(&path).unwrap();
         let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&content).unwrap();
         assert_eq!(
-            doc["extensions"]["symposium"]["config"]["command"].as_str().unwrap(),
+            doc["extensions"]["symposium"]["config"]["command"]
+                .as_str()
+                .unwrap(),
             "/usr/local/bin/symposium",
         );
         // Still exactly one extension
@@ -738,7 +837,9 @@ mod tests {
         // Must be valid YAML
         let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&content).unwrap();
         assert_eq!(
-            doc["extensions"]["test-server"]["config"]["command"].as_str().unwrap(),
+            doc["extensions"]["test-server"]["config"]["command"]
+                .as_str()
+                .unwrap(),
             "/path with spaces/symposium",
         );
     }
@@ -753,7 +854,10 @@ mod tests {
 
         let config: serde_json::Value =
             serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
-        assert_eq!(config["mcp"]["symposium"]["command"], "/usr/local/bin/symposium");
+        assert_eq!(
+            config["mcp"]["symposium"]["command"],
+            "/usr/local/bin/symposium"
+        );
         assert_eq!(config["mcp"]["symposium"]["args"][0], "mcp");
     }
 
@@ -780,7 +884,10 @@ mod tests {
 
         let config: serde_json::Value =
             serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
-        assert_eq!(config["mcp"]["symposium"]["command"], "/usr/local/bin/symposium");
+        assert_eq!(
+            config["mcp"]["symposium"]["command"],
+            "/usr/local/bin/symposium"
+        );
     }
 
     #[test]

--- a/src/agents/mcp_server_registration.rs
+++ b/src/agents/mcp_server_registration.rs
@@ -1,0 +1,1 @@
+//! MCP server registration and unregistration for all supported agents.

--- a/src/agents/mcp_server_registration.rs
+++ b/src/agents/mcp_server_registration.rs
@@ -1,1 +1,681 @@
 //! MCP server registration and unregistration for all supported agents.
+//!
+//! Each agent has its own config format and file location. This module
+//! provides per-agent `register_*` and `unregister_*` functions that
+//! are called from the `Agent` methods in the parent module.
+//!
+//! Registration is idempotent: existing entries with correct values are
+//! left untouched, while stale entries are updated in place.
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::Result;
+use indoc::formatdoc;
+use sacp::schema::McpServer;
+use serde_json::json;
+
+use crate::output::{Output, display_path};
+
+use super::{load_json_or_empty, save_json};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Extract the name from any McpServer variant.
+fn server_name(server: &McpServer) -> &str {
+    match server {
+        McpServer::Stdio(s) => &s.name,
+        McpServer::Http(s) => &s.name,
+        McpServer::Sse(s) => &s.name,
+        _ => "unknown",
+    }
+}
+
+/// Convert an McpServer to the JSON value agents expect in their config.
+///
+/// Stdio: `{"command": "...", "args": [...]}`
+/// Http/Sse: `{"url": "..."}`
+fn server_to_json(server: &McpServer) -> serde_json::Value {
+    match server {
+        McpServer::Stdio(s) => {
+            json!({
+                "command": s.command.to_string_lossy(),
+                "args": s.args,
+            })
+        }
+        McpServer::Http(s) => json!({ "url": s.url }),
+        McpServer::Sse(s) => json!({ "url": s.url }),
+        _ => json!({}),
+    }
+}
+
+/// Result of upserting an MCP server entry.
+enum UpsertResult {
+    AlreadyCorrect,
+    Inserted,
+    Updated,
+}
+
+/// Upsert a single MCP server entry into a JSON object container.
+fn upsert_json_mcp_entry(
+    container: &mut serde_json::Value,
+    name: &str,
+    expected: &serde_json::Value,
+) -> UpsertResult {
+    if let Some(existing) = container.get(name) {
+        if existing == expected {
+            return UpsertResult::AlreadyCorrect;
+        }
+        container[name] = expected.clone();
+        UpsertResult::Updated
+    } else {
+        container[name] = expected.clone();
+        UpsertResult::Inserted
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JSON-based registration (Claude, Copilot, Gemini, Kiro, OpenCode)
+// ---------------------------------------------------------------------------
+
+/// Register MCP servers into a JSON config file under a given container key.
+///
+/// If `container_key` is `Some("mcpServers")`, entries go under `config["mcpServers"][name]`.
+/// If `None`, entries go at the top level `config[name]`.
+fn register_json_mcp_servers(
+    config_path: &Path,
+    servers: &[McpServer],
+    container_key: Option<&str>,
+    out: &Output,
+) -> Result<()> {
+    let display = display_path(config_path);
+    let mut config = load_json_or_empty(config_path)?;
+
+    if !config.is_object() {
+        config = json!({});
+    }
+
+    let container = if let Some(key) = container_key {
+        if config.get(key).is_none() {
+            config[key] = json!({});
+        }
+        &mut config[key]
+    } else {
+        &mut config
+    };
+
+    let mut changed = false;
+    for server in servers {
+        let name = server_name(server);
+        let expected = server_to_json(server);
+        match upsert_json_mcp_entry(container, name, &expected) {
+            UpsertResult::AlreadyCorrect => {
+                out.already_ok(format!("{display}: {name} MCP server already configured"));
+            }
+            UpsertResult::Inserted => {
+                out.done(format!("{display}: added {name} MCP server"));
+                changed = true;
+            }
+            UpsertResult::Updated => {
+                out.done(format!("{display}: updated {name} MCP server"));
+                changed = true;
+            }
+        }
+    }
+
+    if changed {
+        save_json(config_path, &config)?;
+    }
+    Ok(())
+}
+
+/// Remove MCP server entries from a JSON config file.
+fn unregister_json_mcp_servers(
+    config_path: &Path,
+    names: &[&str],
+    container_key: Option<&str>,
+    out: &Output,
+) -> Result<()> {
+    let display = display_path(config_path);
+    if !config_path.exists() {
+        return Ok(());
+    }
+
+    let mut config = load_json_or_empty(config_path)?;
+
+    let container = if let Some(key) = container_key {
+        config.get_mut(key).and_then(|v| v.as_object_mut())
+    } else {
+        config.as_object_mut()
+    };
+
+    let Some(obj) = container else {
+        return Ok(());
+    };
+
+    let mut changed = false;
+    for name in names {
+        if obj.remove(*name).is_some() {
+            out.removed(format!("{display}: removed {name} MCP server"));
+            changed = true;
+        }
+    }
+
+    if changed {
+        save_json(config_path, &config)?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Per-agent registration functions
+// ---------------------------------------------------------------------------
+
+/// Claude Code: `mcpServers.<name>` in settings.json
+pub(super) fn register_claude_mcp_servers(path: &Path, servers: &[McpServer], out: &Output) -> Result<()> {
+    register_json_mcp_servers(path, servers, Some("mcpServers"), out)
+}
+
+pub(super) fn unregister_claude_mcp_servers(path: &Path, names: &[&str], out: &Output) -> Result<()> {
+    unregister_json_mcp_servers(path, names, Some("mcpServers"), out)
+}
+
+/// Codex CLI: `[mcp_servers.<name>]` in config.toml
+pub(super) fn register_codex_mcp_servers(config_path: &Path, servers: &[McpServer], out: &Output) -> Result<()> {
+    let display = display_path(config_path);
+
+    let content = if config_path.exists() {
+        fs::read_to_string(config_path)?
+    } else {
+        String::new()
+    };
+
+    let mut doc: toml_edit::DocumentMut = content
+        .parse()
+        .unwrap_or_else(|_| toml_edit::DocumentMut::new());
+
+    if !doc.contains_key("mcp_servers") {
+        doc["mcp_servers"] = toml_edit::Item::Table(toml_edit::Table::new());
+    }
+
+    let mut changed = false;
+    for server in servers {
+        let name = server_name(server);
+        let McpServer::Stdio(stdio) = server else {
+            out.info(format!("{display}: skipping non-stdio MCP server {name} (Codex only supports stdio)"));
+            continue;
+        };
+
+        let cmd = stdio.command.to_string_lossy().to_string();
+        let needs_update = if let Some(existing) = doc["mcp_servers"].get(name) {
+            let cmd_ok = existing.get("command").and_then(|v| v.as_str()) == Some(&cmd);
+            let args_ok = existing
+                .get("args")
+                .and_then(|v| v.as_array())
+                .is_some_and(|a| {
+                    a.iter()
+                        .map(|v| v.as_str().unwrap_or(""))
+                        .collect::<Vec<_>>()
+                        == stdio.args.iter().map(|s| s.as_str()).collect::<Vec<_>>()
+                });
+            if cmd_ok && args_ok {
+                out.already_ok(format!("{display}: {name} MCP server already configured"));
+                false
+            } else {
+                true
+            }
+        } else {
+            true
+        };
+
+        if needs_update {
+            let mut server_table = toml_edit::Table::new();
+            server_table["command"] = toml_edit::value(&cmd);
+            let mut args = toml_edit::Array::new();
+            for arg in &stdio.args {
+                args.push(arg.as_str());
+            }
+            server_table["args"] = toml_edit::value(args);
+            let is_new = doc["mcp_servers"].get(name).is_none();
+            doc["mcp_servers"][name] = toml_edit::Item::Table(server_table);
+            let verb = if is_new { "added" } else { "updated" };
+            out.done(format!("{display}: {verb} {name} MCP server"));
+            changed = true;
+        }
+    }
+
+    if changed {
+        if let Some(parent) = config_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(config_path, doc.to_string())?;
+    }
+    Ok(())
+}
+
+pub(super) fn unregister_codex_mcp_servers(config_path: &Path, names: &[&str], out: &Output) -> Result<()> {
+    let display = display_path(config_path);
+    if !config_path.exists() {
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(config_path)?;
+    let mut doc: toml_edit::DocumentMut = content.parse()?;
+
+    let Some(mcp_servers) = doc.get_mut("mcp_servers").and_then(|v| v.as_table_mut()) else {
+        return Ok(());
+    };
+
+    let mut changed = false;
+    for name in names {
+        if mcp_servers.remove(*name).is_some() {
+            out.removed(format!("{display}: removed {name} MCP server"));
+            changed = true;
+        }
+    }
+
+    if changed {
+        fs::write(config_path, doc.to_string())?;
+    }
+    Ok(())
+}
+
+/// Copilot: top-level `<name>` in mcp.json
+pub(super) fn register_copilot_mcp_servers(path: &Path, servers: &[McpServer], out: &Output) -> Result<()> {
+    register_json_mcp_servers(path, servers, None, out)
+}
+
+pub(super) fn unregister_copilot_mcp_servers(path: &Path, names: &[&str], out: &Output) -> Result<()> {
+    unregister_json_mcp_servers(path, names, None, out)
+}
+
+/// Gemini CLI: same format as Claude (`mcpServers.<name>`)
+pub(super) fn register_gemini_mcp_servers(path: &Path, servers: &[McpServer], out: &Output) -> Result<()> {
+    register_claude_mcp_servers(path, servers, out)
+}
+
+pub(super) fn unregister_gemini_mcp_servers(path: &Path, names: &[&str], out: &Output) -> Result<()> {
+    unregister_claude_mcp_servers(path, names, out)
+}
+
+/// Kiro: `mcpServers.<name>` in mcp.json
+pub(super) fn register_kiro_mcp_servers(path: &Path, servers: &[McpServer], out: &Output) -> Result<()> {
+    register_claude_mcp_servers(path, servers, out)
+}
+
+pub(super) fn unregister_kiro_mcp_servers(path: &Path, names: &[&str], out: &Output) -> Result<()> {
+    unregister_claude_mcp_servers(path, names, out)
+}
+
+/// Goose: `extensions.<name>` in config.yaml (string manipulation to preserve comments)
+pub(super) fn register_goose_mcp_servers(config_path: &Path, servers: &[McpServer], out: &Output) -> Result<()> {
+    let display = display_path(config_path);
+
+    let mut content = if config_path.exists() {
+        fs::read_to_string(config_path)?
+    } else {
+        String::new()
+    };
+
+    let mut changed = false;
+    for server in servers {
+        let name = server_name(server);
+        let McpServer::Stdio(stdio) = server else {
+            out.info(format!("{display}: skipping non-stdio MCP server {name} (Goose extensions use stdio)"));
+            continue;
+        };
+
+        let needle = format!("{name}:");
+        if content.contains(&needle) {
+            out.already_ok(format!("{display}: {name} MCP server already configured"));
+            continue;
+        }
+
+        let cmd = stdio.command.to_string_lossy();
+        let args: Vec<_> = stdio.args.iter().map(|a| a.as_str()).collect();
+        let args_yaml = format!("[{}]", args.join(", "));
+
+        let snippet = formatdoc! {"
+            {name}:
+                provider: mcp
+                config:
+                  command: {cmd}
+                  args: {args_yaml}
+        "};
+
+        content = if content.trim().is_empty() {
+            format!("extensions:\n  {}", snippet.trim())
+        } else if content.contains("extensions:") {
+            content.replace("extensions:", &format!("extensions:\n  {}", snippet.trim()))
+        } else {
+            format!("{}\nextensions:\n  {}", content.trim(), snippet.trim())
+        };
+
+        out.done(format!("{display}: added {name} MCP server"));
+        changed = true;
+    }
+
+    if changed {
+        if let Some(parent) = config_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(config_path, content)?;
+    }
+    Ok(())
+}
+
+pub(super) fn unregister_goose_mcp_servers(config_path: &Path, names: &[&str], out: &Output) -> Result<()> {
+    let display = display_path(config_path);
+    if !config_path.exists() {
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(config_path)?;
+    let lines: Vec<&str> = content.lines().collect();
+    let mut new_lines = Vec::new();
+    let mut in_section = false;
+    let mut section_indent = 0;
+    let mut changed = false;
+
+    for line in lines {
+        let trimmed = line.trim();
+        if !trimmed.is_empty() && names.iter().any(|n| trimmed.starts_with(&format!("{n}:"))) {
+            section_indent = line.len() - trimmed.len();
+            in_section = true;
+            changed = true;
+            let name = trimmed.split(':').next().unwrap_or("?");
+            out.removed(format!("{display}: removed {name} MCP server"));
+            continue;
+        }
+        if in_section && !trimmed.is_empty() {
+            let line_indent = line.len() - trimmed.len();
+            if line_indent <= section_indent {
+                in_section = false;
+            }
+        }
+        if !in_section {
+            new_lines.push(line);
+        }
+    }
+
+    if changed {
+        fs::write(config_path, new_lines.join("\n"))?;
+    }
+    Ok(())
+}
+
+/// OpenCode: `mcp.<name>` in opencode.json
+pub(super) fn register_opencode_mcp_servers(path: &Path, servers: &[McpServer], out: &Output) -> Result<()> {
+    register_json_mcp_servers(path, servers, Some("mcp"), out)
+}
+
+pub(super) fn unregister_opencode_mcp_servers(path: &Path, names: &[&str], out: &Output) -> Result<()> {
+    unregister_json_mcp_servers(path, names, Some("mcp"), out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sacp::schema::McpServerStdio;
+
+    fn test_servers() -> Vec<McpServer> {
+        vec![McpServer::Stdio(
+            McpServerStdio::new("symposium", "/usr/local/bin/symposium")
+                .args(vec!["mcp".into()]),
+        )]
+    }
+
+    fn test_server_names() -> Vec<&'static str> {
+        vec!["symposium"]
+    }
+
+    // -- Claude MCP (also covers Gemini and Kiro via delegation) --
+
+    #[test]
+    fn register_claude_creates_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("settings.json");
+        register_claude_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+
+        let settings: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(settings["mcpServers"]["symposium"]["command"], "/usr/local/bin/symposium");
+        assert_eq!(settings["mcpServers"]["symposium"]["args"][0], "mcp");
+    }
+
+    #[test]
+    fn register_claude_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("settings.json");
+        register_claude_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+        register_claude_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+
+        let settings: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(settings["mcpServers"].as_object().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn register_claude_updates_stale() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("settings.json");
+        let stale = json!({"mcpServers": {"symposium": {"command": "/old/path", "args": ["mcp"]}}});
+        save_json(&path, &stale).unwrap();
+
+        register_claude_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+
+        let settings: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(settings["mcpServers"]["symposium"]["command"], "/usr/local/bin/symposium");
+    }
+
+    #[test]
+    fn unregister_claude_removes_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("settings.json");
+        register_claude_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+        unregister_claude_mcp_servers(&path, &test_server_names(), &Output::quiet()).unwrap();
+
+        let settings: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(settings["mcpServers"].get("symposium").is_none());
+    }
+
+    // -- Codex MCP (TOML) --
+
+    #[test]
+    fn register_codex_creates_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        register_codex_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        let doc: toml::Value = content.parse().unwrap();
+        assert_eq!(doc["mcp_servers"]["symposium"]["command"].as_str().unwrap(), "/usr/local/bin/symposium");
+        assert_eq!(doc["mcp_servers"]["symposium"]["args"].as_array().unwrap()[0].as_str().unwrap(), "mcp");
+    }
+
+    #[test]
+    fn register_codex_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        register_codex_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+        register_codex_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        let doc: toml::Value = content.parse().unwrap();
+        assert_eq!(doc["mcp_servers"].as_table().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn register_codex_updates_stale() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        fs::write(&path, "[mcp_servers.symposium]\ncommand = \"/old/path\"\nargs = [\"mcp\"]\n").unwrap();
+
+        register_codex_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        let doc: toml::Value = content.parse().unwrap();
+        assert_eq!(doc["mcp_servers"]["symposium"]["command"].as_str().unwrap(), "/usr/local/bin/symposium");
+    }
+
+    #[test]
+    fn unregister_codex_removes_section() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        register_codex_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+        unregister_codex_mcp_servers(&path, &test_server_names(), &Output::quiet()).unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        let doc: toml::Value = content.parse().unwrap();
+        assert!(doc.get("mcp_servers").and_then(|s| s.get("symposium")).is_none());
+    }
+
+    // -- Copilot MCP --
+
+    #[test]
+    fn register_copilot_creates_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("mcp.json");
+        register_copilot_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+
+        let config: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(config["symposium"]["command"], "/usr/local/bin/symposium");
+        assert_eq!(config["symposium"]["args"][0], "mcp");
+    }
+
+    #[test]
+    fn register_copilot_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("mcp.json");
+        register_copilot_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+        register_copilot_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+
+        let config: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(config.as_object().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn register_copilot_updates_stale() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("mcp.json");
+        let stale = json!({"symposium": {"command": "/old/path", "args": ["mcp"]}});
+        save_json(&path, &stale).unwrap();
+
+        register_copilot_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+
+        let config: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(config["symposium"]["command"], "/usr/local/bin/symposium");
+    }
+
+    #[test]
+    fn unregister_copilot_removes_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("mcp.json");
+        register_copilot_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+        unregister_copilot_mcp_servers(&path, &test_server_names(), &Output::quiet()).unwrap();
+
+        let config: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(config.get("symposium").is_none());
+    }
+
+    // -- Goose MCP (YAML) --
+
+    #[test]
+    fn register_goose_creates_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.yaml");
+        register_goose_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        let doc: serde_yaml::Value = serde_yaml::from_str(&content).unwrap();
+        let ext = &doc["extensions"]["symposium"];
+        assert_eq!(ext["provider"].as_str().unwrap(), "mcp");
+        assert_eq!(ext["config"]["command"].as_str().unwrap(), "/usr/local/bin/symposium");
+    }
+
+    #[test]
+    fn register_goose_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.yaml");
+        register_goose_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+        register_goose_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        let doc: serde_yaml::Value = serde_yaml::from_str(&content).unwrap();
+        assert_eq!(doc["extensions"].as_mapping().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn unregister_goose_removes_section() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.yaml");
+        register_goose_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+        unregister_goose_mcp_servers(&path, &test_server_names(), &Output::quiet()).unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        if !content.trim().is_empty() {
+            let doc: serde_yaml::Value = serde_yaml::from_str(&content).unwrap();
+            assert!(doc.get("extensions").and_then(|e| e.get("symposium")).is_none());
+        }
+    }
+
+    // -- OpenCode MCP --
+
+    #[test]
+    fn register_opencode_creates_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("opencode.json");
+        register_opencode_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+
+        let config: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(config["mcp"]["symposium"]["command"], "/usr/local/bin/symposium");
+        assert_eq!(config["mcp"]["symposium"]["args"][0], "mcp");
+    }
+
+    #[test]
+    fn register_opencode_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("opencode.json");
+        register_opencode_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+        register_opencode_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+
+        let config: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(config["mcp"].as_object().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn register_opencode_updates_stale() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("opencode.json");
+        let stale = json!({"mcp": {"symposium": {"command": "/old/path", "args": ["mcp"]}}});
+        save_json(&path, &stale).unwrap();
+
+        register_opencode_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+
+        let config: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(config["mcp"]["symposium"]["command"], "/usr/local/bin/symposium");
+    }
+
+    #[test]
+    fn unregister_opencode_removes_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("opencode.json");
+        register_opencode_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+        unregister_opencode_mcp_servers(&path, &test_server_names(), &Output::quiet()).unwrap();
+
+        let config: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(config["mcp"].get("symposium").is_none());
+    }
+}

--- a/src/agents/mcp_server_registration.rs
+++ b/src/agents/mcp_server_registration.rs
@@ -345,12 +345,6 @@ pub(super) fn register_goose_mcp_servers(config_path: &Path, servers: &[McpServe
             continue;
         };
 
-        let needle = format!("{name}:");
-        if content.contains(&needle) {
-            out.already_ok(format!("{display}: {name} MCP server already configured"));
-            continue;
-        }
-
         let cmd = stdio.command.to_string_lossy();
         let quoted_args: Vec<_> = stdio.args.iter().map(|a| format!("\"{}\"", a.replace('"', "\\\""))).collect();
         let args_yaml = format!("[{}]", quoted_args.join(", "));
@@ -363,6 +357,53 @@ pub(super) fn register_goose_mcp_servers(config_path: &Path, servers: &[McpServe
                   args: {args_yaml}
         "};
 
+        let needle = format!("{name}:");
+        let already_exists = content.contains(&needle);
+
+        if already_exists {
+            // Check if the existing entry matches — parse out the section
+            // and compare command/args. If it matches, skip; otherwise
+            // remove the old section so we can re-insert below.
+            let lines: Vec<&str> = content.lines().collect();
+            let mut new_lines = Vec::new();
+            let mut in_section = false;
+            let mut section_indent = 0;
+            let mut old_section = String::new();
+
+            for line in &lines {
+                let trimmed = line.trim();
+                if !in_section && !trimmed.is_empty() && trimmed.starts_with(&needle) {
+                    section_indent = line.len() - trimmed.len();
+                    in_section = true;
+                    old_section.push_str(trimmed);
+                    old_section.push('\n');
+                    continue;
+                }
+                if in_section && !trimmed.is_empty() {
+                    let line_indent = line.len() - trimmed.len();
+                    if line_indent <= section_indent {
+                        in_section = false;
+                    }
+                }
+                if in_section {
+                    old_section.push_str(trimmed);
+                    old_section.push('\n');
+                } else {
+                    new_lines.push(*line);
+                }
+            }
+
+            // Rebuild expected snippet for comparison (trimmed, no leading indent)
+            let expected_trimmed = snippet.trim();
+            if old_section.trim() == expected_trimmed {
+                out.already_ok(format!("{display}: {name} MCP server already configured"));
+                continue;
+            }
+
+            // Stale — remove old section, fall through to insert
+            content = new_lines.join("\n");
+        }
+
         content = if content.trim().is_empty() {
             format!("extensions:\n  {}", snippet.trim())
         } else if content.contains("extensions:") {
@@ -371,7 +412,8 @@ pub(super) fn register_goose_mcp_servers(config_path: &Path, servers: &[McpServe
             format!("{}\nextensions:\n  {}", content.trim(), snippet.trim())
         };
 
-        out.done(format!("{display}: added {name} MCP server"));
+        let verb = if already_exists { "updated" } else { "added" };
+        out.done(format!("{display}: {verb} {name} MCP server"));
         changed = true;
     }
 
@@ -647,6 +689,44 @@ mod tests {
             let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&content).unwrap();
             assert!(doc.get("extensions").and_then(|e| e.get("symposium")).is_none());
         }
+    }
+
+    #[test]
+    fn register_goose_updates_stale() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.yaml");
+        // Write a config with an old binary path
+        fs::write(&path, "extensions:\n  symposium:\n    provider: mcp\n    config:\n      command: \"/old/path\"\n      args: [\"mcp\"]\n").unwrap();
+
+        register_goose_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&content).unwrap();
+        assert_eq!(
+            doc["extensions"]["symposium"]["config"]["command"].as_str().unwrap(),
+            "/usr/local/bin/symposium",
+        );
+        // Still exactly one extension
+        assert_eq!(doc["extensions"].as_mapping().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn register_goose_quotes_special_chars() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.yaml");
+        let servers = vec![McpServer::Stdio(
+            McpServerStdio::new("test-server", "/path with spaces/symposium")
+                .args(vec!["--flag:value".into()]),
+        )];
+        register_goose_mcp_servers(&path, &servers, &Output::quiet()).unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        // Must be valid YAML
+        let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&content).unwrap();
+        assert_eq!(
+            doc["extensions"]["test-server"]["config"]["command"].as_str().unwrap(),
+            "/path with spaces/symposium",
+        );
     }
 
     // -- OpenCode MCP --

--- a/src/agents/mcp_server_registration.rs
+++ b/src/agents/mcp_server_registration.rs
@@ -29,7 +29,7 @@ fn server_name(server: &McpServer) -> &str {
         McpServer::Stdio(s) => &s.name,
         McpServer::Http(s) => &s.name,
         McpServer::Sse(s) => &s.name,
-        _ => "unknown",
+        _ => panic!("unsupported McpServer variant"),
     }
 }
 
@@ -47,7 +47,7 @@ fn server_to_json(server: &McpServer) -> serde_json::Value {
         }
         McpServer::Http(s) => json!({ "url": s.url }),
         McpServer::Sse(s) => json!({ "url": s.url }),
-        _ => json!({}),
+        _ => panic!("unsupported McpServer variant"),
     }
 }
 

--- a/src/agents/mcp_server_registration.rs
+++ b/src/agents/mcp_server_registration.rs
@@ -613,7 +613,7 @@ mod tests {
         register_goose_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
 
         let content = fs::read_to_string(&path).unwrap();
-        let doc: serde_yaml::Value = serde_yaml::from_str(&content).unwrap();
+        let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&content).unwrap();
         let ext = &doc["extensions"]["symposium"];
         assert_eq!(ext["provider"].as_str().unwrap(), "mcp");
         assert_eq!(ext["config"]["command"].as_str().unwrap(), "/usr/local/bin/symposium");
@@ -627,7 +627,7 @@ mod tests {
         register_goose_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
 
         let content = fs::read_to_string(&path).unwrap();
-        let doc: serde_yaml::Value = serde_yaml::from_str(&content).unwrap();
+        let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&content).unwrap();
         assert_eq!(doc["extensions"].as_mapping().unwrap().len(), 1);
     }
 
@@ -640,7 +640,7 @@ mod tests {
 
         let content = fs::read_to_string(&path).unwrap();
         if !content.trim().is_empty() {
-            let doc: serde_yaml::Value = serde_yaml::from_str(&content).unwrap();
+            let doc: serde_yaml_ng::Value = serde_yaml_ng::from_str(&content).unwrap();
             assert!(doc.get("extensions").and_then(|e| e.get("symposium")).is_none());
         }
     }

--- a/src/agents/mcp_server_registration.rs
+++ b/src/agents/mcp_server_registration.rs
@@ -352,14 +352,14 @@ pub(super) fn register_goose_mcp_servers(config_path: &Path, servers: &[McpServe
         }
 
         let cmd = stdio.command.to_string_lossy();
-        let args: Vec<_> = stdio.args.iter().map(|a| a.as_str()).collect();
-        let args_yaml = format!("[{}]", args.join(", "));
+        let quoted_args: Vec<_> = stdio.args.iter().map(|a| format!("\"{}\"", a.replace('"', "\\\""))).collect();
+        let args_yaml = format!("[{}]", quoted_args.join(", "));
 
         let snippet = formatdoc! {"
             {name}:
                 provider: mcp
                 config:
-                  command: {cmd}
+                  command: \"{cmd}\"
                   args: {args_yaml}
         "};
 

--- a/src/agents/mcp_server_registration.rs
+++ b/src/agents/mcp_server_registration.rs
@@ -532,6 +532,20 @@ mod tests {
     }
 
     #[test]
+    fn register_claude_recovers_non_object_container() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("settings.json");
+        // mcpServers is a string instead of an object
+        save_json(&path, &json!({"mcpServers": "corrupted"})).unwrap();
+
+        register_claude_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
+
+        let settings: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(settings["mcpServers"]["symposium"]["command"], "/usr/local/bin/symposium");
+    }
+
+    #[test]
     fn unregister_claude_removes_entry() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("settings.json");

--- a/src/agents/mcp_server_registration.rs
+++ b/src/agents/mcp_server_registration.rs
@@ -531,13 +531,17 @@ mod tests {
     fn register_codex_updates_stale() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("config.toml");
-        fs::write(&path, "[mcp_servers.symposium]\ncommand = \"/old/path\"\nargs = [\"mcp\"]\n").unwrap();
+        fs::write(&path, "[mcp_servers.symposium]\ncommand = \"/old/path\"\nargs = [\"old-arg\"]\n").unwrap();
 
         register_codex_mcp_servers(&path, &test_servers(), &Output::quiet()).unwrap();
 
         let content = fs::read_to_string(&path).unwrap();
         let doc: toml::Value = content.parse().unwrap();
-        assert_eq!(doc["mcp_servers"]["symposium"]["command"].as_str().unwrap(), "/usr/local/bin/symposium");
+        let entry = &doc["mcp_servers"]["symposium"];
+        assert_eq!(entry["command"].as_str().unwrap(), "/usr/local/bin/symposium");
+        assert_eq!(entry["args"].as_array().unwrap()[0].as_str().unwrap(), "mcp");
+        // Ensure no duplicate — still exactly one server entry
+        assert_eq!(doc["mcp_servers"].as_table().unwrap().len(), 1);
     }
 
     #[test]

--- a/src/agents/mcp_server_registration.rs
+++ b/src/agents/mcp_server_registration.rs
@@ -98,7 +98,7 @@ fn register_json_mcp_servers(
     }
 
     let container = if let Some(key) = container_key {
-        if config.get(key).is_none() {
+        if !config.get(key).is_some_and(|v| v.is_object()) {
             config[key] = json!({});
         }
         &mut config[key]

--- a/src/agents/mcp_server_registration.rs
+++ b/src/agents/mcp_server_registration.rs
@@ -35,18 +35,36 @@ fn server_name(server: &McpServer) -> &str {
 
 /// Convert an McpServer to the JSON value agents expect in their config.
 ///
-/// Stdio: `{"command": "...", "args": [...]}`
-/// Http/Sse: `{"url": "..."}`
+/// Stdio: `{"command": "...", "args": [...], "env": [...]}`
+/// Http/Sse: `{"url": "...", "headers": [...]}`
+///
+/// `env` and `headers` are omitted when empty.
 fn server_to_json(server: &McpServer) -> serde_json::Value {
     match server {
         McpServer::Stdio(s) => {
-            json!({
+            let mut v = json!({
                 "command": s.command.to_string_lossy(),
                 "args": s.args,
-            })
+            });
+            if !s.env.is_empty() {
+                v["env"] = serde_json::to_value(&s.env).unwrap();
+            }
+            v
         }
-        McpServer::Http(s) => json!({ "url": s.url }),
-        McpServer::Sse(s) => json!({ "url": s.url }),
+        McpServer::Http(s) => {
+            let mut v = json!({ "url": s.url });
+            if !s.headers.is_empty() {
+                v["headers"] = serde_json::to_value(&s.headers).unwrap();
+            }
+            v
+        }
+        McpServer::Sse(s) => {
+            let mut v = json!({ "url": s.url });
+            if !s.headers.is_empty() {
+                v["headers"] = serde_json::to_value(&s.headers).unwrap();
+            }
+            v
+        }
         _ => panic!("unsupported McpServer variant"),
     }
 }

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -121,7 +121,12 @@ impl Agent {
     // -----------------------------------------------------------------------
 
     /// Register hooks in the project-level agent config.
-    pub fn register_project_hooks(&self, project_root: &Path, _sym: &Symposium, out: &Output) -> Result<()> {
+    pub fn register_project_hooks(
+        &self,
+        project_root: &Path,
+        _sym: &Symposium,
+        out: &Output,
+    ) -> Result<()> {
         match self {
             Agent::Claude => {
                 register_claude_hooks(&project_root.join(".claude").join("settings.json"), out)
@@ -186,137 +191,185 @@ impl Agent {
     // -----------------------------------------------------------------------
 
     /// Register MCP servers in the project-level agent config.
-    pub fn register_project_mcp_servers(&self, project_root: &Path, servers: &[sacp::schema::McpServer], out: &Output) -> Result<()> {
+    pub fn register_project_mcp_servers(
+        &self,
+        project_root: &Path,
+        servers: &[sacp::schema::McpServer],
+        out: &Output,
+    ) -> Result<()> {
         match self {
             Agent::Claude => mcp_server_registration::register_claude_mcp_servers(
                 &project_root.join(".claude").join("settings.json"),
-                servers, out,
+                servers,
+                out,
             ),
             Agent::Codex => mcp_server_registration::register_codex_mcp_servers(
                 &project_root.join(".codex").join("config.toml"),
-                servers, out,
+                servers,
+                out,
             ),
             Agent::Copilot => mcp_server_registration::register_copilot_mcp_servers(
                 &project_root.join(".vscode").join("mcp.json"),
-                servers, out,
+                servers,
+                out,
             ),
             Agent::Gemini => mcp_server_registration::register_gemini_mcp_servers(
                 &project_root.join(".gemini").join("settings.json"),
-                servers, out,
+                servers,
+                out,
             ),
             Agent::Kiro => mcp_server_registration::register_kiro_mcp_servers(
                 &project_root.join(".kiro").join("settings").join("mcp.json"),
-                servers, out,
+                servers,
+                out,
             ),
             Agent::Goose => mcp_server_registration::register_goose_mcp_servers(
                 &project_root.join(".goose").join("config.yaml"),
-                servers, out,
+                servers,
+                out,
             ),
             Agent::OpenCode => mcp_server_registration::register_opencode_mcp_servers(
                 &project_root.join("opencode.json"),
-                servers, out,
+                servers,
+                out,
             ),
         }
     }
 
     /// Register MCP servers in the global agent config.
-    pub fn register_global_mcp_servers(&self, home: &Path, servers: &[sacp::schema::McpServer], out: &Output) -> Result<()> {
+    pub fn register_global_mcp_servers(
+        &self,
+        home: &Path,
+        servers: &[sacp::schema::McpServer],
+        out: &Output,
+    ) -> Result<()> {
         match self {
             Agent::Claude => mcp_server_registration::register_claude_mcp_servers(
                 &home.join(".claude").join("settings.json"),
-                servers, out,
+                servers,
+                out,
             ),
             Agent::Codex => mcp_server_registration::register_codex_mcp_servers(
                 &home.join(".codex").join("config.toml"),
-                servers, out,
+                servers,
+                out,
             ),
             Agent::Copilot => mcp_server_registration::register_copilot_mcp_servers(
                 &home.join(".copilot").join("mcp-config.json"),
-                servers, out,
+                servers,
+                out,
             ),
             Agent::Gemini => mcp_server_registration::register_gemini_mcp_servers(
                 &home.join(".gemini").join("settings.json"),
-                servers, out,
+                servers,
+                out,
             ),
             Agent::Kiro => mcp_server_registration::register_kiro_mcp_servers(
                 &home.join(".kiro").join("settings").join("mcp.json"),
-                servers, out,
+                servers,
+                out,
             ),
             Agent::Goose => mcp_server_registration::register_goose_mcp_servers(
                 &home.join(".config").join("goose").join("config.yaml"),
-                servers, out,
+                servers,
+                out,
             ),
             Agent::OpenCode => mcp_server_registration::register_opencode_mcp_servers(
                 &home.join(".config").join("opencode").join("opencode.json"),
-                servers, out,
+                servers,
+                out,
             ),
         }
     }
 
     /// Remove MCP servers from the project-level agent config.
-    pub fn unregister_project_mcp_servers(&self, project_root: &Path, names: &[&str], out: &Output) -> Result<()> {
+    pub fn unregister_project_mcp_servers(
+        &self,
+        project_root: &Path,
+        names: &[&str],
+        out: &Output,
+    ) -> Result<()> {
         match self {
             Agent::Claude => mcp_server_registration::unregister_claude_mcp_servers(
                 &project_root.join(".claude").join("settings.json"),
-                names, out,
+                names,
+                out,
             ),
             Agent::Codex => mcp_server_registration::unregister_codex_mcp_servers(
                 &project_root.join(".codex").join("config.toml"),
-                names, out,
+                names,
+                out,
             ),
             Agent::Copilot => mcp_server_registration::unregister_copilot_mcp_servers(
                 &project_root.join(".vscode").join("mcp.json"),
-                names, out,
+                names,
+                out,
             ),
             Agent::Gemini => mcp_server_registration::unregister_gemini_mcp_servers(
                 &project_root.join(".gemini").join("settings.json"),
-                names, out,
+                names,
+                out,
             ),
             Agent::Kiro => mcp_server_registration::unregister_kiro_mcp_servers(
                 &project_root.join(".kiro").join("settings").join("mcp.json"),
-                names, out,
+                names,
+                out,
             ),
             Agent::Goose => mcp_server_registration::unregister_goose_mcp_servers(
                 &project_root.join(".goose").join("config.yaml"),
-                names, out,
+                names,
+                out,
             ),
             Agent::OpenCode => mcp_server_registration::unregister_opencode_mcp_servers(
                 &project_root.join("opencode.json"),
-                names, out,
+                names,
+                out,
             ),
         }
     }
 
     /// Remove MCP servers from the global agent config.
-    pub fn unregister_global_mcp_servers(&self, home: &Path, names: &[&str], out: &Output) -> Result<()> {
+    pub fn unregister_global_mcp_servers(
+        &self,
+        home: &Path,
+        names: &[&str],
+        out: &Output,
+    ) -> Result<()> {
         match self {
             Agent::Claude => mcp_server_registration::unregister_claude_mcp_servers(
                 &home.join(".claude").join("settings.json"),
-                names, out,
+                names,
+                out,
             ),
             Agent::Codex => mcp_server_registration::unregister_codex_mcp_servers(
                 &home.join(".codex").join("config.toml"),
-                names, out,
+                names,
+                out,
             ),
             Agent::Copilot => mcp_server_registration::unregister_copilot_mcp_servers(
                 &home.join(".copilot").join("mcp-config.json"),
-                names, out,
+                names,
+                out,
             ),
             Agent::Gemini => mcp_server_registration::unregister_gemini_mcp_servers(
                 &home.join(".gemini").join("settings.json"),
-                names, out,
+                names,
+                out,
             ),
             Agent::Kiro => mcp_server_registration::unregister_kiro_mcp_servers(
                 &home.join(".kiro").join("settings").join("mcp.json"),
-                names, out,
+                names,
+                out,
             ),
             Agent::Goose => mcp_server_registration::unregister_goose_mcp_servers(
                 &home.join(".config").join("goose").join("config.yaml"),
-                names, out,
+                names,
+                out,
             ),
             Agent::OpenCode => mcp_server_registration::unregister_opencode_mcp_servers(
                 &home.join(".config").join("opencode").join("opencode.json"),
-                names, out,
+                names,
+                out,
             ),
         }
     }
@@ -983,7 +1036,6 @@ fn unregister_flat_hooks(config_path: &Path, command_key: &str, out: &Output) {
     }
 }
 
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -1267,5 +1319,4 @@ mod tests {
         assert!(settings["hooks"]["BeforeTool"].is_array());
         assert!(settings["hooks"]["AfterTool"].is_array());
     }
-
 }

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -12,8 +12,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Result, bail};
 use serde_json::json;
 
-use sacp::schema::McpServer;
-
+use crate::config::Symposium;
 use crate::output::{Output, display_path};
 
 /// Supported AI agents.
@@ -122,7 +121,7 @@ impl Agent {
     // -----------------------------------------------------------------------
 
     /// Register hooks in the project-level agent config.
-    pub fn register_project_hooks(&self, project_root: &Path, out: &Output) -> Result<()> {
+    pub fn register_project_hooks(&self, project_root: &Path, _sym: &Symposium, out: &Output) -> Result<()> {
         match self {
             Agent::Claude => {
                 register_claude_hooks(&project_root.join(".claude").join("settings.json"), out)
@@ -147,11 +146,14 @@ impl Agent {
                 out.info("OpenCode uses JS/TS plugins for hooks; skipping hook registration (skills only)");
                 Ok(())
             }
-        }
+        }?;
+
+        Ok(())
     }
 
     /// Register hooks in the global agent config.
-    pub fn register_global_hooks(&self, home: &Path, out: &Output) -> Result<()> {
+    pub fn register_global_hooks(&self, home: &Path, _sym: &Symposium, out: &Output) -> Result<()> {
+        // Register hooks
         match self {
             Agent::Claude => {
                 register_claude_hooks(&home.join(".claude").join("settings.json"), out)
@@ -174,7 +176,9 @@ impl Agent {
                 out.info("OpenCode uses JS/TS plugins for hooks; skipping hook registration (skills only)");
                 Ok(())
             }
-        }
+        }?;
+
+        Ok(())
     }
 
     // -----------------------------------------------------------------------
@@ -182,7 +186,7 @@ impl Agent {
     // -----------------------------------------------------------------------
 
     /// Register MCP servers in the project-level agent config.
-    pub fn register_project_mcp_servers(&self, project_root: &Path, servers: &[McpServer], out: &Output) -> Result<()> {
+    pub fn register_project_mcp_servers(&self, project_root: &Path, servers: &[sacp::schema::McpServer], out: &Output) -> Result<()> {
         match self {
             Agent::Claude => mcp_server_registration::register_claude_mcp_servers(
                 &project_root.join(".claude").join("settings.json"),
@@ -216,7 +220,7 @@ impl Agent {
     }
 
     /// Register MCP servers in the global agent config.
-    pub fn register_global_mcp_servers(&self, home: &Path, servers: &[McpServer], out: &Output) -> Result<()> {
+    pub fn register_global_mcp_servers(&self, home: &Path, servers: &[sacp::schema::McpServer], out: &Output) -> Result<()> {
         match self {
             Agent::Claude => mcp_server_registration::register_claude_mcp_servers(
                 &home.join(".claude").join("settings.json"),
@@ -318,7 +322,7 @@ impl Agent {
     }
 
     /// Remove hooks from the project-level agent config.
-    pub fn unregister_project_hooks(&self, project_root: &Path, out: &Output) {
+    pub fn unregister_project_hooks(&self, project_root: &Path, _sym: &Symposium, out: &Output) {
         match self {
             Agent::Claude => {
                 unregister_claude_hooks(&project_root.join(".claude").join("settings.json"), out)
@@ -339,7 +343,7 @@ impl Agent {
     }
 
     /// Remove hooks from the global agent config.
-    pub fn unregister_global_hooks(&self, home: &Path, out: &Output) {
+    pub fn unregister_global_hooks(&self, home: &Path, _sym: &Symposium, out: &Output) {
         match self {
             Agent::Claude => {
                 unregister_claude_hooks(&home.join(".claude").join("settings.json"), out)

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -12,6 +12,8 @@ use std::path::{Path, PathBuf};
 use anyhow::{Result, bail};
 use serde_json::json;
 
+use sacp::schema::McpServer;
+
 use crate::output::{Output, display_path};
 
 /// Supported AI agents.
@@ -172,6 +174,146 @@ impl Agent {
                 out.info("OpenCode uses JS/TS plugins for hooks; skipping hook registration (skills only)");
                 Ok(())
             }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // MCP server registration
+    // -----------------------------------------------------------------------
+
+    /// Register MCP servers in the project-level agent config.
+    pub fn register_project_mcp_servers(&self, project_root: &Path, servers: &[McpServer], out: &Output) -> Result<()> {
+        match self {
+            Agent::Claude => mcp_server_registration::register_claude_mcp_servers(
+                &project_root.join(".claude").join("settings.json"),
+                servers, out,
+            ),
+            Agent::Codex => mcp_server_registration::register_codex_mcp_servers(
+                &project_root.join(".codex").join("config.toml"),
+                servers, out,
+            ),
+            Agent::Copilot => mcp_server_registration::register_copilot_mcp_servers(
+                &project_root.join(".vscode").join("mcp.json"),
+                servers, out,
+            ),
+            Agent::Gemini => mcp_server_registration::register_gemini_mcp_servers(
+                &project_root.join(".gemini").join("settings.json"),
+                servers, out,
+            ),
+            Agent::Kiro => mcp_server_registration::register_kiro_mcp_servers(
+                &project_root.join(".kiro").join("settings").join("mcp.json"),
+                servers, out,
+            ),
+            Agent::Goose => mcp_server_registration::register_goose_mcp_servers(
+                &project_root.join(".goose").join("config.yaml"),
+                servers, out,
+            ),
+            Agent::OpenCode => mcp_server_registration::register_opencode_mcp_servers(
+                &project_root.join("opencode.json"),
+                servers, out,
+            ),
+        }
+    }
+
+    /// Register MCP servers in the global agent config.
+    pub fn register_global_mcp_servers(&self, home: &Path, servers: &[McpServer], out: &Output) -> Result<()> {
+        match self {
+            Agent::Claude => mcp_server_registration::register_claude_mcp_servers(
+                &home.join(".claude").join("settings.json"),
+                servers, out,
+            ),
+            Agent::Codex => mcp_server_registration::register_codex_mcp_servers(
+                &home.join(".codex").join("config.toml"),
+                servers, out,
+            ),
+            Agent::Copilot => mcp_server_registration::register_copilot_mcp_servers(
+                &home.join(".copilot").join("mcp-config.json"),
+                servers, out,
+            ),
+            Agent::Gemini => mcp_server_registration::register_gemini_mcp_servers(
+                &home.join(".gemini").join("settings.json"),
+                servers, out,
+            ),
+            Agent::Kiro => mcp_server_registration::register_kiro_mcp_servers(
+                &home.join(".kiro").join("settings").join("mcp.json"),
+                servers, out,
+            ),
+            Agent::Goose => mcp_server_registration::register_goose_mcp_servers(
+                &home.join(".config").join("goose").join("config.yaml"),
+                servers, out,
+            ),
+            Agent::OpenCode => mcp_server_registration::register_opencode_mcp_servers(
+                &home.join(".config").join("opencode").join("opencode.json"),
+                servers, out,
+            ),
+        }
+    }
+
+    /// Remove MCP servers from the project-level agent config.
+    pub fn unregister_project_mcp_servers(&self, project_root: &Path, names: &[&str], out: &Output) -> Result<()> {
+        match self {
+            Agent::Claude => mcp_server_registration::unregister_claude_mcp_servers(
+                &project_root.join(".claude").join("settings.json"),
+                names, out,
+            ),
+            Agent::Codex => mcp_server_registration::unregister_codex_mcp_servers(
+                &project_root.join(".codex").join("config.toml"),
+                names, out,
+            ),
+            Agent::Copilot => mcp_server_registration::unregister_copilot_mcp_servers(
+                &project_root.join(".vscode").join("mcp.json"),
+                names, out,
+            ),
+            Agent::Gemini => mcp_server_registration::unregister_gemini_mcp_servers(
+                &project_root.join(".gemini").join("settings.json"),
+                names, out,
+            ),
+            Agent::Kiro => mcp_server_registration::unregister_kiro_mcp_servers(
+                &project_root.join(".kiro").join("settings").join("mcp.json"),
+                names, out,
+            ),
+            Agent::Goose => mcp_server_registration::unregister_goose_mcp_servers(
+                &project_root.join(".goose").join("config.yaml"),
+                names, out,
+            ),
+            Agent::OpenCode => mcp_server_registration::unregister_opencode_mcp_servers(
+                &project_root.join("opencode.json"),
+                names, out,
+            ),
+        }
+    }
+
+    /// Remove MCP servers from the global agent config.
+    pub fn unregister_global_mcp_servers(&self, home: &Path, names: &[&str], out: &Output) -> Result<()> {
+        match self {
+            Agent::Claude => mcp_server_registration::unregister_claude_mcp_servers(
+                &home.join(".claude").join("settings.json"),
+                names, out,
+            ),
+            Agent::Codex => mcp_server_registration::unregister_codex_mcp_servers(
+                &home.join(".codex").join("config.toml"),
+                names, out,
+            ),
+            Agent::Copilot => mcp_server_registration::unregister_copilot_mcp_servers(
+                &home.join(".copilot").join("mcp-config.json"),
+                names, out,
+            ),
+            Agent::Gemini => mcp_server_registration::unregister_gemini_mcp_servers(
+                &home.join(".gemini").join("settings.json"),
+                names, out,
+            ),
+            Agent::Kiro => mcp_server_registration::unregister_kiro_mcp_servers(
+                &home.join(".kiro").join("settings").join("mcp.json"),
+                names, out,
+            ),
+            Agent::Goose => mcp_server_registration::unregister_goose_mcp_servers(
+                &home.join(".config").join("goose").join("config.yaml"),
+                names, out,
+            ),
+            Agent::OpenCode => mcp_server_registration::unregister_opencode_mcp_servers(
+                &home.join(".config").join("opencode").join("opencode.json"),
+                names, out,
+            ),
         }
     }
 

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -4,6 +4,8 @@
 //! configured and where skill files are placed. This module centralizes
 //! that knowledge.
 
+mod mcp_server_registration;
+
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -835,6 +837,7 @@ fn unregister_flat_hooks(config_path: &Path, command_key: &str, out: &Output) {
     }
 }
 
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -1118,4 +1121,5 @@ mod tests {
         assert!(settings["hooks"]["BeforeTool"].is_array());
         assert!(settings["hooks"]["AfterTool"].is_array());
     }
+
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -358,6 +358,7 @@ pub struct Symposium {
     config_dir: PathBuf,
     cache_dir: PathBuf,
     home_dir: PathBuf,
+    symposium_binary: String,
 }
 
 impl Symposium {
@@ -382,6 +383,7 @@ impl Symposium {
             config_dir,
             cache_dir,
             home_dir,
+            symposium_binary: resolve_symposium_binary(),
         }
     }
 
@@ -410,6 +412,7 @@ impl Symposium {
             config_dir,
             cache_dir,
             home_dir,
+            symposium_binary: resolve_test_binary(),
         }
     }
 
@@ -450,6 +453,10 @@ impl Symposium {
 
     pub fn home_dir(&self) -> &Path {
         &self.home_dir
+    }
+
+    pub fn symposium_binary(&self) -> &str {
+        &self.symposium_binary
     }
 
     /// Returns the effective list of plugin sources, including built-in defaults.
@@ -567,6 +574,43 @@ impl Symposium {
             }
         }
     }
+}
+
+/// Resolve the path to the symposium binary.
+///
+/// Tries `current_exe()` first, then `which symposium`, falling back to `"symposium"`.
+fn resolve_symposium_binary() -> String {
+    if let Ok(exe) = std::env::current_exe() {
+        if exe.file_name().and_then(|n| n.to_str()) == Some("symposium") {
+            return exe.to_string_lossy().into_owned();
+        }
+    }
+    if let Ok(out) = std::process::Command::new("which").arg("symposium").output() {
+        if out.status.success() {
+            let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !path.is_empty() {
+                return path;
+            }
+        }
+    }
+    "symposium".to_string()
+}
+
+/// Resolve the symposium binary for test contexts.
+///
+/// Looks for the binary in the same directory as the test executable
+/// (i.e. the cargo build output directory), which is where `cargo test`
+/// places compiled binaries.
+fn resolve_test_binary() -> String {
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            let candidate = dir.join("symposium");
+            if candidate.exists() {
+                return candidate.to_string_lossy().into_owned();
+            }
+        }
+    }
+    resolve_symposium_binary()
 }
 
 /// Resolve config dir from environment variables.

--- a/src/config.rs
+++ b/src/config.rs
@@ -358,7 +358,6 @@ pub struct Symposium {
     config_dir: PathBuf,
     cache_dir: PathBuf,
     home_dir: PathBuf,
-    symposium_binary: String,
 }
 
 impl Symposium {
@@ -383,7 +382,6 @@ impl Symposium {
             config_dir,
             cache_dir,
             home_dir,
-            symposium_binary: resolve_symposium_binary(),
         }
     }
 
@@ -412,7 +410,6 @@ impl Symposium {
             config_dir,
             cache_dir,
             home_dir,
-            symposium_binary: resolve_test_binary(),
         }
     }
 
@@ -453,10 +450,6 @@ impl Symposium {
 
     pub fn home_dir(&self) -> &Path {
         &self.home_dir
-    }
-
-    pub fn symposium_binary(&self) -> &str {
-        &self.symposium_binary
     }
 
     /// Returns the effective list of plugin sources, including built-in defaults.
@@ -574,43 +567,6 @@ impl Symposium {
             }
         }
     }
-}
-
-/// Resolve the path to the symposium binary.
-///
-/// Tries `current_exe()` first, then `which symposium`, falling back to `"symposium"`.
-fn resolve_symposium_binary() -> String {
-    if let Ok(exe) = std::env::current_exe() {
-        if exe.file_name().and_then(|n| n.to_str()) == Some("symposium") {
-            return exe.to_string_lossy().into_owned();
-        }
-    }
-    if let Ok(out) = std::process::Command::new("which").arg("symposium").output() {
-        if out.status.success() {
-            let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
-            if !path.is_empty() {
-                return path;
-            }
-        }
-    }
-    "symposium".to_string()
-}
-
-/// Resolve the symposium binary for test contexts.
-///
-/// Looks for the binary in the same directory as the test executable
-/// (i.e. the cargo build output directory), which is where `cargo test`
-/// places compiled binaries.
-fn resolve_test_binary() -> String {
-    if let Ok(exe) = std::env::current_exe() {
-        if let Some(dir) = exe.parent() {
-            let candidate = dir.join("symposium");
-            if candidate.exists() {
-                return candidate.to_string_lossy().into_owned();
-            }
-        }
-    }
-    resolve_symposium_binary()
 }
 
 /// Resolve config dir from environment variables.

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -9,6 +9,39 @@ use crate::git_source::UpdateLevel;
 use crate::hook::HookEvent;
 use crate::hook_schema::HookAgent;
 
+use sacp::schema::{McpServer, McpServerStdio};
+
+/// An MCP server entry in a plugin manifest.
+///
+/// Either a builtin reference (resolved to the symposium binary at sync time)
+/// or a concrete MCP server definition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum McpServerEntry {
+    /// A builtin MCP server: `{ name = "symposium", builtin = ["mcp"] }`.
+    /// Resolved to `McpServerStdio { command: <symposium binary>, args: builtin }`.
+    Builtin { name: String, builtin: Vec<String> },
+    /// A concrete MCP server definition from the ACP schema.
+    Custom(McpServer),
+}
+
+impl McpServerEntry {
+    /// Resolve this entry into a concrete `McpServer`.
+    ///
+    /// Builtin entries are expanded using the symposium binary path.
+    pub fn resolve(&self, sym: &Symposium) -> McpServer {
+        match self {
+            McpServerEntry::Builtin { name, builtin } => {
+                McpServer::Stdio(
+                    McpServerStdio::new(name.clone(), sym.symposium_binary())
+                        .args(builtin.clone()),
+                )
+            }
+            McpServerEntry::Custom(server) => server.clone(),
+        }
+    }
+}
+
 /// Source declaration for remote plugin artifacts.
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct PluginSource {
@@ -101,6 +134,9 @@ pub struct Plugin {
     pub installation: Option<Installation>,
     pub hooks: Vec<Hook>,
     pub skills: Vec<SkillGroup>,
+    /// MCP servers to register for this plugin.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mcp_servers: Vec<McpServerEntry>,
     /// Text to inject as additional context at session start.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_start_context: Option<String>,
@@ -206,6 +242,8 @@ struct PluginManifest {
     hooks: Vec<Hook>,
     #[serde(default)]
     skills: Vec<SkillGroup>,
+    #[serde(default)]
+    mcp_servers: Vec<McpServerEntry>,
     #[serde(default, rename = "session-start-context")]
     session_start_context: Option<String>,
 }
@@ -637,6 +675,7 @@ pub fn load_plugin(manifest_path: &Path) -> Result<ParsedPlugin> {
             installation: manifest.installation,
             hooks: manifest.hooks,
             skills: manifest.skills,
+            mcp_servers: manifest.mcp_servers,
             session_start_context: manifest.session_start_context,
         },
     })
@@ -654,6 +693,7 @@ mod tests {
             installation: manifest.installation,
             hooks: manifest.hooks,
             skills: manifest.skills,
+            mcp_servers: manifest.mcp_servers,
             session_start_context: manifest.session_start_context,
         })
     }
@@ -967,5 +1007,26 @@ mod tests {
         assert_eq!(plugin.skills.len(), 2);
         assert!(plugin.skills[0].crates.as_ref().unwrap()[0].references_crate("serde"));
         assert!(plugin.skills[1].crates.as_ref().unwrap()[0].references_crate("tokio"));
+    }
+
+    #[test]
+    fn parse_manifest_with_builtin_mcp_server() {
+        let toml = indoc! {r#"
+            name = "symposium"
+
+            [[mcp_servers]]
+            name = "symposium"
+            builtin = ["mcp"]
+        "#};
+        let plugin = from_str(toml).expect("parse");
+        assert_eq!(plugin.mcp_servers.len(), 1);
+        assert!(matches!(&plugin.mcp_servers[0], McpServerEntry::Builtin { name, builtin }
+            if name == "symposium" && builtin == &["mcp"]));
+    }
+
+    #[test]
+    fn parse_manifest_with_no_mcp_servers() {
+        let plugin = from_str(SAMPLE).expect("parse");
+        assert!(plugin.mcp_servers.is_empty());
     }
 }

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -994,7 +994,8 @@ mod tests {
             command = "/usr/local/bin/my-server"
             args = ["--stdio"]
             env = []
-        "#}).expect("parse");
+        "#})
+        .expect("parse");
         expect_test::expect![[r#"
             Stdio(
                 McpServerStdio {
@@ -1006,7 +1007,8 @@ mod tests {
                     env: [],
                     meta: None,
                 },
-            )"#]].assert_eq(&format!("{entry:#?}"));
+            )"#]]
+        .assert_eq(&format!("{entry:#?}"));
     }
 
     #[test]
@@ -1016,7 +1018,8 @@ mod tests {
             name = "my-server"
             url = "http://localhost:8080/mcp"
             headers = []
-        "#}).expect("parse");
+        "#})
+        .expect("parse");
         expect_test::expect![[r#"
             Http(
                 McpServerHttp {
@@ -1025,7 +1028,8 @@ mod tests {
                     headers: [],
                     meta: None,
                 },
-            )"#]].assert_eq(&format!("{entry:#?}"));
+            )"#]]
+        .assert_eq(&format!("{entry:#?}"));
     }
 
     #[test]
@@ -1035,7 +1039,8 @@ mod tests {
             name = "my-server"
             url = "http://localhost:8080/sse"
             headers = []
-        "#}).expect("parse");
+        "#})
+        .expect("parse");
         expect_test::expect![[r#"
             Sse(
                 McpServerSse {
@@ -1044,6 +1049,7 @@ mod tests {
                     headers: [],
                     meta: None,
                 },
-            )"#]].assert_eq(&format!("{entry:#?}"));
+            )"#]]
+        .assert_eq(&format!("{entry:#?}"));
     }
 }

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -9,67 +9,10 @@ use crate::git_source::UpdateLevel;
 use crate::hook::HookEvent;
 use crate::hook_schema::HookAgent;
 
-use sacp::schema::{McpServer, McpServerStdio};
+use sacp::schema::McpServer;
 
 /// An MCP server entry in a plugin manifest.
-///
-/// Either a builtin reference (resolved to the symposium binary at sync time)
-/// or a concrete MCP server definition.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum McpServerEntry {
-    /// A builtin MCP server: `{ name = "symposium", type = "builtin", args = ["mcp"] }`.
-    /// Resolved to `McpServerStdio { command: <symposium binary>, args }`.
-    Builtin {
-        name: String,
-        r#type: BuiltinTag,
-        #[serde(default)]
-        args: Vec<String>,
-    },
-    /// A concrete MCP server definition from the ACP schema.
-    Custom(McpServer),
-}
-
-/// Tag value that must be the string `"builtin"`.
-#[derive(Debug, Clone)]
-pub struct BuiltinTag;
-
-impl Serialize for BuiltinTag {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str("builtin")
-    }
-}
-
-impl<'de> Deserialize<'de> for BuiltinTag {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let s = String::deserialize(deserializer)?;
-        if s == "builtin" {
-            Ok(BuiltinTag)
-        } else {
-            Err(serde::de::Error::invalid_value(
-                serde::de::Unexpected::Str(&s),
-                &"\"builtin\"",
-            ))
-        }
-    }
-}
-
-impl McpServerEntry {
-    /// Resolve this entry into a concrete `McpServer`.
-    ///
-    /// Builtin entries are expanded using the symposium binary path.
-    pub fn resolve(&self, sym: &Symposium) -> McpServer {
-        match self {
-            McpServerEntry::Builtin { name, args, .. } => {
-                McpServer::Stdio(
-                    McpServerStdio::new(name.clone(), sym.symposium_binary())
-                        .args(args.clone()),
-                )
-            }
-            McpServerEntry::Custom(server) => server.clone(),
-        }
-    }
-}
+pub type McpServerEntry = McpServer;
 
 /// Source declaration for remote plugin artifacts.
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
@@ -1039,42 +982,9 @@ mod tests {
     }
 
     #[test]
-    fn parse_manifest_with_builtin_mcp_server() {
-        let toml = indoc! {r#"
-            name = "symposium"
-
-            [[mcp_servers]]
-            name = "symposium"
-            type = "builtin"
-            args = ["mcp"]
-        "#};
-        let plugin = from_str(toml).expect("parse");
-        assert_eq!(plugin.mcp_servers.len(), 1);
-        assert!(matches!(&plugin.mcp_servers[0], McpServerEntry::Builtin { name, args, .. }
-            if name == "symposium" && args == &["mcp"]));
-    }
-
-    #[test]
     fn parse_manifest_with_no_mcp_servers() {
         let plugin = from_str(SAMPLE).expect("parse");
         assert!(plugin.mcp_servers.is_empty());
-    }
-
-    #[test]
-    fn mcp_entry_builtin() {
-        let entry: McpServerEntry = toml::from_str(indoc! {r#"
-            name = "symposium"
-            type = "builtin"
-            args = ["mcp"]
-        "#}).expect("parse");
-        expect_test::expect![[r#"
-            Builtin {
-                name: "symposium",
-                type: BuiltinTag,
-                args: [
-                    "mcp",
-                ],
-            }"#]].assert_eq(&format!("{entry:#?}"));
     }
 
     #[test]
@@ -1086,18 +996,16 @@ mod tests {
             env = []
         "#}).expect("parse");
         expect_test::expect![[r#"
-            Custom(
-                Stdio(
-                    McpServerStdio {
-                        name: "my-server",
-                        command: "/usr/local/bin/my-server",
-                        args: [
-                            "--stdio",
-                        ],
-                        env: [],
-                        meta: None,
-                    },
-                ),
+            Stdio(
+                McpServerStdio {
+                    name: "my-server",
+                    command: "/usr/local/bin/my-server",
+                    args: [
+                        "--stdio",
+                    ],
+                    env: [],
+                    meta: None,
+                },
             )"#]].assert_eq(&format!("{entry:#?}"));
     }
 
@@ -1110,15 +1018,13 @@ mod tests {
             headers = []
         "#}).expect("parse");
         expect_test::expect![[r#"
-            Custom(
-                Http(
-                    McpServerHttp {
-                        name: "my-server",
-                        url: "http://localhost:8080/mcp",
-                        headers: [],
-                        meta: None,
-                    },
-                ),
+            Http(
+                McpServerHttp {
+                    name: "my-server",
+                    url: "http://localhost:8080/mcp",
+                    headers: [],
+                    meta: None,
+                },
             )"#]].assert_eq(&format!("{entry:#?}"));
     }
 
@@ -1131,15 +1037,13 @@ mod tests {
             headers = []
         "#}).expect("parse");
         expect_test::expect![[r#"
-            Custom(
-                Sse(
-                    McpServerSse {
-                        name: "my-server",
-                        url: "http://localhost:8080/sse",
-                        headers: [],
-                        meta: None,
-                    },
-                ),
+            Sse(
+                McpServerSse {
+                    name: "my-server",
+                    url: "http://localhost:8080/sse",
+                    headers: [],
+                    meta: None,
+                },
             )"#]].assert_eq(&format!("{entry:#?}"));
     }
 }

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -18,11 +18,40 @@ use sacp::schema::{McpServer, McpServerStdio};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum McpServerEntry {
-    /// A builtin MCP server: `{ name = "symposium", builtin = ["mcp"] }`.
-    /// Resolved to `McpServerStdio { command: <symposium binary>, args: builtin }`.
-    Builtin { name: String, builtin: Vec<String> },
+    /// A builtin MCP server: `{ name = "symposium", type = "builtin", args = ["mcp"] }`.
+    /// Resolved to `McpServerStdio { command: <symposium binary>, args }`.
+    Builtin {
+        name: String,
+        r#type: BuiltinTag,
+        #[serde(default)]
+        args: Vec<String>,
+    },
     /// A concrete MCP server definition from the ACP schema.
     Custom(McpServer),
+}
+
+/// Tag value that must be the string `"builtin"`.
+#[derive(Debug, Clone)]
+pub struct BuiltinTag;
+
+impl Serialize for BuiltinTag {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str("builtin")
+    }
+}
+
+impl<'de> Deserialize<'de> for BuiltinTag {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        if s == "builtin" {
+            Ok(BuiltinTag)
+        } else {
+            Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(&s),
+                &"\"builtin\"",
+            ))
+        }
+    }
 }
 
 impl McpServerEntry {
@@ -31,10 +60,10 @@ impl McpServerEntry {
     /// Builtin entries are expanded using the symposium binary path.
     pub fn resolve(&self, sym: &Symposium) -> McpServer {
         match self {
-            McpServerEntry::Builtin { name, builtin } => {
+            McpServerEntry::Builtin { name, args, .. } => {
                 McpServer::Stdio(
                     McpServerStdio::new(name.clone(), sym.symposium_binary())
-                        .args(builtin.clone()),
+                        .args(args.clone()),
                 )
             }
             McpServerEntry::Custom(server) => server.clone(),
@@ -1016,17 +1045,101 @@ mod tests {
 
             [[mcp_servers]]
             name = "symposium"
-            builtin = ["mcp"]
+            type = "builtin"
+            args = ["mcp"]
         "#};
         let plugin = from_str(toml).expect("parse");
         assert_eq!(plugin.mcp_servers.len(), 1);
-        assert!(matches!(&plugin.mcp_servers[0], McpServerEntry::Builtin { name, builtin }
-            if name == "symposium" && builtin == &["mcp"]));
+        assert!(matches!(&plugin.mcp_servers[0], McpServerEntry::Builtin { name, args, .. }
+            if name == "symposium" && args == &["mcp"]));
     }
 
     #[test]
     fn parse_manifest_with_no_mcp_servers() {
         let plugin = from_str(SAMPLE).expect("parse");
         assert!(plugin.mcp_servers.is_empty());
+    }
+
+    #[test]
+    fn mcp_entry_builtin() {
+        let entry: McpServerEntry = toml::from_str(indoc! {r#"
+            name = "symposium"
+            type = "builtin"
+            args = ["mcp"]
+        "#}).expect("parse");
+        expect_test::expect![[r#"
+            Builtin {
+                name: "symposium",
+                type: BuiltinTag,
+                args: [
+                    "mcp",
+                ],
+            }"#]].assert_eq(&format!("{entry:#?}"));
+    }
+
+    #[test]
+    fn mcp_entry_stdio() {
+        let entry: McpServerEntry = toml::from_str(indoc! {r#"
+            name = "my-server"
+            command = "/usr/local/bin/my-server"
+            args = ["--stdio"]
+            env = []
+        "#}).expect("parse");
+        expect_test::expect![[r#"
+            Custom(
+                Stdio(
+                    McpServerStdio {
+                        name: "my-server",
+                        command: "/usr/local/bin/my-server",
+                        args: [
+                            "--stdio",
+                        ],
+                        env: [],
+                        meta: None,
+                    },
+                ),
+            )"#]].assert_eq(&format!("{entry:#?}"));
+    }
+
+    #[test]
+    fn mcp_entry_http() {
+        let entry: McpServerEntry = toml::from_str(indoc! {r#"
+            type = "http"
+            name = "my-server"
+            url = "http://localhost:8080/mcp"
+            headers = []
+        "#}).expect("parse");
+        expect_test::expect![[r#"
+            Custom(
+                Http(
+                    McpServerHttp {
+                        name: "my-server",
+                        url: "http://localhost:8080/mcp",
+                        headers: [],
+                        meta: None,
+                    },
+                ),
+            )"#]].assert_eq(&format!("{entry:#?}"));
+    }
+
+    #[test]
+    fn mcp_entry_sse() {
+        let entry: McpServerEntry = toml::from_str(indoc! {r#"
+            type = "sse"
+            name = "my-server"
+            url = "http://localhost:8080/sse"
+            headers = []
+        "#}).expect("parse");
+        expect_test::expect![[r#"
+            Custom(
+                Sse(
+                    McpServerSse {
+                        name: "my-server",
+                        url: "http://localhost:8080/sse",
+                        headers: [],
+                        meta: None,
+                    },
+                ),
+            )"#]].assert_eq(&format!("{entry:#?}"));
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -161,7 +161,7 @@ pub async fn sync_agent(sym: &Symposium, project_root: Option<&Path>, out: &Outp
     let mcp_servers: Vec<sacp::schema::McpServer> = registry
         .plugins
         .iter()
-        .flat_map(|p| p.plugin.mcp_servers.iter().map(|e| e.resolve(sym)))
+        .flat_map(|p| p.plugin.mcp_servers.iter().cloned())
         .collect();
 
     // Register hooks and MCP servers for configured agents

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -209,7 +209,7 @@ pub async fn sync_agent(sym: &Symposium, project_root: Option<&Path>, out: &Outp
             sacp::schema::McpServer::Stdio(s) => s.name.as_str(),
             sacp::schema::McpServer::Http(s) => s.name.as_str(),
             sacp::schema::McpServer::Sse(s) => s.name.as_str(),
-            _ => "unknown",
+            _ => panic!("unsupported McpServer variant"),
         })
         .collect();
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -156,7 +156,15 @@ pub async fn sync_agent(sym: &Symposium, project_root: Option<&Path>, out: &Outp
     let project_config = project_root.and_then(ProjectConfig::load);
     let agent_names = resolve_agents(&sym.config, project_config.as_ref());
 
-    // Register hooks for configured agents
+    // Collect MCP servers from all plugins
+    let registry = plugins::load_registry_with(sym, project_config.as_ref(), project_root);
+    let mcp_servers: Vec<sacp::schema::McpServer> = registry
+        .plugins
+        .iter()
+        .flat_map(|p| p.plugin.mcp_servers.iter().map(|e| e.resolve(sym)))
+        .collect();
+
+    // Register hooks and MCP servers for configured agents
     for agent_name in &agent_names {
         let agent = Agent::from_config_name(agent_name)?;
 
@@ -167,12 +175,18 @@ pub async fn sync_agent(sym: &Symposium, project_root: Option<&Path>, out: &Outp
 
             if is_project_agent {
                 agent
-                    .register_project_hooks(root, out)
+                    .register_project_hooks(root, sym, out)
                     .context("failed to register project hooks")?;
+                agent
+                    .register_project_mcp_servers(root, &mcp_servers, out)
+                    .context("failed to register project MCP servers")?;
             } else {
                 agent
-                    .register_global_hooks(sym.home_dir(), out)
+                    .register_global_hooks(sym.home_dir(), sym, out)
                     .context("failed to register global hooks")?;
+                agent
+                    .register_global_mcp_servers(sym.home_dir(), &mcp_servers, out)
+                    .context("failed to register global MCP servers")?;
             }
 
             if let Some(ref config) = project_config {
@@ -180,18 +194,34 @@ pub async fn sync_agent(sym: &Symposium, project_root: Option<&Path>, out: &Outp
             }
         } else {
             agent
-                .register_global_hooks(sym.home_dir(), out)
+                .register_global_hooks(sym.home_dir(), sym, out)
                 .context("failed to register global hooks")?;
+            agent
+                .register_global_mcp_servers(sym.home_dir(), &mcp_servers, out)
+                .context("failed to register global MCP servers")?;
         }
     }
+
+    // Collect server names for unregistration
+    let server_names: Vec<&str> = mcp_servers
+        .iter()
+        .map(|s| match s {
+            sacp::schema::McpServer::Stdio(s) => s.name.as_str(),
+            sacp::schema::McpServer::Http(s) => s.name.as_str(),
+            sacp::schema::McpServer::Sse(s) => s.name.as_str(),
+            _ => "unknown",
+        })
+        .collect();
 
     // Remove hooks for agents that are no longer configured
     for &agent in Agent::all() {
         if !agent_names.contains(&agent.config_name().to_string()) {
             if let Some(root) = project_root {
-                agent.unregister_project_hooks(root, out);
+                agent.unregister_project_hooks(root, sym, out);
+                let _ = agent.unregister_project_mcp_servers(root, &server_names, out);
             }
-            agent.unregister_global_hooks(sym.home_dir(), out);
+            agent.unregister_global_hooks(sym.home_dir(), sym, out);
+            let _ = agent.unregister_global_mcp_servers(sym.home_dir(), &server_names, out);
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

Registers symposium as an MCP server in each agent's config alongside the existing hook-based integration. This provides an alternative integration path for agents to discover and invoke symposium via the Model Context Protocol.

### Changes

- **MCP registration module** — new `agents::mcp_server_registration` module with per-agent register/unregister functions supporting JSON (Claude, Copilot, Gemini, Kiro, OpenCode), TOML (Codex), and YAML (Goose) config formats
- **Binary resolution** — `Symposium` struct now resolves and exposes the symposium binary path, used to populate MCP server entries with the correct command
- **Wired into sync** — hook registration/unregistration now also registers/unregisters the MCP server entry, so `symposium sync` keeps both hooks and MCP config in sync
- **Idempotent & update-aware** — existing entries with correct values are left untouched; stale entries (e.g. binary moved) are updated in place
- **Module restructure** — `agents.rs` converted to `agents/mod.rs` directory to house the new submodule
- **Tests** — registration tests for all agent formats covering creation, idempotency, stale updates, and unregistration
- **Docs** — added MCP server registration section to Claude Code agent documentation

<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

<!-- Symposium is an AI project. We encourage the use of agentic tooling! We do however require disclosure. The disclosure helps us to calibrate our reviews. See our [PR disclosure policy](https://symposium-dev.github.io/symposium/design/governance.html#pr-disclosure-policy). -->

* The AI tool authored large parts of the code

**Confidence level.**

* I am very happy with it

**Questions for reviewers.**

<!-- Any specific areas of uncertainty or things you'd like reviewers to look at? -->

</details>
