### PR TITLE
fix(doc): Add GitHub and Zulip links.

### DIFF
--- a/md/design/governance.md
+++ b/md/design/governance.md
@@ -35,7 +35,7 @@ We want to keep moving quickly, especially in this early phase, therefore we hav
 
 ## Sync meeting
 
-We hold a regular sync meeting to discuss recent changes, plans, and direction. The meeting is open to all maintainers and contributors. If you're interested in attending, reach out to a core team member on Zulip.
+We hold a regular sync meeting to discuss recent changes, plans, and direction. The meeting is open to all maintainers and contributors. If you're interested in attending, reach out to a core team member on [Zulip](https://symposium-dev.zulipchat.com).
 
 ## Releases
 
@@ -43,4 +43,4 @@ Merging a release PR is coordinated among core team members.
 
 ## Getting involved
 
-The best way to get started is to pick up an issue, open a PR, and join the conversation on Zulip. Landing non-trivial contributions and attending the sync meeting is the path to joining the devs team.
+The best way to get started is to pick up an [issue](https://github.com/symposium-dev/symposium/issues), open a [PR](https://github.com/symposium-dev/symposium/pulls), and join the conversation on [Zulip](https://symposium-dev.zulipchat.com). Landing non-trivial contributions and attending the sync meeting is the path to joining the devs team.


### PR DESCRIPTION
## What does this PR do?

I missed the Zulip link in the blog and it took me a while to find it. It would help to have it in the Getting involved section.

**AI disclosure.**

<!-- Symposium is an AI project. We encourage the use of agentic tooling! We do however require disclosure. The disclosure helps us to calibrate our reviews. See our [PR disclosure policy](https://symposium-dev.github.io/symposium/design/governance.html#pr-disclosure-policy). -->

<!-- Remove the items that do not apply. -->

* The AI tool authored small parts of the code (e.g., autocomplete, comments)

**Confidence level.**

<!-- Remove the items that do not apply. -->

* It seems reasonable to me, I'd like to know what others think

**Questions for reviewers.**

<!-- Any specific areas of uncertainty or things you'd like reviewers to look at? -->

</details>
