### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/symposium-dev/symposium/compare/symposium-v0.2.1...symposium-v0.3.0) - 2026-05-13
+
+### Added
+
+- track installed skills via per-skill `.symposium` marker file
+- resolve crate-sourced skills during sync
+- add matched_crates predicate resolution
+- add crate_path skill source type with parse-time validation
+
+### Fixed
+
+- resolve path dependencies in crate-info command
+- *(doc)* Add GitHub and Zulip links.
+
+### Other
+
+- Merge pull request #216 from nikomatsakis/gitignore-strategy
+- pacify the merciless cargo-fmt
+- rename publishing-skills.md to authoring-a-plugin.md; add mdbook redirects
+- extract normalize_crate_name helper for hyphen/underscore equality
+- introduce CratePathSource newtype for the CratePath payload
+- make PluginSource an enum preserving shorthand vs explicit crate_path
+- rewrite crate-author documentation for crate-sourced skills
+- remove agent-specific directories
+- update stale `crate` subcommand to `crate-info`
+- Merge pull request #203 from jlizen/clippy/collapsible-if-and-plugins-misc
+- Merge pull request #205 from jlizen/clippy/trivial-mechanical
+- Merge pull request #202 from jlizen/main
+- Refactor installation schema, again
+- Refactor hook installation schema
+- Add ability to resolve hooks using distributions.
+- Merge pull request #192 from anaslimem/claude-updated-input-json
+
 ## [0.2.1](https://github.com/symposium-dev/symposium/compare/symposium-v0.2.0...symposium-v0.2.1) - 2026-04-21
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symposium"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symposium"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "AI the Rust Way"


### PR DESCRIPTION



## 🤖 New release

* `symposium`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `symposium` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field PluginRegistry.warnings in /tmp/.tmpQEaaSK/symposium/src/plugins.rs:627
  field Plugin.installations in /tmp/.tmpQEaaSK/symposium/src/plugins.rs:306
  field Installation.name in /tmp/.tmpQEaaSK/symposium/src/plugins.rs:260
  field Installation.requirements in /tmp/.tmpQEaaSK/symposium/src/plugins.rs:262
  field Installation.install_commands in /tmp/.tmpQEaaSK/symposium/src/plugins.rs:265
  field Installation.source in /tmp/.tmpQEaaSK/symposium/src/plugins.rs:269
  field Installation.executable in /tmp/.tmpQEaaSK/symposium/src/plugins.rs:274
  field Installation.script in /tmp/.tmpQEaaSK/symposium/src/plugins.rs:278
  field Installation.args in /tmp/.tmpQEaaSK/symposium/src/plugins.rs:281
  field Hook.agent in /tmp/.tmpQEaaSK/symposium/src/plugins.rs:351
  field Hook.requirements in /tmp/.tmpQEaaSK/symposium/src/plugins.rs:355
  field Hook.executable in /tmp/.tmpQEaaSK/symposium/src/plugins.rs:361
  field Hook.script in /tmp/.tmpQEaaSK/symposium/src/plugins.rs:362
  field Hook.args in /tmp/.tmpQEaaSK/symposium/src/plugins.rs:365

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_missing.ron

Failed in:
  enum symposium::git_source::UpdateLevel, previously in file /tmp/.tmp7MGOGt/symposium/src/git_source.rs:9

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/function_missing.ron

Failed in:
  function symposium::git_source::parse_github_url, previously in file /tmp/.tmp7MGOGt/symposium/src/git_source.rs:52

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/module_missing.ron

Failed in:
  mod symposium::git_source, previously in file /tmp/.tmp7MGOGt/symposium/src/git_source.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/struct_missing.ron

Failed in:
  struct symposium::git_source::PluginCacheManager, previously in file /tmp/.tmp7MGOGt/symposium/src/git_source.rs:189
  struct symposium::git_source::GitHubSource, previously in file /tmp/.tmp7MGOGt/symposium/src/git_source.rs:23
  struct symposium::git_source::PluginCacheMeta, previously in file /tmp/.tmp7MGOGt/symposium/src/git_source.rs:180
  struct symposium::git_source::GitHubClient, previously in file /tmp/.tmp7MGOGt/symposium/src/git_source.rs:93

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field summary of struct Installation, previously in file /tmp/.tmp7MGOGt/symposium/src/plugins.rs:118
  field commands of struct Installation, previously in file /tmp/.tmp7MGOGt/symposium/src/plugins.rs:119
  field installation of struct Plugin, previously in file /tmp/.tmp7MGOGt/symposium/src/plugins.rs:78

--- failure struct_with_pub_fields_changed_type: struct with pub fields became an enum or union ---

Description:
A struct with pub fields became an enum or union, breaking accesses to its public fields.
        ref: https://github.com/obi1kenobi/cargo-semver-checks/issues/297#issuecomment-1399099659
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/struct_with_pub_fields_changed_type.ron

Failed in:
  struct symposium::plugins::PluginSource became enum in file /tmp/.tmpQEaaSK/symposium/src/plugins.rs:53

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/trait_method_added.ron

Failed in:
  trait method symposium::hook_schema::ErasedAgentHookEvent::translate_output in file /tmp/.tmpQEaaSK/symposium/src/hook_schema.rs:158
  trait method symposium::hook_schema::ErasedAgentHookEvent::translate_input in file /tmp/.tmpQEaaSK/symposium/src/hook_schema.rs:161

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/trait_method_missing.ron

Failed in:
  method from_symposium_output of trait AgentHookEvent, previously in file /tmp/.tmp7MGOGt/symposium/src/hook_schema.rs:130
  method from_symposium_output of trait ErasedAgentHookEvent, previously in file /tmp/.tmp7MGOGt/symposium/src/hook_schema.rs:158
  method from_symposium_input of trait ErasedAgentHookEvent, previously in file /tmp/.tmp7MGOGt/symposium/src/hook_schema.rs:161
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/symposium-dev/symposium/compare/symposium-v0.2.1...symposium-v0.3.0) - 2026-05-13

### Added

- track installed skills via per-skill `.symposium` marker file
- resolve crate-sourced skills during sync
- add matched_crates predicate resolution
- add crate_path skill source type with parse-time validation

### Fixed

- resolve path dependencies in crate-info command
- *(doc)* Add GitHub and Zulip links.

### Other

- Merge pull request #216 from nikomatsakis/gitignore-strategy
- pacify the merciless cargo-fmt
- rename publishing-skills.md to authoring-a-plugin.md; add mdbook redirects
- extract normalize_crate_name helper for hyphen/underscore equality
- introduce CratePathSource newtype for the CratePath payload
- make PluginSource an enum preserving shorthand vs explicit crate_path
- rewrite crate-author documentation for crate-sourced skills
- remove agent-specific directories
- update stale `crate` subcommand to `crate-info`
- Merge pull request #203 from jlizen/clippy/collapsible-if-and-plugins-misc
- Merge pull request #205 from jlizen/clippy/trivial-mechanical
- Merge pull request #202 from jlizen/main
- Refactor installation schema, again
- Refactor hook installation schema
- Add ability to resolve hooks using distributions.
- Merge pull request #192 from anaslimem/claude-updated-input-json
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).