### PR TITLE
refactor: use strip_prefix instead of manual slicing

### DIFF
--- a/src/predicate.rs
+++ b/src/predicate.rs
@@ -171,10 +171,10 @@ impl<'a> Parser<'a> {
                 // `==X.Y` → exact match (`=X.Y` in semver)
                 // `=X.Y`  → compatible version (`^X.Y`), matching Cargo's default
                 // `>=`, `<=`, `>`, `<`, `^`, `~` → passed through as-is
-                let constraint = if raw.starts_with("==") {
-                    std::borrow::Cow::Owned(format!("={}", &raw[2..]))
-                } else if raw.starts_with('=') {
-                    std::borrow::Cow::Owned(format!("^{}", &raw[1..]))
+                let constraint = if let Some(rest) = raw.strip_prefix("==") {
+                    std::borrow::Cow::Owned(format!("={rest}"))
+                } else if let Some(rest) = raw.strip_prefix('=') {
+                    std::borrow::Cow::Owned(format!("^{rest}"))
                 } else {
                     std::borrow::Cow::Borrowed(raw)
                 };


### PR DESCRIPTION
## What does this PR do?

Initial pass to address clippy lints, before adding to to CI.

This one uses `strip_prefix` instead of manual slicing. I think it's more readable.

<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

* I used an AI tool for research, autocomplete, or in other minimal ways
* The AI tool authored small parts of the code (e.g., autocomplete, comments)
* The AI tool authored large parts of the code


**Confidence level.**

<!-- Remove the items that do not apply. -->


* I am very happy with it



</details>
