### PR TITLE
fix: reject invalid SKILL.md YAML frontmatter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ sacp = "11"
 semver = "1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml_ng = "0.10"
 tar = "0.4"
 tempfile = "3.6"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
@@ -54,7 +55,6 @@ toml_edit = "0.25.11"
 assert_matches = "1.5"
 expect-test = "1.5.1"
 indoc = "2.0.7"
-serde_yaml_ng = "0.10"
 symposium-testlib = { path = "symposium-testlib" }
 
 [workspace]

--- a/md/design/sync-agent-flow.md
+++ b/md/design/sync-agent-flow.md
@@ -10,7 +10,7 @@ Scans workspace dependencies, installs applicable skills into agent directories,
 
 3. **Scan dependencies** — read the full dependency graph from the workspace.
 
-4. **Match skills to dependencies** — for each plugin, parse `SKILL.md` YAML frontmatter, reject malformed or non-string metadata, then evaluate skill group crate predicates and individual skill `crates` frontmatter against the workspace dependencies.
+4. **Match skills to dependencies** — for each plugin, parse `SKILL.md` YAML frontmatter, reject malformed or non-string metadata, warn about skipped invalid skills, then evaluate skill group crate predicates and individual skill `crates` frontmatter against the workspace dependencies.
 
 5. **Install skills per agent** — for each configured agent:
    - Copy applicable `SKILL.md` files into the agent's expected skill directory.

--- a/md/design/sync-agent-flow.md
+++ b/md/design/sync-agent-flow.md
@@ -10,7 +10,7 @@ Scans workspace dependencies, installs applicable skills into agent directories,
 
 3. **Scan dependencies** — read the full dependency graph from the workspace.
 
-4. **Match skills to dependencies** — for each plugin, evaluate skill group crate predicates and individual skill `crates` frontmatter against the workspace dependencies.
+4. **Match skills to dependencies** — for each plugin, parse `SKILL.md` YAML frontmatter, reject malformed or non-string metadata, then evaluate skill group crate predicates and individual skill `crates` frontmatter against the workspace dependencies.
 
 5. **Install skills per agent** — for each configured agent:
    - Copy applicable `SKILL.md` files into the agent's expected skill directory.

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -196,6 +196,17 @@ pub struct PluginRegistry {
     /// Skills discovered as standalone directories containing a `SKILL.md`
     /// file directly in a plugin source directory (no TOML manifest needed).
     pub standalone_skills: Vec<crate::skills::Skill>,
+    /// Non-fatal load warnings for plugins or standalone skills that were skipped.
+    pub warnings: Vec<LoadWarning>,
+}
+
+/// A non-fatal plugin source load failure.
+#[derive(Debug, Clone)]
+pub struct LoadWarning {
+    /// Path to the plugin or skill that was skipped.
+    pub path: PathBuf,
+    /// Human-readable error message.
+    pub message: String,
 }
 
 /// Raw scan results from a plugin source directory.
