### PR TITLE
Plugin validatation

### DIFF
--- a/src/bin/symposium.rs
+++ b/src/bin/symposium.rs
@@ -207,8 +207,5 @@ fn print_validation_result(r: &plugins::ValidationResult, indent: &str) -> usize
 }
 
 fn count_results(results: &[plugins::ValidationResult]) -> usize {
-    results
-        .iter()
-        .map(|r| 1 + count_results(&r.children))
-        .sum()
+    results.iter().map(|r| 1 + count_results(&r.children)).sum()
 }

--- a/src/bin/symposium.rs
+++ b/src/bin/symposium.rs
@@ -114,22 +114,14 @@ async fn handle_plugin_command(sym: &config::Symposium, command: PluginCommand) 
                             return ExitCode::FAILURE;
                         }
                         for r in &results {
-                            match &r.result {
-                                Ok(()) => {
-                                    println!("ok: {} ({})", r.path.display(), r.kind);
-                                }
-                                Err(e) => {
-                                    eprintln!("FAIL: {} ({}): {e}", r.path.display(), r.kind);
-                                    errors += 1;
-                                }
-                            }
+                            errors += print_validation_result(r, "  ");
                         }
-                        let total = results.len();
+                        let total = count_results(&results);
                         let passed = total - errors;
-                        println!("\n{passed}/{total} valid");
+                        println!("\n  {passed}/{total} valid");
                     }
                     Err(e) => {
-                        eprintln!("{}: {e}", path.display());
+                        eprintln!("✗ {}: {e}", path.display());
                         return ExitCode::FAILURE;
                     }
                 }
@@ -139,21 +131,21 @@ async fn handle_plugin_command(sym: &config::Symposium, command: PluginCommand) 
                         Ok(crate_names) => {
                             if !crate_names.is_empty() {
                                 println!(
-                                    "\nChecking {} crate name(s) on crates.io...",
+                                    "\n📦 Checking {} crate name(s) on crates.io...",
                                     crate_names.len()
                                 );
                                 for name in &crate_names {
                                     if plugins::check_crate_exists(name).await {
-                                        println!("  ok: {name}");
+                                        println!("  ✅ {name}");
                                     } else {
-                                        eprintln!("  FAIL: {name} not found on crates.io");
+                                        eprintln!("  ✗ {name} — not found on crates.io");
                                         errors += 1;
                                     }
                                 }
                             }
                         }
                         Err(e) => {
-                            eprintln!("failed to collect crate names: {e}");
+                            eprintln!("✗ failed to collect crate names: {e}");
                             errors += 1;
                         }
                     }
@@ -190,4 +182,33 @@ async fn handle_plugin_command(sym: &config::Symposium, command: PluginCommand) 
             }
         },
     }
