### PR TITLE
docs: update stale `crate` subcommand to `crate-info`

### DIFF
--- a/md/design/welcome.md
+++ b/md/design/welcome.md
@@ -9,7 +9,7 @@ Symposium is a standard Cargo project with both a library and a binary:
 ```bash
 cargo check              # type-check
 cargo test               # run the test suite
-cargo run -- crate tokio # run locally: crate-specific guidance
+cargo run -- crate-info tokio # run locally: crate-specific guidance
 ```
 
 Tests use snapshot assertions via the `expect-test` crate. If a snapshot changes, run with `UPDATE_EXPECT=1` to update it:


### PR DESCRIPTION
## What does this PR do?

`md/design/welcome.md` still tells contributors to run `cargo run -- crate tokio`, but ca82222f renamed the subcommand to `crate-info` without updating this file. The documented command currently errors with `unrecognized subcommand 'crate'`.

<details>
<summary>Disclosure questions</summary>

**AI disclosure.** The AI tool authored small parts of the code (e.g., autocomplete, comments)

**Confidence level.** I am very happy with it

</details>