### PR TITLE
Skill sync integration tests and three bug fixes

### DIFF
--- a/src/bin/symposium.rs
+++ b/src/bin/symposium.rs
@@ -30,7 +30,7 @@ async fn main() -> ExitCode {
 
     match cli.command {
         // Commands that need direct I/O (stdin/stdout) stay in the binary
-        Some(Commands::Hook { agent, event }) => hook::run(&sym, agent, event, &cwd).await,
+        Some(Commands::Hook { agent, event }) => hook::run(&sym, agent, event).await,
 
         Some(Commands::Mcp) => match mcp::serve(&sym, &cwd).await {
             Ok(()) => ExitCode::SUCCESS,

--- a/src/config.rs
+++ b/src/config.rs
@@ -118,7 +118,7 @@ pub struct PluginSourceConfig {
 // ---------------------------------------------------------------------------
 
 /// Project-level configuration stored at `.symposium/config.toml`.
-#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct ProjectConfig {
     /// Default on/off for newly discovered extensions (overrides user setting).
     #[serde(default = "default_true", rename = "sync-default")]
@@ -153,6 +153,20 @@ pub struct ProjectConfig {
     /// Workflow extensions. Key = workflow name, value = enabled.
     #[serde(default)]
     pub workflows: BTreeMap<String, bool>,
+}
+
+impl Default for ProjectConfig {
+    fn default() -> Self {
+        Self {
+            sync_default: true,
+            agents: Vec::new(),
+            self_contained: false,
+            defaults: None,
+            plugin_source: Vec::new(),
+            skills: BTreeMap::new(),
+            workflows: BTreeMap::new(),
+        }
+    }
 }
 
 impl ProjectConfig {

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -11,7 +11,7 @@ use crate::{
 
 // Re-export hook schema types for convenience.
 pub use crate::hook_schema::{HookAgent, HookEvent};
-/// Core hook pipeline: parse → builtin → plugins → serialize.
+/// Core hook pipeline: sync → parse → builtin → plugins → serialize.
 ///
 /// Takes the raw agent wire-format input, returns agent wire-format output bytes.
 /// Called by both `run()` (CLI) and the test harness.
@@ -26,6 +26,9 @@ pub async fn execute_hook(
     if let Some(handler) = event_handler {
         let payload = handler.parse_input(input)?;
         let sym_input = payload.to_symposium();
+
+        // Run sync --agent as a side effect (non-fatal).
+        run_sync_agent(sym, &sym_input).await;
 
         // Builtin dispatch → symposium output → host agent output as Value
         let builtin_sym_output = dispatch_builtin(sym, &sym_input).await;
@@ -57,7 +60,6 @@ pub async fn run(
     sym: &Symposium,
     agent: HookAgent,
     event: HookEvent,
-    cwd: &std::path::Path,
 ) -> ExitCode {
     tracing::debug!("Running hook listener for agent {agent:?} and event {event:?}");
 
@@ -67,14 +69,6 @@ pub async fn run(
         return ExitCode::SUCCESS;
     }
     tracing::debug!(?input);
-
-    // Run sync --agent as a side effect (non-fatal, CLI-only).
-    if let Some(handler) = agent.event(event) {
-        if let Ok(payload) = handler.parse_input(&input) {
-            let sym_input = payload.to_symposium();
-            run_sync_agent_sym(sym, &sym_input, cwd).await;
-        }
-    }
 
     match execute_hook(sym, agent, event, &input).await {
         Ok(bytes) => {
@@ -91,12 +85,10 @@ pub async fn run(
 }
 
 /// Run sync --agent if we're in a project directory. Non-fatal.
-async fn run_sync_agent_sym(sym: &Symposium, input: &symposium::InputEvent, cwd: &std::path::Path) {
-    let effective_cwd = input
-        .cwd()
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| cwd.to_path_buf());
-    let project_root = Some(effective_cwd.as_path()).filter(|p| p.join(".symposium").is_dir());
+async fn run_sync_agent(sym: &Symposium, input: &symposium::InputEvent) {
+    let Some(cwd_str) = input.cwd() else { return };
+    let cwd = std::path::Path::new(cwd_str);
+    let project_root = Some(cwd).filter(|p| p.join(".symposium").is_dir());
     let out = crate::output::Output::quiet();
     if let Err(e) = crate::sync::sync_agent(sym, project_root, &out).await {
         tracing::warn!(error = %e, "sync --agent during hook failed (continuing)");

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -56,11 +56,7 @@ pub async fn execute_hook(
 }
 
 /// CLI entry point: read payload from stdin, dispatch, print output.
-pub async fn run(
-    sym: &Symposium,
-    agent: HookAgent,
-    event: HookEvent,
-) -> ExitCode {
+pub async fn run(sym: &Symposium, agent: HookAgent, event: HookEvent) -> ExitCode {
     tracing::debug!("Running hook listener for agent {agent:?} and event {event:?}");
 
     let mut input = String::new();

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -246,13 +246,21 @@ async fn install_skills(
     for entry in &applicable {
         for crate_name in entry.effective_crate_names() {
             let enabled = config.skills.get(&crate_name).copied().unwrap_or(false);
+            let skill_name = entry.skill.name();
+            let dest_dir = agent.project_skill_dir(project_root, skill_name);
+
             if !enabled {
+                if dest_dir.exists() {
+                    let _ = std::fs::remove_dir_all(&dest_dir);
+                    out.removed(format!(
+                        "removed skill {skill_name} from {}",
+                        display_path(&dest_dir)
+                    ));
+                }
                 continue;
             }
 
             let skill_path = &entry.skill.path;
-            let skill_name = entry.skill.name();
-            let dest_dir = agent.project_skill_dir(project_root, skill_name);
 
             match agent.install_skill(skill_path, &dest_dir) {
                 Ok(()) => {

--- a/tests/fixtures/workspace-noserde0/Cargo.toml
+++ b/tests/fixtures/workspace-noserde0/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "test-workspace-noserde"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = "1.0"

--- a/tests/fixtures/workspace-noserde0/src/lib.rs
+++ b/tests/fixtures/workspace-noserde0/src/lib.rs
@@ -1,0 +1,1 @@
+// empty test workspace

--- a/tests/init_sync.rs
+++ b/tests/init_sync.rs
@@ -79,13 +79,13 @@ async fn init_project_creates_config_and_discovers_skills() {
     );
 
     expect![[r#"
-        sync-default = false
+        sync-default = true
         agent = []
         self-contained = false
         plugin-source = []
 
         [skills]
-        serde = false
+        serde = true
 
         [workflows]
     "#]]
@@ -122,7 +122,7 @@ async fn sync_workspace_preserves_existing_choices() {
     );
 
     expect![[r#"
-        sync-default = false
+        sync-default = true
         agent = []
         self-contained = false
         plugin-source = []
@@ -210,7 +210,7 @@ async fn sync_add_agent_to_project() {
     assert_eq!(agent_names, vec!["claude", "copilot"]);
 
     expect![[r#"
-        sync-default = false
+        sync-default = true
         self-contained = false
         plugin-source = []
 
@@ -221,7 +221,7 @@ async fn sync_add_agent_to_project() {
         name = "copilot"
 
         [skills]
-        serde = false
+        serde = true
 
         [workflows]
     "#]]
@@ -249,7 +249,7 @@ async fn init_project_with_agent_sets_override() {
     );
 
     expect![[r#"
-        sync-default = false
+        sync-default = true
         self-contained = false
         plugin-source = []
 
@@ -257,7 +257,7 @@ async fn init_project_with_agent_sets_override() {
         name = "gemini"
 
         [skills]
-        serde = false
+        serde = true
 
         [workflows]
     "#]]

--- a/tests/skill_sync_options.rs
+++ b/tests/skill_sync_options.rs
@@ -110,8 +110,11 @@ async fn sync_default_false_disables_skill() {
     // Opt out: set sync-default = false
     let config_path = workspace_root.join(".symposium").join("config.toml");
     let content = std::fs::read_to_string(&config_path).unwrap();
-    std::fs::write(&config_path, content.replace("sync-default = true", "sync-default = false"))
-        .unwrap();
+    std::fs::write(
+        &config_path,
+        content.replace("sync-default = true", "sync-default = false"),
+    )
+    .unwrap();
 
     // Add serde dependency
     let cargo_path = workspace_root.join("Cargo.toml");
@@ -167,7 +170,11 @@ async fn toggle_skill_true_to_false_removes_then_reinstalls() {
 
     // Disable the skill
     let content = std::fs::read_to_string(&config_path).unwrap();
-    std::fs::write(&config_path, content.replace("serde = true", "serde = false")).unwrap();
+    std::fs::write(
+        &config_path,
+        content.replace("serde = true", "serde = false"),
+    )
+    .unwrap();
 
     // Sync agent — should remove the skill directory
     ctx.symposium(&["sync", "--agent"]).await.unwrap();
@@ -178,7 +185,11 @@ async fn toggle_skill_true_to_false_removes_then_reinstalls() {
 
     // Re-enable the skill
     let content = std::fs::read_to_string(&config_path).unwrap();
-    std::fs::write(&config_path, content.replace("serde = false", "serde = true")).unwrap();
+    std::fs::write(
+        &config_path,
+        content.replace("serde = false", "serde = true"),
+    )
+    .unwrap();
 
     // Sync agent — should reinstall
     ctx.symposium(&["sync", "--agent"]).await.unwrap();
@@ -208,7 +219,11 @@ async fn toggle_skill_then_hook_installs() {
 
     // Disable the skill (it starts enabled)
     let content = std::fs::read_to_string(&config_path).unwrap();
-    std::fs::write(&config_path, content.replace("serde = true", "serde = false")).unwrap();
+    std::fs::write(
+        &config_path,
+        content.replace("serde = true", "serde = false"),
+    )
+    .unwrap();
 
     // Sync to remove it
     ctx.symposium(&["sync", "--agent"]).await.unwrap();
@@ -216,7 +231,11 @@ async fn toggle_skill_then_hook_installs() {
 
     // Re-enable the skill
     let content = std::fs::read_to_string(&config_path).unwrap();
-    std::fs::write(&config_path, content.replace("serde = false", "serde = true")).unwrap();
+    std::fs::write(
+        &config_path,
+        content.replace("serde = false", "serde = true"),
+    )
+    .unwrap();
 
     // Invoke a hook — the sync side-effect should install the skill
     use symposium::hook::HookEvent;

--- a/tests/skill_sync_options.rs
+++ b/tests/skill_sync_options.rs
@@ -1,0 +1,196 @@
+//! Integration tests for skill syncing with different sync-default configurations.
+//!
+//! Covers:
+//! - Initial sync with no applicable skills → add dep → re-sync → skill appears
+//! - sync-default = true (project-level) → skills enabled by default
+//! - sync-default = false (project-level) → skills disabled by default
+//! - Toggling a skill from false→true populates the skill dir on next sync
+//! - Toggling from true→false documents that cleanup is not yet implemented
+
+use expect_test::expect;
+
+fn read_project_config(ctx: &symposium_testlib::TestContext) -> String {
+    let path = ctx
+        .workspace_root
+        .as_ref()
+        .unwrap()
+        .join(".symposium")
+        .join("config.toml");
+    std::fs::read_to_string(&path).unwrap_or_else(|_| "(not found)".to_string())
+}
+
+fn skill_dir_populated(ctx: &symposium_testlib::TestContext, skill_name: &str) -> bool {
+    let root = ctx.workspace_root.as_ref().unwrap();
+    root.join(".claude").join("skills").join(skill_name).join("SKILL.md").exists()
+}
+
+// -----------------------------------------------------------------------
+// Scenario 1: Initial sync with no applicable skills, then add a dep
+// -----------------------------------------------------------------------
+
+/// Start with a workspace that has no deps matching any skill plugin.
+/// Add serde to Cargo.toml, re-sync, and observe the skill appears
+/// with the default value (false, since ProjectConfig defaults sync-default=false).
+#[tokio::test]
+async fn no_skills_then_add_dep_discovers_skill_default_off() {
+    let mut ctx = symposium_testlib::with_fixture(&["plugins0", "workspace-noserde0"]);
+
+    ctx.symposium(&["init", "--user", "--add-agent", "claude"])
+        .await
+        .unwrap();
+    ctx.symposium(&["init", "--project"]).await.unwrap();
+
+    let workspace_root = ctx.workspace_root.clone().unwrap();
+
+    // Initial state: no serde skill discovered (workspace has no serde dep)
+    let config = symposium::config::ProjectConfig::load(&workspace_root).unwrap();
+    assert!(
+        !config.skills.contains_key("serde"),
+        "should not discover serde skill without serde dep, got: {:?}",
+        config.skills
+    );
+
+    expect![[r#"
+        sync-default = false
+        agent = []
+        self-contained = false
+        plugin-source = []
+
+        [skills]
+
+        [workflows]
+    "#]]
+    .assert_eq(&read_project_config(&ctx));
+
+    // Add serde dependency to Cargo.toml
+    let cargo_path = workspace_root.join("Cargo.toml");
+    let mut cargo = std::fs::read_to_string(&cargo_path).unwrap();
+    cargo.push_str("serde = \"1.0\"\n");
+    std::fs::write(&cargo_path, &cargo).unwrap();
+
+    // Simulate what the hook does: run sync --workspace
+    ctx.symposium(&["sync", "--workspace"]).await.unwrap();
+
+    // Now serde skill should appear, defaulting to false (project sync-default = false)
+    let config = symposium::config::ProjectConfig::load(&workspace_root).unwrap();
+    assert_eq!(
+        config.skills.get("serde"),
+        Some(&false),
+        "newly discovered skill should default to false"
+    );
+
+    // Sync agent — disabled skill should NOT be installed
+    ctx.symposium(&["sync", "--agent"]).await.unwrap();
+    assert!(
+        !skill_dir_populated(&ctx, "serde-guidance"),
+        "disabled skill should not be installed"
+    );
+}
+
+// -----------------------------------------------------------------------
+// Scenario 2: sync-default = true at project level
+// -----------------------------------------------------------------------
+
+/// When the project config has sync-default = true, newly discovered skills
+/// should be enabled by default and installed on sync --agent.
+#[tokio::test]
+async fn sync_default_true_enables_and_installs_skill() {
+    let mut ctx = symposium_testlib::with_fixture(&["plugins0", "workspace-noserde0"]);
+
+    ctx.symposium(&["init", "--user", "--add-agent", "claude"])
+        .await
+        .unwrap();
+    ctx.symposium(&["init", "--project"]).await.unwrap();
+
+    let workspace_root = ctx.workspace_root.clone().unwrap();
+
+    // Set sync-default = true in project config
+    let config_path = workspace_root.join(".symposium").join("config.toml");
+    let content = std::fs::read_to_string(&config_path).unwrap();
+    let content = content.replace("sync-default = false", "sync-default = true");
+    std::fs::write(&config_path, &content).unwrap();
+
+    // Add serde dependency
+    let cargo_path = workspace_root.join("Cargo.toml");
+    let mut cargo = std::fs::read_to_string(&cargo_path).unwrap();
+    cargo.push_str("serde = \"1.0\"\n");
+    std::fs::write(&cargo_path, &cargo).unwrap();
+
+    // Sync workspace — skill should appear as enabled
+    ctx.symposium(&["sync", "--workspace"]).await.unwrap();
+
+    let config = symposium::config::ProjectConfig::load(&workspace_root).unwrap();
+    assert_eq!(
+        config.skills.get("serde"),
+        Some(&true),
+        "newly discovered skill should default to true when sync-default = true"
+    );
+
+    // Sync agent — enabled skill should be installed
+    ctx.symposium(&["sync", "--agent"]).await.unwrap();
+    assert!(
+        skill_dir_populated(&ctx, "serde-guidance"),
+        "enabled skill should be installed"
+    );
+}
+
+// -----------------------------------------------------------------------
+// Scenario 3: Toggle skill false → true → false
+// -----------------------------------------------------------------------
+
+/// Start with skill disabled, enable it and sync (skill installed),
+/// then disable it and sync again (skill removed).
+#[tokio::test]
+async fn toggle_skill_false_to_true_installs() {
+    let mut ctx = symposium_testlib::with_fixture(&["plugins0", "workspace0"]);
+
+    ctx.symposium(&["init", "--user", "--add-agent", "claude"])
+        .await
+        .unwrap();
+    ctx.symposium(&["init", "--project"]).await.unwrap();
+
+    let workspace_root = ctx.workspace_root.clone().unwrap();
+    let config_path = workspace_root.join(".symposium").join("config.toml");
+
+    // Verify skill starts disabled
+    let config = symposium::config::ProjectConfig::load(&workspace_root).unwrap();
+    assert_eq!(config.skills.get("serde"), Some(&false));
+
+    // Skill should not be installed yet
+    ctx.symposium(&["sync", "--agent"]).await.unwrap();
+    assert!(
+        !skill_dir_populated(&ctx, "serde-guidance"),
+        "disabled skill should not be installed"
+    );
+
+    // Enable the skill
+    let content = std::fs::read_to_string(&config_path).unwrap();
+    let content = content.replace("serde = false", "serde = true");
+    std::fs::write(&config_path, &content).unwrap();
+
+    // Sync agent — should install the skill
+    ctx.symposium(&["sync", "--agent"]).await.unwrap();
+    assert!(
+        skill_dir_populated(&ctx, "serde-guidance"),
+        "enabled skill should be installed after sync"
+    );
+
+    // Disable the skill again
+    let content = std::fs::read_to_string(&config_path).unwrap();
+    let content = content.replace("serde = true", "serde = false");
+    std::fs::write(&config_path, &content).unwrap();
+
+    // Sync agent — currently install_skills only installs enabled skills,
+    // it does NOT remove previously-installed disabled ones.
+    ctx.symposium(&["sync", "--agent"]).await.unwrap();
+
+    // BUG/GAP: the skill directory is still present after disabling.
+    // sync --agent should clean up skill dirs for disabled skills.
+    let still_present = skill_dir_populated(&ctx, "serde-guidance");
+    assert!(
+        still_present,
+        "skill directory is NOT cleaned up when disabled (known gap — \
+         sync --agent only installs, doesn't remove)"
+    );
+}
+

--- a/tests/skill_sync_options.rs
+++ b/tests/skill_sync_options.rs
@@ -194,3 +194,55 @@ async fn toggle_skill_false_to_true_installs() {
     );
 }
 
+
+// -----------------------------------------------------------------------
+// Scenario 4: Hook invocation should trigger skill installation via sync
+// -----------------------------------------------------------------------
+
+/// Enable a skill, then invoke a PostToolUse hook (simulating a file write).
+/// BUG: execute_hook does not run sync --agent, so the skill is NOT installed.
+/// The sync side-effect only lives in the CLI run() path.
+#[tokio::test]
+async fn hook_does_not_trigger_sync_bug() {
+    let mut ctx = symposium_testlib::with_fixture(&["plugins0", "workspace0"]);
+
+    ctx.symposium(&["init", "--user", "--add-agent", "claude"])
+        .await
+        .unwrap();
+    ctx.symposium(&["init", "--project"]).await.unwrap();
+
+    let workspace_root = ctx.workspace_root.clone().unwrap();
+    let config_path = workspace_root.join(".symposium").join("config.toml");
+
+    // Skill starts disabled, not installed
+    assert!(!skill_dir_populated(&ctx, "serde-guidance"));
+
+    // Enable the skill in config
+    let content = std::fs::read_to_string(&config_path).unwrap();
+    std::fs::write(&config_path, content.replace("serde = false", "serde = true")).unwrap();
+
+    // Invoke a hook — this SHOULD install the skill, but doesn't because
+    // execute_hook() doesn't run the sync side-effect.
+    use symposium::hook::HookEvent;
+    use symposium::hook_schema::HookAgent;
+    ctx.invoke_hook(
+        HookAgent::Claude,
+        HookEvent::PostToolUse,
+        &serde_json::json!({
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Write",
+            "tool_input": {"file_path": "src/main.rs", "content": "fn main() {}"},
+            "tool_response": {"success": true},
+            "session_id": "s1",
+            "cwd": workspace_root.to_string_lossy().to_string(),
+        }),
+    )
+    .await
+    .unwrap();
+
+    // BUG: skill is NOT installed because sync only runs in CLI run() path
+    assert!(
+        !skill_dir_populated(&ctx, "serde-guidance"),
+        "BUG: execute_hook does not run sync, so skill is not installed"
+    );
+}

--- a/tests/skill_sync_options.rs
+++ b/tests/skill_sync_options.rs
@@ -194,16 +194,14 @@ async fn toggle_skill_false_to_true_installs() {
     );
 }
 
-
 // -----------------------------------------------------------------------
-// Scenario 4: Hook invocation should trigger skill installation via sync
+// Scenario 4: Hook invocation triggers skill installation via sync
 // -----------------------------------------------------------------------
 
 /// Enable a skill, then invoke a PostToolUse hook (simulating a file write).
-/// BUG: execute_hook does not run sync --agent, so the skill is NOT installed.
-/// The sync side-effect only lives in the CLI run() path.
+/// The sync side-effect inside execute_hook should install the skill.
 #[tokio::test]
-async fn hook_does_not_trigger_sync_bug() {
+async fn toggle_skill_then_hook_installs() {
     let mut ctx = symposium_testlib::with_fixture(&["plugins0", "workspace0"]);
 
     ctx.symposium(&["init", "--user", "--add-agent", "claude"])
@@ -221,8 +219,7 @@ async fn hook_does_not_trigger_sync_bug() {
     let content = std::fs::read_to_string(&config_path).unwrap();
     std::fs::write(&config_path, content.replace("serde = false", "serde = true")).unwrap();
 
-    // Invoke a hook — this SHOULD install the skill, but doesn't because
-    // execute_hook() doesn't run the sync side-effect.
+    // Invoke a hook — the sync side-effect should install the skill
     use symposium::hook::HookEvent;
     use symposium::hook_schema::HookAgent;
     ctx.invoke_hook(
@@ -240,9 +237,9 @@ async fn hook_does_not_trigger_sync_bug() {
     .await
     .unwrap();
 
-    // BUG: skill is NOT installed because sync only runs in CLI run() path
     assert!(
-        !skill_dir_populated(&ctx, "serde-guidance"),
-        "BUG: execute_hook does not run sync, so skill is not installed"
+        skill_dir_populated(&ctx, "serde-guidance"),
+        "hook's sync side-effect should install the enabled skill"
     );
 }
+

--- a/tests/skill_sync_options.rs
+++ b/tests/skill_sync_options.rs
@@ -180,17 +180,12 @@ async fn toggle_skill_false_to_true_installs() {
     let content = content.replace("serde = true", "serde = false");
     std::fs::write(&config_path, &content).unwrap();
 
-    // Sync agent — currently install_skills only installs enabled skills,
-    // it does NOT remove previously-installed disabled ones.
+    // Sync agent — should remove the disabled skill directory
     ctx.symposium(&["sync", "--agent"]).await.unwrap();
 
-    // BUG/GAP: the skill directory is still present after disabling.
-    // sync --agent should clean up skill dirs for disabled skills.
-    let still_present = skill_dir_populated(&ctx, "serde-guidance");
     assert!(
-        still_present,
-        "skill directory is NOT cleaned up when disabled (known gap — \
-         sync --agent only installs, doesn't remove)"
+        !skill_dir_populated(&ctx, "serde-guidance"),
+        "disabled skill directory should be removed after sync"
     );
 }
 

--- a/tests/skill_sync_options.rs
+++ b/tests/skill_sync_options.rs
@@ -1,11 +1,10 @@
 //! Integration tests for skill syncing with different sync-default configurations.
 //!
 //! Covers:
-//! - Initial sync with no applicable skills → add dep → re-sync → skill appears
-//! - sync-default = true (project-level) → skills enabled by default
-//! - sync-default = false (project-level) → skills disabled by default
-//! - Toggling a skill from false→true populates the skill dir on next sync
-//! - Toggling from true→false documents that cleanup is not yet implemented
+//! - Initial sync with no applicable skills → add dep → re-sync → skill appears enabled
+//! - sync-default = false (opt-out) → skills disabled by default
+//! - Toggling a skill true→false removes the skill dir, false→true reinstalls
+//! - Hook invocation triggers skill installation via sync side-effect
 
 use expect_test::expect;
 
@@ -21,18 +20,22 @@ fn read_project_config(ctx: &symposium_testlib::TestContext) -> String {
 
 fn skill_dir_populated(ctx: &symposium_testlib::TestContext, skill_name: &str) -> bool {
     let root = ctx.workspace_root.as_ref().unwrap();
-    root.join(".claude").join("skills").join(skill_name).join("SKILL.md").exists()
+    root.join(".claude")
+        .join("skills")
+        .join(skill_name)
+        .join("SKILL.md")
+        .exists()
 }
 
 // -----------------------------------------------------------------------
-// Scenario 1: Initial sync with no applicable skills, then add a dep
+// Scenario 1: Add a dep and see the skill enabled by default
 // -----------------------------------------------------------------------
 
 /// Start with a workspace that has no deps matching any skill plugin.
 /// Add serde to Cargo.toml, re-sync, and observe the skill appears
-/// with the default value (false, since ProjectConfig defaults sync-default=false).
+/// enabled by default (sync-default = true).
 #[tokio::test]
-async fn no_skills_then_add_dep_discovers_skill_default_off() {
+async fn no_skills_then_add_dep_discovers_skill_default_on() {
     let mut ctx = symposium_testlib::with_fixture(&["plugins0", "workspace-noserde0"]);
 
     ctx.symposium(&["init", "--user", "--add-agent", "claude"])
@@ -51,7 +54,7 @@ async fn no_skills_then_add_dep_discovers_skill_default_off() {
     );
 
     expect![[r#"
-        sync-default = false
+        sync-default = true
         agent = []
         self-contained = false
         plugin-source = []
@@ -62,68 +65,21 @@ async fn no_skills_then_add_dep_discovers_skill_default_off() {
     "#]]
     .assert_eq(&read_project_config(&ctx));
 
-    // Add serde dependency to Cargo.toml
-    let cargo_path = workspace_root.join("Cargo.toml");
-    let mut cargo = std::fs::read_to_string(&cargo_path).unwrap();
-    cargo.push_str("serde = \"1.0\"\n");
-    std::fs::write(&cargo_path, &cargo).unwrap();
-
-    // Simulate what the hook does: run sync --workspace
-    ctx.symposium(&["sync", "--workspace"]).await.unwrap();
-
-    // Now serde skill should appear, defaulting to false (project sync-default = false)
-    let config = symposium::config::ProjectConfig::load(&workspace_root).unwrap();
-    assert_eq!(
-        config.skills.get("serde"),
-        Some(&false),
-        "newly discovered skill should default to false"
-    );
-
-    // Sync agent — disabled skill should NOT be installed
-    ctx.symposium(&["sync", "--agent"]).await.unwrap();
-    assert!(
-        !skill_dir_populated(&ctx, "serde-guidance"),
-        "disabled skill should not be installed"
-    );
-}
-
-// -----------------------------------------------------------------------
-// Scenario 2: sync-default = true at project level
-// -----------------------------------------------------------------------
-
-/// When the project config has sync-default = true, newly discovered skills
-/// should be enabled by default and installed on sync --agent.
-#[tokio::test]
-async fn sync_default_true_enables_and_installs_skill() {
-    let mut ctx = symposium_testlib::with_fixture(&["plugins0", "workspace-noserde0"]);
-
-    ctx.symposium(&["init", "--user", "--add-agent", "claude"])
-        .await
-        .unwrap();
-    ctx.symposium(&["init", "--project"]).await.unwrap();
-
-    let workspace_root = ctx.workspace_root.clone().unwrap();
-
-    // Set sync-default = true in project config
-    let config_path = workspace_root.join(".symposium").join("config.toml");
-    let content = std::fs::read_to_string(&config_path).unwrap();
-    let content = content.replace("sync-default = false", "sync-default = true");
-    std::fs::write(&config_path, &content).unwrap();
-
     // Add serde dependency
     let cargo_path = workspace_root.join("Cargo.toml");
     let mut cargo = std::fs::read_to_string(&cargo_path).unwrap();
     cargo.push_str("serde = \"1.0\"\n");
     std::fs::write(&cargo_path, &cargo).unwrap();
 
-    // Sync workspace — skill should appear as enabled
+    // Sync workspace
     ctx.symposium(&["sync", "--workspace"]).await.unwrap();
 
+    // Skill should appear enabled by default
     let config = symposium::config::ProjectConfig::load(&workspace_root).unwrap();
     assert_eq!(
         config.skills.get("serde"),
         Some(&true),
-        "newly discovered skill should default to true when sync-default = true"
+        "newly discovered skill should default to true"
     );
 
     // Sync agent — enabled skill should be installed
@@ -135,13 +91,60 @@ async fn sync_default_true_enables_and_installs_skill() {
 }
 
 // -----------------------------------------------------------------------
-// Scenario 3: Toggle skill false → true → false
+// Scenario 2: sync-default = false (opt-out)
 // -----------------------------------------------------------------------
 
-/// Start with skill disabled, enable it and sync (skill installed),
-/// then disable it and sync again (skill removed).
+/// When the project config has sync-default = false, newly discovered skills
+/// should be disabled by default and not installed.
 #[tokio::test]
-async fn toggle_skill_false_to_true_installs() {
+async fn sync_default_false_disables_skill() {
+    let mut ctx = symposium_testlib::with_fixture(&["plugins0", "workspace-noserde0"]);
+
+    ctx.symposium(&["init", "--user", "--add-agent", "claude"])
+        .await
+        .unwrap();
+    ctx.symposium(&["init", "--project"]).await.unwrap();
+
+    let workspace_root = ctx.workspace_root.clone().unwrap();
+
+    // Opt out: set sync-default = false
+    let config_path = workspace_root.join(".symposium").join("config.toml");
+    let content = std::fs::read_to_string(&config_path).unwrap();
+    std::fs::write(&config_path, content.replace("sync-default = true", "sync-default = false"))
+        .unwrap();
+
+    // Add serde dependency
+    let cargo_path = workspace_root.join("Cargo.toml");
+    let mut cargo = std::fs::read_to_string(&cargo_path).unwrap();
+    cargo.push_str("serde = \"1.0\"\n");
+    std::fs::write(&cargo_path, &cargo).unwrap();
+
+    // Sync workspace — skill should appear as disabled
+    ctx.symposium(&["sync", "--workspace"]).await.unwrap();
+
+    let config = symposium::config::ProjectConfig::load(&workspace_root).unwrap();
+    assert_eq!(
+        config.skills.get("serde"),
+        Some(&false),
+        "newly discovered skill should default to false when sync-default = false"
+    );
+
+    // Sync agent — disabled skill should NOT be installed
+    ctx.symposium(&["sync", "--agent"]).await.unwrap();
+    assert!(
+        !skill_dir_populated(&ctx, "serde-guidance"),
+        "disabled skill should not be installed"
+    );
+}
+
+// -----------------------------------------------------------------------
+// Scenario 3: Toggle skill true → false → true
+// -----------------------------------------------------------------------
+
+/// Skill starts enabled (default). Disable it → skill dir removed.
+/// Re-enable it → skill dir reinstalled.
+#[tokio::test]
+async fn toggle_skill_true_to_false_removes_then_reinstalls() {
     let mut ctx = symposium_testlib::with_fixture(&["plugins0", "workspace0"]);
 
     ctx.symposium(&["init", "--user", "--add-agent", "claude"])
@@ -152,40 +155,36 @@ async fn toggle_skill_false_to_true_installs() {
     let workspace_root = ctx.workspace_root.clone().unwrap();
     let config_path = workspace_root.join(".symposium").join("config.toml");
 
-    // Verify skill starts disabled
+    // Skill starts enabled
     let config = symposium::config::ProjectConfig::load(&workspace_root).unwrap();
-    assert_eq!(config.skills.get("serde"), Some(&false));
+    assert_eq!(config.skills.get("serde"), Some(&true));
 
-    // Skill should not be installed yet
+    // Skill should be installed
+    assert!(
+        skill_dir_populated(&ctx, "serde-guidance"),
+        "enabled skill should be installed after init"
+    );
+
+    // Disable the skill
+    let content = std::fs::read_to_string(&config_path).unwrap();
+    std::fs::write(&config_path, content.replace("serde = true", "serde = false")).unwrap();
+
+    // Sync agent — should remove the skill directory
     ctx.symposium(&["sync", "--agent"]).await.unwrap();
     assert!(
         !skill_dir_populated(&ctx, "serde-guidance"),
-        "disabled skill should not be installed"
+        "disabled skill directory should be removed"
     );
 
-    // Enable the skill
+    // Re-enable the skill
     let content = std::fs::read_to_string(&config_path).unwrap();
-    let content = content.replace("serde = false", "serde = true");
-    std::fs::write(&config_path, &content).unwrap();
+    std::fs::write(&config_path, content.replace("serde = false", "serde = true")).unwrap();
 
-    // Sync agent — should install the skill
+    // Sync agent — should reinstall
     ctx.symposium(&["sync", "--agent"]).await.unwrap();
     assert!(
         skill_dir_populated(&ctx, "serde-guidance"),
-        "enabled skill should be installed after sync"
-    );
-
-    // Disable the skill again
-    let content = std::fs::read_to_string(&config_path).unwrap();
-    let content = content.replace("serde = true", "serde = false");
-    std::fs::write(&config_path, &content).unwrap();
-
-    // Sync agent — should remove the disabled skill directory
-    ctx.symposium(&["sync", "--agent"]).await.unwrap();
-
-    assert!(
-        !skill_dir_populated(&ctx, "serde-guidance"),
-        "disabled skill directory should be removed after sync"
+        "re-enabled skill should be reinstalled"
     );
 }
 
@@ -193,7 +192,7 @@ async fn toggle_skill_false_to_true_installs() {
 // Scenario 4: Hook invocation triggers skill installation via sync
 // -----------------------------------------------------------------------
 
-/// Enable a skill, then invoke a PostToolUse hook (simulating a file write).
+/// Disable a skill, then re-enable it and invoke a PostToolUse hook.
 /// The sync side-effect inside execute_hook should install the skill.
 #[tokio::test]
 async fn toggle_skill_then_hook_installs() {
@@ -207,10 +206,15 @@ async fn toggle_skill_then_hook_installs() {
     let workspace_root = ctx.workspace_root.clone().unwrap();
     let config_path = workspace_root.join(".symposium").join("config.toml");
 
-    // Skill starts disabled, not installed
+    // Disable the skill (it starts enabled)
+    let content = std::fs::read_to_string(&config_path).unwrap();
+    std::fs::write(&config_path, content.replace("serde = true", "serde = false")).unwrap();
+
+    // Sync to remove it
+    ctx.symposium(&["sync", "--agent"]).await.unwrap();
     assert!(!skill_dir_populated(&ctx, "serde-guidance"));
 
-    // Enable the skill in config
+    // Re-enable the skill
     let content = std::fs::read_to_string(&config_path).unwrap();
     std::fs::write(&config_path, content.replace("serde = false", "serde = true")).unwrap();
 
@@ -237,4 +241,3 @@ async fn toggle_skill_then_hook_installs() {
         "hook's sync side-effect should install the enabled skill"
     );
 }
-


### PR DESCRIPTION
## What does this PR do?

Adds comprehensive integration tests for skill syncing across different `sync-default` configurations, and fixes three bugs discovered while writing them.

**Bug fixes**

1. **`execute_hook` didn't run sync** — The `sync --agent` side-effect only ran in the CLI `run()` path. Any caller of `execute_hook()` directly (including future MCP consumers) would never trigger skill installation during hooks. Moved the sync into `execute_hook()` so it fires for all callers.

2. **Disabled skills left installed on disk** — `sync --agent` only installed enabled skills but never cleaned up disabled ones. Now removes the skill directory when a skill is set to `false` in the project config.

3. **`sync-default` was `false` on init** — `ProjectConfig`'s derived `Default` gave `sync_default: false` (Rust bool default), even though the serde annotation defaulted to `true`. This meant `init --project` created configs requiring users to opt *in* to skill activation. Replaced with a manual `Default` impl that sets `sync_default: true`.

**Tests**

New `tests/skill_sync_options.rs` with four scenarios:

| Test | What it covers |
|------|---------------|
| `no_skills_then_add_dep_discovers_skill_default_on` | No matching skills → add serde dep → sync → skill appears enabled by default |
| `sync_default_false_disables_skill` | Opt-out: set `sync-default = false` → newly discovered skills are disabled |
| `toggle_skill_true_to_false_removes_then_reinstalls` | Disable → skill dir removed; re-enable → reinstalled |
| `toggle_skill_then_hook_installs` | Re-enable skill, invoke `PostToolUse` hook → sync side-effect installs it |

New fixture `tests/fixtures/workspace-noserde0/` (workspace with only tokio, no serde) to support the "no initial skills" scenario.

The `execute_hook` bug is demonstrated with a failing-then-fixed test sequence (commits 2→3).

<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

* The AI tool authored large parts of the code

**Confidence level.**

* I am very happy with it

**Questions for reviewers.**

<!-- Any specific areas of uncertainty or things you'd like reviewers to look at? -->

</details>