+}
+
+fn print_validation_result(r: &plugins::ValidationResult, indent: &str) -> usize {
+    let mut errors = 0;
+    match &r.result {
+        Ok(()) => {
+            if let Some(ref w) = r.warning {
+                println!("{indent}⚠️  {} ({}): {w}", r.path.display(), r.kind);
+            } else {
+                println!("{indent}✅ {} ({})", r.path.display(), r.kind);
+            }
+        }
+        Err(e) => {
+            eprintln!("{indent}✗ {} ({}): {e}", r.path.display(), r.kind);
+            errors += 1;
+        }
+    }
+    let child_indent = format!("{indent}    ");
+    for child in &r.children {
+        errors += print_validation_result(child, &child_indent);
+    }
+    errors
+}
+
+fn count_results(results: &[plugins::ValidationResult]) -> usize {
+    results
+        .iter()
+        .map(|r| 1 + count_results(&r.children))
+        .sum()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -112,6 +112,7 @@ impl Default for DefaultsConfig {
 
 /// A configured plugin source — either a git repository or a local path.
 #[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct PluginSourceConfig {
     /// Display name for this source.
     pub name: String,

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -28,6 +28,7 @@ pub struct PluginMcpServer {
 
 /// Source declaration for remote plugin artifacts.
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct PluginSource {
     /// Path on the local filesystem.
     pub path: Option<PathBuf>,
@@ -41,6 +42,7 @@ pub struct PluginSource {
 /// Each group declares which crates it advises on (`crates`) and
 /// optionally a remote source for the skill files.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SkillGroup {
     /// Crate predicates this group advises on (e.g., `["serde", "serde_json>=1.0"]`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -110,11 +112,15 @@ impl Plugin {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct Installation {
+    #[serde(default)]
+    pub summary: Option<String>,
     pub commands: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct Hook {
     pub name: String,
     pub event: HookEvent,
@@ -202,6 +208,7 @@ struct SourceDirContents {
 
 /// Raw TOML manifest deserialized from a plugin `.toml` file.
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct PluginManifest {
     name: String,
     crates: Vec<crate::predicate::Predicate>,
@@ -575,6 +582,10 @@ pub struct ValidationResult {
     pub kind: ValidationKind,
     /// `Ok(())` if valid, `Err` with the validation error.
     pub result: Result<()>,
+    /// Optional warning (non-fatal).
+    pub warning: Option<String>,
+    /// Child results (e.g., skills belonging to a plugin).
+    pub children: Vec<ValidationResult>,
 }
 
 /// The kind of item that was validated.
@@ -600,30 +611,78 @@ impl std::fmt::Display for ValidationKind {
 pub fn validate_source_dir(dir: &Path) -> Result<Vec<ValidationResult>> {
     let contents = scan_source_dir(dir)?;
     let mut results = Vec::new();
+    let mut plugin_skill_dirs: Vec<PathBuf> = Vec::new();
 
     for plugin_result in contents.plugins {
-        let (path, result) = match plugin_result {
-            Ok(parsed) => (parsed.path, Ok(())),
+        let (path, plugin, result) = match plugin_result {
+            Ok(parsed) => (parsed.path.clone(), Some(parsed), Ok(())),
             Err(e) => {
-                // Extract the path from the error context if possible,
-                // otherwise use a placeholder.
                 let path = dir.join("<unknown>.toml");
-                (path, Err(e))
+                (path, None, Err(e))
             }
         };
+
+        let mut children = Vec::new();
+
+        // Validate that local skill groups contain discoverable skills.
+        if let Some(parsed) = &plugin {
+            let plugin_dir = parsed.path.parent().unwrap_or(dir);
+            for group in &parsed.plugin.skills {
+                if let Some(ref rel_path) = group.source.path {
+                    let joined = plugin_dir.join(rel_path);
+                    let skills_dir: PathBuf = joined.components().collect();
+                    plugin_skill_dirs.push(skills_dir.clone());
+                    let found = crate::skills::discover_skills(&skills_dir, group);
+                    if found.is_empty() {
+                        children.push(ValidationResult {
+                            path: skills_dir,
+                            kind: ValidationKind::Skill,
+                            result: Ok(()),
+                            warning: Some(
+                                "skill group source.path contains no SKILL.md files".into(),
+                            ),
+                            children: Vec::new(),
+                        });
+                    } else {
+                        for skill_result in found {
+                            let (skill_path, result) = match skill_result {
+                                Ok(skill) => (skill.path.clone(), Ok(())),
+                                Err(e) => (skills_dir.join("SKILL.md"), Err(e)),
+                            };
+                            children.push(ValidationResult {
+                                path: skill_path,
+                                kind: ValidationKind::Skill,
+                                result,
+                                warning: None,
+                                children: Vec::new(),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
         results.push(ValidationResult {
-            path,
+            path: path.clone(),
             kind: ValidationKind::Plugin,
             result,
+            warning: None,
+            children,
         });
     }
 
     for skill_md in contents.skill_files {
+        // Skip skills already validated as part of a plugin group.
+        if plugin_skill_dirs.iter().any(|d| skill_md.starts_with(d)) {
+            continue;
+        }
         let result = crate::skills::load_standalone_skill(&skill_md).map(|_| ());
         results.push(ValidationResult {
             path: skill_md,
             kind: ValidationKind::Skill,
             result,
+            warning: None,
+            children: Vec::new(),
         });
     }
 
@@ -1118,6 +1177,22 @@ mod tests {
     async fn check_crate_exists_on_crates_io() {
         assert!(check_crate_exists("serde").await);
         assert!(!check_crate_exists("this-crate-definitely-does-not-exist-zzz").await);
+    }
+
+    #[test]
+    fn path_at_wrong_level_is_rejected() {
+        let toml = indoc! {r#"
+            name = "Symposium"
+            crates = ["*"]
+
+            [[skills]]
+            path = "."
+        "#};
+        let err = from_str(toml).unwrap_err();
+        assert!(
+            err.to_string().contains("unknown field"),
+            "expected unknown field error, got: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What does this PR do?

**Problem:** Plugin TOML manifests silently accepted typos and misplaced fields. For example, writing `path = "."` at the `[[skills]]` level (instead of `source.path = "."`) was silently ignored by serde's default behavior. Additionally, `plugin validate` didn't check whether a plugin's local skill groups actually contained valid skills.

**Changes:**

1. Added `#[serde(deny_unknown_fields)]` to all deserialized plugin structs (`PluginSource`, `SkillGroup`, `Installation`, `Hook`, `PluginManifest`, `PluginSourceConfig`). Typos and misplaced keys now produce clear errors.

2. `plugin validate` now discovers and validates skills from a plugin's local `source.path` groups, displaying them as children of the plugin in a tree.

Sample output:

```
  ✅ /Users/nikomat/dev/symposium-recommendations/symposium/SYMPOSIUM.toml (plugin)
      ✅ /Users/nikomat/dev/symposium-recommendations/symposium/find-crate-source/SKILL.md (skill)
      ✅ /Users/nikomat/dev/symposium-recommendations/symposium/rust-best-practice/SKILL.md (skill)
  ✅ /Users/nikomat/dev/symposium-recommendations/assert-struct/SKILL.md (skill)
  ✅ /Users/nikomat/dev/symposium-recommendations/toasty/SKILL.md (skill)

  5/5 valid

📦 Checking 2 crate name(s) on crates.io...
  ✅ assert-struct
  ✅ toasty
```
