### PR TITLE
fix(hooks): match tool hooks with regex

### DIFF
--- a/md/design/common-issues.md
+++ b/md/design/common-issues.md
@@ -16,10 +16,6 @@ Copilot sends `toolArgs` as a JSON *string* (not an object). Our `CopilotPreTool
 
 `CopilotPreToolUseOutput::from_hook_output()` never maps `permissionDecision` or `permissionDecisionReason` from the builtin hook output. If a builtin handler wants to deny a tool call, the decision is silently lost in Copilot output.
 
-### `matches_matcher` uses substring instead of regex (Claude Code / Gemini)
-
-`HookSubPayload::matches_matcher()` uses `matcher.contains(&tool_name)` — a substring check. The Claude Code and Gemini references specify regex matching for tool events. Patterns like `"mcp__.*"` or `"^Bash$"` would not work correctly. Also the operand order is inverted (checks if matcher contains tool name, not if tool name matches the matcher regex).
-
 ### Gemini `SessionStart` matcher
 
 `ensure_gemini_hook_entry` uses `"matcher": ".*"` for all events including `SessionStart`. Per the Gemini reference, lifecycle events use exact-string matchers, not regex. Likely harmless in practice since `".*"` matches anything.

--- a/src/hook_schema/symposium.rs
+++ b/src/hook_schema/symposium.rs
@@ -3,6 +3,7 @@
 //! Each agent module converts to/from these types. Builtin dispatch
 //! operates entirely on these types.
 
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use super::HookEvent;
@@ -87,12 +88,14 @@ impl InputEvent {
         if matcher == "*" {
             return true;
         }
-        match self {
-            InputEvent::PreToolUse(p) => matcher.contains(&p.tool_name),
-            InputEvent::PostToolUse(p) => matcher.contains(&p.tool_name),
-            InputEvent::UserPromptSubmit(_) => true,
-            InputEvent::SessionStart(_) => true,
-        }
+
+        let tool_name = match self {
+            InputEvent::PreToolUse(p) => &p.tool_name,
+            InputEvent::PostToolUse(p) => &p.tool_name,
+            InputEvent::UserPromptSubmit(_) | InputEvent::SessionStart(_) => return true,
+        };
+
+        Regex::new(matcher).map_or(false, |re| re.is_match(tool_name))
     }
 }
 
@@ -218,5 +221,48 @@ impl super::AgentHookInput for InputEvent {
     }
     fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_matchers_use_regex_against_tool_name() {
+        let input = InputEvent::PreToolUse(PreToolUseInput {
+            tool_name: "mcp__filesystem__read".to_string(),
+            tool_input: serde_json::Value::Null,
+            session_id: None,
+            cwd: None,
+        });
+
+        assert!(input.matches_matcher("mcp__.*"));
+        assert!(input.matches_matcher("^mcp__filesystem__read$"));
+        assert!(!input.matches_matcher("^Bash$"));
+        assert!(!input.matches_matcher("^filesystem$"));
+    }
+
+    #[test]
+    fn invalid_regex_matchers_do_not_match() {
+        let input = InputEvent::PostToolUse(PostToolUseInput {
+            tool_name: "Bash".to_string(),
+            tool_input: serde_json::Value::Null,
+            tool_response: serde_json::Value::Null,
+            session_id: None,
+            cwd: None,
+        });
+
+        assert!(!input.matches_matcher("("));
+    }
+
+    #[test]
+    fn wildcard_matches_everything() {
+        let input = InputEvent::SessionStart(SessionStartInput {
+            session_id: None,
+            cwd: None,
+        });
+
+        assert!(input.matches_matcher("*"));
     }
 }


### PR DESCRIPTION
## What does this PR do?
Fixes hook matcher evaluation for Claude Code and Gemini tool hooks by treating `matcher` as a regex applied to the tool name instead of a substring check. This restores support for patterns like `mcp__.*` and `^Bash$`, and adds regression tests for regex matching and invalid patterns.
<details>
<summary>Disclosure questions</summary>


**AI disclosure.**
<!-- Symposium is an AI project. We encourage the use of agentic tooling! We do however require disclosure. The disclosure helps us to calibrate our reviews. See our [PR disclosure policy](https://symposium-dev.github.io/symposium/design/gov/ernance.html#pr-disclosure-policy). -->
<!-- Remove the items that do not apply. -->
* I used an AI tool for research, autocomplete
* The AI tool authored large parts of the code

**Confidence level.**
<!-- Remove the items that do not apply. -->
* I am very happy with it

