### PR TITLE
fix: update stale `symposium init` references to `cargo agents init`

### DIFF
--- a/md/introduction.md
+++ b/md/introduction.md
@@ -24,13 +24,13 @@
 
 ```bash
 cargo binstall symposium # or: cargo install symposium
-symposium init
+cargo agents init
 ```
 
 After initialization, start your agent in a Rust project as usual.
 
 - For first-time setup details, see [Installing Symposium](./install.md).
-- For command reference, see [The `symposium` command](./reference/cargo-agents.md).
+- For command reference, see [The `cargo agents` command](./reference/cargo-agents.md).
 - For agent compatibility, see [Supported agents](./reference/supported-agents.md).
 
 ## Recent posts

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,4 +1,4 @@
-//! Init command: `symposium init`.
+//! Init command: `cargo agents init`.
 
 use std::io::IsTerminal;
 use std::path::PathBuf;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -116,7 +116,7 @@ pub async fn sync(sym: &Symposium, cwd: &Path, out: &Output) -> Result<()> {
     );
 
     if agent_names.is_empty() {
-        out.info("no agents configured — run `symposium init` to add one");
+        out.info("no agents configured, run `cargo agents init` to add one");
         return Ok(());
     }
 


### PR DESCRIPTION
## What does this PR do?

Clean up some stale references to `symposium init` in the docs, they confused me in my environment setup just now since `cargo install symposium` puts `cargo-agents` on PATH (via `~/.cargo`) but not `symposium`.

**AI disclosure.**

* I used an AI tool for research, autocomplete, or in other minimal ways
* The AI tool authored small parts of the code (e.g., autocomplete, comments)
* The AI tool authored large parts of the code


**Confidence level.**

* I am very happy with it


**Questions for reviewers.**

n/a