@@ -430,6 +441,7 @@ pub fn load_registry(sym: &Symposium) -> PluginRegistry {
     let sources = sym.plugin_sources();
     let mut plugins = Vec::new();
     let mut standalone_skills = Vec::new();
+    let mut warnings = Vec::new();
 
     for dir in resolve_plugin_source_dirs(sym, &sources) {
         match scan_source_dir(&dir) {
@@ -437,22 +449,38 @@ pub fn load_registry(sym: &Symposium) -> PluginRegistry {
                 for result in contents.plugins {
                     match result {
                         Ok(p) => plugins.push(p),
-                        Err(e) => tracing::warn!(error = %e, "failed to load plugin"),
+                        Err(e) => {
+                            tracing::warn!(error = %e, "failed to load plugin");
+                            warnings.push(LoadWarning {
+                                path: dir.join("<unknown>.toml"),
+                                message: format!("failed to load plugin: {e}"),
+                            });
+                        }
                     }
                 }
                 for skill_md in contents.skill_files {
                     match crate::skills::load_standalone_skill(&skill_md) {
                         Ok(skill) => standalone_skills.push(skill),
-                        Err(e) => tracing::warn!(
-                            path = %skill_md.display(),
-                            error = %e,
-                            "failed to load standalone skill"
-                        ),
+                        Err(e) => {
+                            tracing::warn!(
+                                path = %skill_md.display(),
+                                error = %e,
+                                "failed to load standalone skill"
+                            );
+                            warnings.push(LoadWarning {
+                                path: skill_md,
+                                message: format!("failed to load standalone skill: {e}"),
+                            });
+                        }
                     }
                 }
             }
             Err(e) => {
                 tracing::warn!(dir = %dir.display(), error = %e, "failed to scan plugin source dir");
+                warnings.push(LoadWarning {
+                    path: dir,
+                    message: format!("failed to scan plugin source dir: {e}"),
+                });
             }
         }
     }
@@ -466,6 +494,7 @@ pub fn load_registry(sym: &Symposium) -> PluginRegistry {
     PluginRegistry {
         plugins,
         standalone_skills,
+        warnings,
     }
 }
 

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -1148,6 +1148,30 @@ mod tests {
     }
 
     #[test]
+    fn validate_source_dir_rejects_illformed_standalone_skill() {
+        use crate::test_utils::{File, instantiate_fixture};
+        let tmp = instantiate_fixture(&[File(
+            "bad-skill/SKILL.md",
+            indoc! {"
+                ---
+                name: rust-best-practice
+                description: [Critical] Best practice for Rust coding.
+                crates: serde
+                ---
+
+                Body.
+            "},
+        )]);
+
+        let results = validate_source_dir(tmp.path()).unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(
+            results[0].result.is_err(),
+            "standalone skill with non-string YAML value should fail validation"
+        );
+    }
+
+    #[test]
     fn collect_crate_names_from_source_dir() {
         use crate::test_utils::{File, instantiate_fixture};
         let tmp = instantiate_fixture(&[

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -768,6 +768,7 @@ mod tests {
                 plugin,
             }],
             standalone_skills: vec![],
+            warnings: vec![],
         };
 
         // Query for serde - should find no skills because plugin doesn't apply
@@ -807,6 +808,7 @@ mod tests {
                 plugin,
             }],
             standalone_skills: vec![],
+            warnings: vec![],
         };
 
         // Query for serde - should find no skills because group doesn't match
@@ -867,6 +869,7 @@ mod tests {
                 plugin,
             }],
             standalone_skills: vec![],
+            warnings: vec![],
         };
 
         // Query for serde - should find the skill because all levels match
