### PR TITLE
refactor: fix trivial clippy lints (needless_borrow, auto_deref, life…

### DIFF
--- a/src/agents/mcp_server_registration.rs
+++ b/src/agents/mcp_server_registration.rs
@@ -306,7 +306,7 @@ pub(super) fn unregister_codex_mcp_servers(
 
     let mut changed = false;
     for name in names {
-        if mcp_servers.remove(*name).is_some() {
+        if mcp_servers.remove(name).is_some() {
             out.removed(format!("{display}: removed {name} MCP server"));
             changed = true;
         }

--- a/src/init.rs
+++ b/src/init.rs
@@ -131,7 +131,7 @@ fn prompt_for_hook_scope(current: crate::config::HookScope) -> Result<crate::con
 
     let selection = dialoguer::Select::new()
         .with_prompt("Install hooks and agent configuration")
-        .items(&items)
+        .items(items)
         .default(default)
         .interact()?;
 
@@ -152,7 +152,7 @@ fn prompt_for_agents(existing: &[AgentEntry]) -> Result<Vec<Agent>> {
 
     let selections = MultiSelect::new()
         .with_prompt("Which agents do you use? (space to select, enter to confirm)")
-        .items(&items)
+        .items(items)
         .defaults(&defaults)
         .interact()?;
 

--- a/src/installation.rs
+++ b/src/installation.rs
@@ -246,11 +246,7 @@ fn install_cargo_crate_sync(
     Ok(())
 }
 
-pub fn get_binary_cache_dir<'sym>(
-    sym: &'sym Symposium,
-    krate: &str,
-    version: &str,
-) -> Result<PathBuf> {
+pub fn get_binary_cache_dir(sym: &Symposium, krate: &str, version: &str) -> Result<PathBuf> {
     let path = sym.cache_dir().join("binaries").join(krate).join(version);
     Ok(path)
 }

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -419,10 +419,11 @@ fn validate_installation(install: &Installation) -> Result<()> {
 /// - Not all agents have hook wire formats (e.g., Goose uses MCP extensions,
 ///   OpenCode uses JS plugins), so only agents with shell-hook JSON formats
 ///   appear here.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum HookFormat {
     /// Symposium canonical format (default).
+    #[default]
     Symposium,
     /// A specific agent's wire format.
     Claude,
@@ -430,12 +431,6 @@ pub enum HookFormat {
     Copilot,
     Gemini,
     Kiro,
-}
-
-impl Default for HookFormat {
-    fn default() -> Self {
-        HookFormat::Symposium
-    }
 }
 
 impl HookFormat {

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -220,7 +220,7 @@ async fn resolve_skill_dir(
     }
 
     if let Some(git_source) = &group.source.git {
-        match fetch_skill_source(sym, &git_source).await {
+        match fetch_skill_source(sym, git_source).await {
             Ok(path) => return Some(path),
             Err(e) => {
                 tracing::warn!(git = %git_source, error = %e, "failed to fetch skill source");


### PR DESCRIPTION
## What does this PR do?

Initial pass to address clippy lints, before adding to to CI.

This addresses:
- needless_borrow
- explicit_auto_deref
- needless_lifetimes
- derivable_impls

All seem reasonable.

They all seem fine to me.

<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

* I used an AI tool for research, autocomplete, or in other minimal ways
* The AI tool authored small parts of the code (e.g., autocomplete, comments)
* The AI tool authored large parts of the code


**Confidence level.**

<!-- Remove the items that do not apply. -->


* I am very happy with it



</details>
