### PR TITLE
feat: track skill installs at workspace scope with git-ignored artifacts

### DIFF
--- a/md/design/module-structure.md
+++ b/md/design/module-structure.md
@@ -18,7 +18,7 @@ Implements `cargo agents init`. Prompts for agents (or accepts `--add-agent`/`--
 
 ### `sync.rs` — synchronization command
 
-Implements `cargo agents sync`. Scans workspace dependencies, finds applicable skills from plugin sources, installs them into each configured agent's skill directory, manages a per-agent `.symposium.toml` manifest to track installed skills, and cleans up stale skills. Also provides `register_hooks()` for use by `init`.
+Implements `cargo agents sync`. Scans workspace dependencies, finds applicable skills from plugin sources, installs them into each configured agent's skill directory, and drops a `.symposium` marker file into each installed skill directory. On subsequent syncs, scans every agent's skills parent directory and reaps any marker-bearing subdirectory it didn't install this time, leaving user-managed skills (which lack the marker) untouched. Writes a `.gitignore` with `*` into every directory it creates. Also provides `register_hooks()` for use by `init`.
 
 ### `plugins.rs` — plugin registry
 

--- a/md/design/sync-agent-flow.md
+++ b/md/design/sync-agent-flow.md
@@ -14,24 +14,20 @@ Scans workspace dependencies, installs applicable skills into agent directories,
 
 5. **Install skills per agent** — for each configured agent:
    - Copy applicable `SKILL.md` files into the agent's expected skill directory.
-   - Write a `.symposium.toml` manifest in the agent's skill directory tracking which skills were installed by symposium.
-   - Remove skills that are in the old manifest but no longer applicable.
-   - Leave skills not in the manifest (user-managed) untouched.
+   - Drop a `.symposium` marker file into each installed skill directory so future syncs (and other tools) can recognize it as symposium-managed.
+   - For every skill directory symposium creates along the way (the skill directory itself or its `skills/` parent), write a `.gitignore` containing a single `*` so symposium-managed files stay out of version control.
 
-6. **Register hooks** — ensure global hooks and MCP servers are registered for all configured agents. Unregister hooks for agents no longer in the config.
+6. **Reap stale skills** — across every known agent's skills parent directory, remove any subdirectory that contains the `.symposium` marker but wasn't installed this sync. Directories without the marker (user-managed) are left untouched.
 
-## Skill manifest
+7. **Register hooks** — ensure global hooks and MCP servers are registered for all configured agents. Unregister hooks for agents no longer in the config.
 
-Each agent's skill directory contains a `.symposium.toml` file tracking what symposium installed:
+## Marker file
 
-```toml
-installed = [
-    "serde-guidance",
-    "tokio-guidance",
-]
-```
+Each skill directory symposium installs contains an empty `.symposium` file. Cleanup walks every agent's skills parent directory (`.claude/skills/`, `.agents/skills/`, `.kiro/skills/`, `.gemini/skills/`) and reaps any subdirectory whose marker is present but which wasn't installed this sync. This lets symposium reclaim stale skills (including those left behind by agents removed from the config) without touching user-managed skills, which are identified by the absence of the marker.
 
-This allows symposium to clean up stale skills without touching user-managed skill files.
+## Gitignore
+
+Each skill directory symposium creates (and its `skills/` parent if new) receives a `.gitignore` containing just `*`. Pre-existing directories are left alone. The wildcard also hides the marker file and the gitignore itself, so `git status` stays clean.
 
 ## Auto-sync
 

--- a/md/reference/cargo-agents-sync.md
+++ b/md/reference/cargo-agents-sync.md
@@ -18,9 +18,9 @@ Must be run from within a Rust workspace. Performs the following steps:
 
 3. **Discover applicable skills** — loads plugin sources (from user config) and matches skill predicates against workspace dependencies.
 
-4. **Install skills** — for each configured agent, copies applicable `SKILL.md` files into the agent's expected skill directory (e.g., `.claude/skills/` for Claude Code, `.agents/skills/` for Copilot/Gemini/Codex).
+4. **Install skills** — for each configured agent, copies applicable `SKILL.md` files into the agent's expected skill directory (e.g., `.claude/skills/` for Claude Code, `.agents/skills/` for Copilot/Gemini/Codex). A `.gitignore` containing `*` is written into every new skill directory (and its `skills/` parent if new), and an empty `.symposium` marker file is dropped into each installed skill directory.
 
-5. **Clean up stale skills** — removes skills that were previously installed by symposium but are no longer applicable (e.g., because a dependency was removed). Tracks installed skills in a per-agent manifest (`.symposium.toml` in the agent's skill directory). Skills not in the manifest (user-managed) are left untouched.
+5. **Clean up stale skills** — scans every agent's skills parent directory and removes any subdirectory containing the `.symposium` marker that wasn't installed this sync. Directories without the marker (user-managed) are left untouched.
 
 6. **Register hooks** — ensures hooks and MCP servers are registered for all configured agents. Registers both global hooks (for all projects) and project-specific hooks (for the current project). Unregisters hooks for agents no longer in the config.
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -2,14 +2,13 @@
 //!
 //! Scans workspace dependencies, finds applicable skills from plugin sources,
 //! installs them into each configured agent's skill directory, and cleans up
-//! stale skills using a per-agent manifest.
+//! stale skills by looking for a `.symposium` marker file in each skill dir.
 
 use std::collections::BTreeSet;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use serde::{Deserialize, Serialize};
 
 use crate::agents::Agent;
 use crate::config::Symposium;
@@ -17,48 +16,51 @@ use crate::output::{Output, display_path};
 use crate::plugins;
 use crate::skills;
 
-/// Manifest tracking which skills symposium installed for a given agent.
-/// Stored at e.g. `.agents/skills/.symposium.toml` or `.claude/skills/.symposium.toml`.
-#[derive(Debug, Default, Deserialize, Serialize)]
-struct SkillManifest {
-    /// Skill names installed by symposium.
-    #[serde(default)]
-    installed: BTreeSet<String>,
+/// Marker file written into every skill directory symposium installs.
+///
+/// Cleanup walks each agent's skills parent dir and removes any subdir
+/// containing this marker that isn't in the freshly-installed set, leaving
+/// user-managed skill directories (which lack the marker) untouched.
+const MARKER_FILE: &str = ".symposium";
+
+/// Create `path` (and any missing ancestors up to `boundary`), writing a
+/// `.gitignore` file containing `*` into each directory we newly create.
+///
+/// `boundary` is the workspace root — we never walk above it, and we do not
+/// write a `.gitignore` there (it already exists and isn't ours to manage).
+/// If `path` or an ancestor already exists, no `.gitignore` is added — we
+/// only annotate directories we actually create.
+pub(crate) fn create_managed_dir_all(path: &Path, boundary: &Path) -> Result<()> {
+    if path.exists() {
+        return Ok(());
+    }
+    if path == boundary {
+        fs::create_dir_all(path).with_context(|| format!("create {}", path.display()))?;
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        create_managed_dir_all(parent, boundary)?;
+    }
+    fs::create_dir(path).with_context(|| format!("create {}", path.display()))?;
+    let gi = path.join(".gitignore");
+    if !gi.exists() {
+        fs::write(&gi, "*\n").with_context(|| format!("write {}", gi.display()))?;
+    }
+    Ok(())
 }
 
-impl SkillManifest {
-    fn load(path: &Path) -> Self {
-        fs::read_to_string(path)
-            .ok()
-            .and_then(|s| toml::from_str(&s).ok())
-            .unwrap_or_default()
-    }
-
-    fn save(&self, path: &Path) -> Result<()> {
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        let contents = toml::to_string_pretty(self)?;
-        fs::write(path, contents)?;
-        Ok(())
-    }
-}
-
-/// Returns the manifest path for a given agent's skill directory.
-fn manifest_path(agent: Agent, project_root: &Path) -> std::path::PathBuf {
-    // Use the agent's skill dir parent (e.g. `.agents/skills/`, `.claude/skills/`)
-    // and put the manifest there.
-    let dummy_dir = agent.project_skill_dir(project_root, ".symposium-probe");
-    // dummy_dir is e.g. `.agents/skills/.symposium-probe`
-    // parent is `.agents/skills/`
-    dummy_dir
+/// Skills parent directory for an agent (e.g. `.claude/skills/` or
+/// `.agents/skills/`), derived from `Agent::project_skill_dir`.
+fn skills_parent_dir(agent: Agent, project_root: &Path) -> PathBuf {
+    agent
+        .project_skill_dir(project_root, "_")
         .parent()
         .expect("skill dir must have parent")
-        .join(".symposium.toml")
+        .to_path_buf()
 }
 
 /// Run the full sync: discover applicable skills, install into agent dirs,
-/// clean up stale skills.
+/// clean up stale installations.
 pub async fn sync(sym: &Symposium, cwd: &Path, out: &Output) -> Result<()> {
     let project_root = crate::init::find_workspace_root(cwd)?;
     tracing::debug!(root = %project_root.display(), "resolved workspace root");
@@ -132,6 +134,10 @@ pub async fn sync(sym: &Symposium, cwd: &Path, out: &Output) -> Result<()> {
         return Ok(());
     }
 
+    // Track every skill directory we (re)install during this sync. Anything
+    // we find later that has the marker file but isn't in this set is stale.
+    let mut installed_dirs: BTreeSet<PathBuf> = BTreeSet::new();
+
     for agent_name in &agent_names {
         let agent = Agent::from_config_name(agent_name)?;
 
@@ -148,17 +154,25 @@ pub async fn sync(sym: &Symposium, cwd: &Path, out: &Output) -> Result<()> {
             .register_global_mcp_servers(&hook_root, &mcp_servers, out)
             .context("failed to register MCP servers")?;
 
-        // Install skills and manage manifest
-        let manifest_file = manifest_path(agent, &project_root);
-        let old_manifest = SkillManifest::load(&manifest_file);
-
-        let mut new_manifest = SkillManifest::default();
-
         for &(skill_name, skill_source) in &to_install {
             let dest_dir = agent.project_skill_dir(&project_root, skill_name);
+
+            // Create the destination (and any missing parents) with a `*` gitignore
+            // in each new directory.
+            if let Err(e) = create_managed_dir_all(&dest_dir, &project_root) {
+                out.warn(format!("failed to create {}: {e}", display_path(&dest_dir)));
+                continue;
+            }
+
             match agent.install_skill(skill_source, &dest_dir) {
                 Ok(()) => {
-                    new_manifest.installed.insert(skill_name.to_string());
+                    // Drop the marker so future syncs (and other tools) can
+                    // recognize this directory as symposium-managed.
+                    let marker = dest_dir.join(MARKER_FILE);
+                    if let Err(e) = fs::write(&marker, "") {
+                        out.warn(format!("failed to write {}: {e}", display_path(&marker)));
+                    }
+                    installed_dirs.insert(dest_dir.clone());
                     tracing::info!(%skill_name, agent = %agent_name, dest = %dest_dir.display(), "installed skill");
                     out.done(format!(
                         "installed skill {skill_name} → {}",
@@ -170,24 +184,41 @@ pub async fn sync(sym: &Symposium, cwd: &Path, out: &Output) -> Result<()> {
                 }
             }
         }
+    }
 
-        // Remove stale skills (in old manifest but not in new)
-        for stale in old_manifest.installed.difference(&new_manifest.installed) {
-            let dest_dir = agent.project_skill_dir(&project_root, stale);
-            if dest_dir.exists() {
-                let _ = fs::remove_dir_all(&dest_dir);
-                tracing::info!(%stale, agent = %agent_name, "removed stale skill");
-                out.removed(format!(
-                    "removed skill {stale} from {}",
-                    display_path(&dest_dir)
-                ));
+    // Stale-skill cleanup: scan every agent's skills parent directory (across
+    // all known agents, so we also clean up after agents removed from config)
+    // and remove subdirs containing the marker that we didn't just install.
+    let mut scanned: BTreeSet<PathBuf> = BTreeSet::new();
+    for &agent in Agent::all() {
+        let parent = skills_parent_dir(agent, &project_root);
+        if !scanned.insert(parent.clone()) {
+            continue;
+        }
+        let Ok(entries) = fs::read_dir(&parent) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() || installed_dirs.contains(&path) {
+                continue;
+            }
+            if !path.join(MARKER_FILE).exists() {
+                continue;
+            }
+            match fs::remove_dir_all(&path) {
+                Ok(()) => {
+                    tracing::info!(path = %path.display(), "removed stale skill");
+                    out.removed(format!("removed {}", display_path(&path)));
+                }
+                Err(e) => {
+                    out.warn(format!(
+                        "failed to remove stale {}: {e}",
+                        display_path(&path)
+                    ));
+                }
             }
         }
-
-        // Write updated manifest
-        new_manifest
-            .save(&manifest_file)
-            .context("failed to write skill manifest")?;
     }
 
     // Unregister hooks/MCP for agents no longer configured

--- a/tests/init_sync.rs
+++ b/tests/init_sync.rs
@@ -106,13 +106,22 @@ async fn sync_installs_skills() {
                 "sync should install serde-guidance skill"
             );
 
-            let manifest_path = workspace_root.join(".claude/skills/.symposium.toml");
-            assert!(manifest_path.exists(), "manifest should be written");
-            let manifest = std::fs::read_to_string(&manifest_path).unwrap();
+            // Each installed skill directory carries a `.symposium` marker so
+            // future syncs (and other tools) can identify it as symposium-managed.
+            let marker = workspace_root.join(".claude/skills/serde-guidance/.symposium");
             assert!(
-                manifest.contains("serde-guidance"),
-                "manifest should track installed skill"
+                marker.exists(),
+                "skill dir should contain .symposium marker"
             );
+
+            // Skill dirs symposium creates get a wildcard gitignore so the
+            // marker, SKILL.md, and gitignore itself stay out of version control.
+            for dir in [".claude/skills", ".claude/skills/serde-guidance"] {
+                let gi = workspace_root.join(dir).join(".gitignore");
+                assert!(gi.exists(), "missing .gitignore in {dir}");
+                let contents = std::fs::read_to_string(&gi).unwrap();
+                assert_eq!(contents.trim(), "*", "unexpected .gitignore in {dir}");
+            }
             Ok(())
         },
     )
@@ -146,11 +155,11 @@ async fn sync_skips_invalid_skill_frontmatter() {
                 "sync should not install a skill with invalid YAML frontmatter"
             );
 
-            let manifest_path = workspace_root.join(".agents/skills/.symposium.toml");
-            let manifest = std::fs::read_to_string(&manifest_path).unwrap();
+            // No marker should exist for the rejected skill.
+            let marker = workspace_root.join(".agents/skills/rust-best-practice/.symposium");
             assert!(
-                !manifest.contains("rust-best-practice"),
-                "manifest should not track a rejected skill"
+                !marker.exists(),
+                "rejected skill directory should not exist"
             );
             Ok(())
         },
@@ -159,7 +168,7 @@ async fn sync_skips_invalid_skill_frontmatter() {
     .unwrap();
 }
 
-/// `sync` removes stale skills tracked in the manifest.
+/// `sync` removes stale skills marked by a `.symposium` file.
 #[tokio::test]
 async fn sync_removes_stale_skills() {
     with_fixture(
@@ -171,18 +180,12 @@ async fn sync_removes_stale_skills() {
 
             let workspace_root = ctx.workspace_root.as_ref().unwrap();
 
-            let manifest_path = workspace_root.join(".claude/skills/.symposium.toml");
-            let manifest = std::fs::read_to_string(&manifest_path).unwrap();
-            let manifest = manifest.replace(
-                r#"installed = ["#,
-                r#"installed = [
-    "fake-old-skill","#,
-            );
-            std::fs::write(&manifest_path, &manifest).unwrap();
-
+            // Plant a fake "previously installed" skill: a marker file makes
+            // the dir look symposium-managed, so the next sync should reap it.
             let fake_dir = workspace_root.join(".claude/skills/fake-old-skill");
             std::fs::create_dir_all(&fake_dir).unwrap();
             std::fs::write(fake_dir.join("SKILL.md"), "old").unwrap();
+            std::fs::write(fake_dir.join(".symposium"), "").unwrap();
 
             ctx.symposium(&["sync"]).await?;
 
@@ -197,7 +200,8 @@ async fn sync_removes_stale_skills() {
     .unwrap();
 }
 
-/// `sync` does not touch skills not in the manifest (user-managed).
+/// `sync` does not touch skill directories without the `.symposium` marker
+/// (user-managed).
 #[tokio::test]
 async fn sync_preserves_user_managed_skills() {
     with_fixture(
@@ -482,10 +486,16 @@ async fn sync_installs_skill_from_crate_path() {
             let content = std::fs::read_to_string(&skill_file)?;
             assert!(content.contains("Use crate-z like this"));
 
-            let manifest_path = workspace_root.join(".claude/skills/.symposium.toml");
-            let manifest = std::fs::read_to_string(&manifest_path)?;
-            assert!(manifest.contains("x-guidance"));
-            assert!(manifest.contains("z-guidance"));
+            assert!(
+                workspace_root
+                    .join(".claude/skills/x-guidance/.symposium")
+                    .exists()
+            );
+            assert!(
+                workspace_root
+                    .join(".claude/skills/z-guidance/.symposium")
+                    .exists()
+            );
             Ok(())
         },
     )
@@ -580,6 +590,100 @@ async fn crate_info_resolves_path_dependency() {
         }
         Ok(())
     })
+    .await
+    .unwrap();
+}
+
+/// Installing default skills in a freshly-initialized git repo must not leak
+/// symposium artifacts into `git status`. The skill directories symposium
+/// creates carry a wildcard `.gitignore` that hides everything they contain,
+/// so `git status` should be clean after sync.
+#[tokio::test]
+async fn sync_installations_are_gitignored() {
+    use std::process::Command;
+
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["plugins0", "workspace0"],
+        async |mut ctx| {
+            let workspace_root = ctx.workspace_root.clone().unwrap();
+
+            // Helper: run a git command in the workspace root, bail on failure.
+            // `-c core.excludesFile=/dev/null` makes the test independent of
+            // the developer's global gitignore (e.g. one that hides `.claude/`),
+            // so behavior matches CI.
+            let git = |args: &[&str]| -> anyhow::Result<String> {
+                let mut full_args = vec!["-c", "core.excludesFile=/dev/null"];
+                full_args.extend_from_slice(args);
+                let out = Command::new("git")
+                    .args(&full_args)
+                    .current_dir(&workspace_root)
+                    .output()?;
+                if !out.status.success() {
+                    anyhow::bail!(
+                        "git {args:?} failed: {}",
+                        String::from_utf8_lossy(&out.stderr)
+                    );
+                }
+                Ok(String::from_utf8(out.stdout)?)
+            };
+
+            // Fresh git repo with the fixture's project files committed.
+            git(&["init", "--quiet", "--initial-branch=main"])?;
+            git(&["config", "user.email", "test@example.com"])?;
+            git(&["config", "user.name", "Test"])?;
+            git(&["config", "commit.gpgsign", "false"])?;
+
+            // Keep the snapshot focused on symposium-managed paths by
+            // excluding test-harness infrastructure (`dot-symposium/` is
+            // where the fixture plants the user-level `~/.symposium/`) and
+            // `cargo metadata`'s generated `Cargo.lock`.
+            std::fs::write(
+                workspace_root.join(".gitignore"),
+                "dot-symposium/\nCargo.lock\n",
+            )?;
+
+            git(&["add", "."])?;
+            git(&["commit", "--quiet", "-m", "initial"])?;
+
+            // Install default skills for a single agent.
+            ctx.symposium(&["init", "--add-agent", "claude"]).await?;
+            ctx.symposium(&["sync"]).await?;
+
+            // Sanity: the skill and marker are actually on disk.
+            assert!(
+                workspace_root
+                    .join(".claude/skills/serde-guidance/SKILL.md")
+                    .exists(),
+                "skill should be installed on disk"
+            );
+            assert!(
+                workspace_root
+                    .join(".claude/skills/serde-guidance/.symposium")
+                    .exists(),
+                "marker should be on disk"
+            );
+
+            // Use `-uall` so untracked dirs expand to their leaf paths —
+            // gives deterministic output regardless of git's collapsing rules.
+            let status = git(&["status", "--porcelain", "-uall"])?;
+
+            // Skill dirs are fully gitignored by the wildcard `.gitignore`
+            // symposium drops into them, so they don't appear here.
+            //
+            // `.claude/settings.json` does appear: the `plugins0` fixture
+            // sets `hook-scope = "project"`, so init+sync register hooks
+            // into the workspace's `.claude/settings.json` rather than the
+            // user's home dir. That file is the user's to commit (or not);
+            // symposium doesn't gitignore it.
+            expect_test::expect![[r#"
+                ?? .claude/settings.json
+            "#]]
+            .assert_eq(&status);
+
+            Ok(())
+        },
+    )
     .await
     .unwrap();
 }


### PR DESCRIPTION
## What does this PR do?

feat: track installed skills via per-skill `.symposium` marker file

Drop a `.symposium` marker into each skill directory symposium installs
so future syncs (and other tools) can recognize it as symposium-managed.
Cleanup walks every known agent's `skills/` parent directory and reaps
any subdirectory containing the marker that wasn't (re)installed this
sync. Directories without the marker (user-managed) are left untouched.

This replaces the workspace-level `.symposium/installed.toml` manifest:
no separate state file, no manifest read/write path, and cleanup now
also covers agents removed from the config (their skill dirs still
carry the marker, so they get reaped on the next sync).

Each newly-created skill directory still receives a `.gitignore`
containing `*`, which hides the marker, `SKILL.md`, and the gitignore
itself — `git status` stays clean after sync. The integration test
that pins `git status --porcelain` via `expect_test` now expects an
empty status (the `.symposium/.gitignore` it used to expect is gone).
