### PR TITLE
refactor: rename from_symposium_* methods to translate_*

### DIFF
--- a/src/hook.rs
+++ b/src/hook.rs
@@ -194,7 +194,7 @@ pub async fn execute_hook(
 
         // Builtin dispatch → symposium output → host agent output as Value
         let builtin_sym_output = dispatch_builtin(sym, &sym_input).await;
-        let builtin_agent_output = handler.from_symposium_output(&builtin_sym_output);
+        let builtin_agent_output = handler.translate_output(&builtin_sym_output);
         let prior_output = builtin_agent_output.to_hook_output();
 
         // Plugin dispatch with format routing
@@ -393,7 +393,7 @@ pub async fn dispatch_plugin_hooks(
             let handler = target.event(event);
             match handler {
                 Some(h) => {
-                    temp_input = h.from_symposium_input(sym_input);
+                    temp_input = h.translate_input(sym_input);
                     &*temp_input
                 }
                 None => continue, // target agent doesn't support this event
@@ -460,7 +460,7 @@ pub async fn dispatch_plugin_hooks(
                             match target_h.parse_output(&child_out.stdout) {
                                 Ok(hook_out) => {
                                     let sym_out = hook_out.to_symposium();
-                                    let host_out = host_h.from_symposium_output(&sym_out);
+                                    let host_out = host_h.translate_output(&sym_out);
                                     host_out.to_hook_output()
                                 }
                                 Err(e) => {
@@ -476,7 +476,7 @@ pub async fn dispatch_plugin_hooks(
                                     if let Ok(sym_out) =
                                         serde_json::from_value::<symposium::OutputEvent>(v.clone())
                                     {
-                                        let host_out = host_h.from_symposium_output(&sym_out);
+                                        let host_out = host_h.translate_output(&sym_out);
                                         host_out.to_hook_output()
                                     } else {
                                         v // fallback: use raw JSON

--- a/src/hook_schema.rs
+++ b/src/hook_schema.rs
@@ -127,7 +127,7 @@ pub trait AgentHookEvent {
         Self::Output::parse_output(output)
     }
     /// Convert a canonical symposium output event into this agent's output.
-    fn from_symposium_output(&self, output: &symposium::OutputEvent) -> Self::Output {
+    fn translate_output(&self, output: &symposium::OutputEvent) -> Self::Output {
         Self::Output::from_symposium(output)
     }
 
@@ -155,10 +155,10 @@ pub trait ErasedAgentHookEvent {
     fn parse_output(&self, output: &[u8]) -> Result<Box<dyn AgentHookOutput>>;
 
     /// Convert a canonical symposium output event into a boxed agent output.
-    fn from_symposium_output(&self, output: &symposium::OutputEvent) -> Box<dyn AgentHookOutput>;
+    fn translate_output(&self, output: &symposium::OutputEvent) -> Box<dyn AgentHookOutput>;
 
     /// Convert a canonical symposium input event into a boxed agent payload.
-    fn from_symposium_input(&self, input: &symposium::InputEvent) -> Box<dyn AgentHookInput>;
+    fn translate_input(&self, input: &symposium::InputEvent) -> Box<dyn AgentHookInput>;
 
     /// Serialize the final accumulated output (as JSON Value) to bytes for stdout.
     /// Most agents emit JSON; Kiro emits plain text.
@@ -182,11 +182,11 @@ where
         let o = self.0.parse_output(output)?;
         Ok(Box::new(o))
     }
-    fn from_symposium_output(&self, output: &symposium::OutputEvent) -> Box<dyn AgentHookOutput> {
-        Box::new(self.0.from_symposium_output(output))
+    fn translate_output(&self, output: &symposium::OutputEvent) -> Box<dyn AgentHookOutput> {
+        Box::new(self.0.translate_output(output))
     }
 
-    fn from_symposium_input(&self, input: &symposium::InputEvent) -> Box<dyn AgentHookInput> {
+    fn translate_input(&self, input: &symposium::InputEvent) -> Box<dyn AgentHookInput> {
         Box::new(E::Input::from_symposium(input))
     }
 

--- a/symposium-testlib/src/lib.rs
+++ b/symposium-testlib/src/lib.rs
@@ -351,7 +351,7 @@ impl TestContext {
             let handler = agent
                 .event(event)
                 .ok_or_else(|| anyhow::anyhow!("agent {agent:?} does not support {event:?}"))?;
-            let agent_input = handler.from_symposium_input(&sym_input);
+            let agent_input = handler.translate_input(&sym_input);
             let input_str = agent_input.to_string()?;
 
             let output_bytes = hook::execute_hook(&self.sym, agent, event, &input_str).await?;


### PR DESCRIPTION
## What does this PR do?

Initial pass to address clippy lints, before adding to to CI.

This one addresses `wrong_self_convention` by renaming `from_symposium_*` to `translate_*`.

It's probably more controversial than the rest. I think I prefer it, but I can also add `expect(wrong_self_convention)` if preferred.

<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

* I used an AI tool for research, autocomplete, or in other minimal ways
* The AI tool authored small parts of the code (e.g., autocomplete, comments)
* The AI tool authored large parts of the code


**Confidence level.**

<!-- Remove the items that do not apply. -->


* I am very happy with it



</details>
