### PR TITLE
fix preserve updatedInput as JSON

### DIFF
--- a/md/design/common-issues.md
+++ b/md/design/common-issues.md
@@ -4,10 +4,6 @@
 
 The following issues were identified by auditing our hook implementations against the agent reference docs (`md/design/agent-details/`). They don't cause crashes (the fallback path handles events without agent-specific handlers) but mean some features are incomplete.
 
-### `updatedInput` type mismatch (Claude Code)
-
-`HookSpecificOutput.updated_input` and Claude's `ClaudeHookSpecificOutput.updated_input` are typed as `Option<String>`, but per the Claude Code reference, `updatedInput` is a JSON object (e.g., `{"command": "safe-cmd"}`). Should be `Option<serde_json::Value>`.
-
 ### `toolArgs` not parsed (Copilot)
 
 Copilot sends `toolArgs` as a JSON *string* (not an object). Our `CopilotPreToolUsePayload` declares it as `serde_json::Value` and passes it through as-is in `to_hook_payload()`. Downstream code expecting structured tool args will get a raw string. Should parse the JSON string into a `Value` during conversion.

--- a/src/hook_schema/claude.rs
+++ b/src/hook_schema/claude.rs
@@ -102,7 +102,7 @@ pub struct ClaudePreToolUseHookOutput {
     )]
     pub permission_decision_reason: Option<String>,
     #[serde(rename = "updatedInput", skip_serializing_if = "Option::is_none")]
-    pub updated_input: Option<String>,
+    pub updated_input: Option<serde_json::Value>,
     #[serde(rename = "additionalContext", skip_serializing_if = "Option::is_none")]
     pub additional_context: Option<String>,
     #[serde(flatten)]
@@ -172,9 +172,7 @@ impl AgentHookOutput for ClaudePreToolUseOutput {
         let h = self.hook_specific_output.as_ref();
         symposium::OutputEvent::PreToolUse(symposium::PreToolUseOutput {
             additional_context: h.and_then(|h| h.additional_context.clone()),
-            updated_input: h
-                .and_then(|h| h.updated_input.as_ref())
-                .and_then(|s| serde_json::from_str(s).ok()),
+            updated_input: h.and_then(|h| h.updated_input.clone()),
         })
     }
     fn to_hook_output(&self) -> serde_json::Value {
@@ -182,6 +180,36 @@ impl AgentHookOutput for ClaudePreToolUseOutput {
     }
     fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pre_tool_use_updated_input_preserves_json_object() {
+        let hook_output = ClaudePreToolUseOutput {
+            hook_specific_output: Some(ClaudePreToolUseHookOutput {
+                hook_event_name: "PreToolUse".into(),
+                permission_decision: None,
+                permission_decision_reason: None,
+                updated_input: Some(serde_json::json!({"command": "safe-cmd"})),
+                additional_context: Some("context".into()),
+                rest: serde_json::Map::new(),
+            }),
+            ..Default::default()
+        };
+
+        let symposium::OutputEvent::PreToolUse(output) = hook_output.to_symposium() else {
+            panic!("wrong output type")
+        };
+
+        assert_eq!(output.additional_context.as_deref(), Some("context"));
+        assert_eq!(
+            output.updated_input,
+            Some(serde_json::json!({"command": "safe-cmd"}))
+        );
     }
 }
 


### PR DESCRIPTION
## What does this PR do?
Fixes Claude Code `PreToolUse` `updatedInput` handling so `updatedInput` is preserved as structured JSON instead of being treated as a string and re-parsed. This avoids silent data loss and keeps Symfony’s Claude hook conversion aligned with the Claude Code spec.
<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

* I used an AI tool for research, autocomplete, or in some minimal ways
* The AI tool authored large parts of the code

**Confidence level.**
* I am very happy with it