@@ -955,6 +958,7 @@ mod tests {
         let registry = PluginRegistry {
             plugins: Vec::new(),
             standalone_skills: vec![skill],
+            warnings: vec![],
         };
 
         let sym = crate::config::Symposium::from_dir(tmp.path());

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -354,6 +354,7 @@ fn collect_skills_applicable_to(
 
 /// Raw frontmatter fields extracted from a SKILL.md file.
 /// `crates` is comma-separated on a single line.
+#[derive(Debug)]
 struct RawFrontmatter {
     fields: BTreeMap<String, String>,
     /// Raw `crates` value (comma-separated predicate string).
@@ -385,24 +386,33 @@ fn parse_frontmatter(content: &str) -> Result<RawFrontmatter> {
         .strip_prefix('\n')
         .unwrap_or(after_first_fence.get(body_start..).unwrap_or(""));
 
+    let yaml: serde_yaml_ng::Value =
+        serde_yaml_ng::from_str(frontmatter_text).context("frontmatter is not valid YAML")?;
+    let mapping = yaml
+        .as_mapping()
+        .context("SKILL.md frontmatter must be a YAML mapping")?;
+
     let mut fields = BTreeMap::new();
     let mut crates = None;
 
-    for line in frontmatter_text.lines() {
-        let line = line.trim();
-        if line.is_empty() {
+    for (key, value) in mapping {
+        let Some(key) = key.as_str() else {
+            bail!("SKILL.md frontmatter keys must be strings");
+        };
+
+        if key == "applies-when" {
+            // Ignored — applies-when is no longer supported.
             continue;
         }
-        if let Some((key, value)) = line.split_once(':') {
-            let key = key.trim();
-            let value = value.trim().to_string();
-            if key == "crates" {
-                crates = Some(value);
-            } else if key == "applies-when" {
-                // Ignored — applies-when is no longer supported.
-            } else {
-                fields.insert(key.to_string(), value);
-            }
+
+        let Some(value) = value.as_str() else {
+            bail!("SKILL.md frontmatter field `{key}` must be a string");
+        };
+
+        if key == "crates" {
+            crates = Some(value.to_string());
+        } else {
+            fields.insert(key.to_string(), value.to_string());
         }
     }
 
@@ -463,6 +473,43 @@ mod tests {
         "};
         let fm = parse_frontmatter(content).unwrap();
         assert_eq!(fm.crates.as_deref(), Some("serde, serde_json>=1.0, toml"));
+    }
+
+    #[test]
+    fn parse_frontmatter_rejects_invalid_yaml_description() {
+        let content = indoc! {"
+            ---
+            name: rust-best-practice
+            description: [Critical] Best practice for Rust coding.
+            ---
+
+            Body.
+        "};
+
+        let err = parse_frontmatter(content).unwrap_err();
+        assert!(
+            err.to_string().contains("frontmatter is not valid YAML"),
+            "expected YAML parse error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_frontmatter_rejects_non_string_description() {
+        let content = indoc! {"
+            ---
+            name: rust-best-practice
+            description: [Critical]
+            ---
+
+            Body.
+        "};
+
+        let err = parse_frontmatter(content).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("frontmatter field `description` must be a string"),
+            "expected scalar string error, got: {err}"
+        );
     }
 
     #[test]
@@ -677,7 +724,7 @@ mod tests {
                 ---
                 name: bad
                 description: Bad crates skill
-                crates: >=not_valid!!
+                crates: \">=not_valid!!\"
                 ---
 
                 Body.

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -400,11 +400,6 @@ fn parse_frontmatter(content: &str) -> Result<RawFrontmatter> {
             bail!("SKILL.md frontmatter keys must be strings");
         };
 
-        if key == "applies-when" {
-            // Ignored — applies-when is no longer supported.
-            continue;
-        }
-
         let Some(value) = value.as_str() else {
             bail!("SKILL.md frontmatter field `{key}` must be a string");
         };

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -67,6 +67,14 @@ pub async fn sync(sym: &Symposium, cwd: &Path, out: &Output) -> Result<()> {
     let registry = plugins::load_registry(sym);
     let workspace = crate::crate_sources::workspace_semver_pairs(&project_root);
 
+    for warning in &registry.warnings {
+        out.warn(format!(
+            "skipping {}: {}",
+            display_path(&warning.path),
+            warning.message
+        ));
+    }
+
     out.info(format!(
         "scanning {} workspace dependencies",
         workspace.len()

--- a/tests/fixtures/invalid-skill0/dot-symposium/config.toml
+++ b/tests/fixtures/invalid-skill0/dot-symposium/config.toml
@@ -1,0 +1,5 @@
+hook-scope = "project"
+
+[defaults]
+symposium-recommendations = false
+user-plugins = true

--- a/tests/fixtures/invalid-skill0/dot-symposium/plugins/bad-skill/SKILL.md
+++ b/tests/fixtures/invalid-skill0/dot-symposium/plugins/bad-skill/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: rust-best-practice
+description: [Critical] Best practice for Rust coding.
+crates: serde
+---
+
+This should not be installed because the frontmatter is invalid YAML.

--- a/tests/init_sync.rs
+++ b/tests/init_sync.rs
@@ -120,6 +120,36 @@ async fn sync_installs_skills() {
     .unwrap();
 }
 
+/// `sync` rejects malformed skill frontmatter before installing skills.
+#[tokio::test]
+async fn sync_skips_invalid_skill_frontmatter() {
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["invalid-skill0", "workspace0"],
+        async |mut ctx| {
+            ctx.symposium(&["init", "--add-agent", "codex"]).await?;
+            ctx.symposium(&["sync"]).await?;
+
+            let workspace_root = ctx.workspace_root.as_ref().unwrap();
+            let skill_file = workspace_root.join(".agents/skills/rust-best-practice/SKILL.md");
+            assert!(
+                !skill_file.exists(),
+                "sync should not install a skill with invalid YAML frontmatter"
+            );
+
+            let manifest_path = workspace_root.join(".agents/skills/.symposium.toml");
+            let manifest = std::fs::read_to_string(&manifest_path).unwrap();
+            assert!(
+                !manifest.contains("rust-best-practice"),
+                "manifest should not track a rejected skill"
+            );
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+}
+
 /// `sync` removes stale skills tracked in the manifest.
 #[tokio::test]
 async fn sync_removes_stale_skills() {

--- a/tests/init_sync.rs
+++ b/tests/init_sync.rs
@@ -128,6 +128,15 @@ async fn sync_skips_invalid_skill_frontmatter() {
         &["invalid-skill0", "workspace0"],
         async |mut ctx| {
             ctx.symposium(&["init", "--add-agent", "codex"]).await?;
+            let registry = symposium::plugins::load_registry(&ctx.sym);
+            assert!(
+                registry.warnings.iter().any(|warning| {
+                    warning.path.ends_with("bad-skill/SKILL.md")
+                        && warning.message.contains("failed to parse frontmatter")
+                }),
+                "registry should record a warning for skipped invalid skill"
+            );
+
             ctx.symposium(&["sync"]).await?;
 
             let workspace_root = ctx.workspace_root.as_ref().unwrap();


### PR DESCRIPTION
## What does this PR do?

## Problem

Symposium parsed `SKILL.md` frontmatter with a loose line-based parser, so malformed YAML like `description: [Critical] ...` could pass validation and be installed by hook-managed sync. Agents then rejected the copied skill at startup because they parse the same frontmatter as YAML.

We are also serving some broken frontmatter in `symposium/recommendations`. That package's CI will now fail due to our tighter validation, and I'll fix it over there (https://github.com/symposium-dev/recommendations/pull/9)

## Solution

Parse skill frontmatter as YAML before matching or installing skills, require metadata fields to be strings, and add a sync regression test proving invalid skill frontmatter is skipped instead of copied into `.agents/skills`.

symposium will warn when it skips loading due to misformatted files. That might not be the right ux choice long-term, but whilst most of our users are people also developing symposium, it's probably good :)


I didn't add a snapshot test since the sync output is not designed to have i/o injected and it would have exploded the diff. Happy to follow up with that if desired.

Here's a manual test though:
```
 Running `/Users/jess/workplace/symposium/target/debug/cargo-agents sync`
⚠️  skipping /tmp/symposium-home/plugins/bad-skill/SKILL.md: failed to load standalone skill: failed to parse frontmatter in /tmp/symposium-home/plugins/bad-skill/SKILL.md
ℹ️  scanning 2 workspace dependencies
🟢 /private/tmp/symposium-workspace/.codex/hooks.json: hooks already registered
➖ removed skill rust-best-practice from /private/tmp/symposium-workspace/.agents/skills/rust-best-practice
ℹ️  no applicable skills found for workspace dependencies
```


**AI disclosure.**

* I used an AI tool for research, autocomplete, or in other minimal ways
* The AI tool authored small parts of the code (e.g., autocomplete, comments)
* The AI tool authored large parts of the code

**Confidence level.**


* I am very happy with it
