### PR TITLE
Add agents-syncing: mirror user-authored skills across agent dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,20 +46,6 @@ yarn-error.log*
 *.swo
 *~
 
-# Agent-specific directories (local dev installs at project root; fixtures
-# under tests/ may legitimately contain these for test setup).
-/.kiro/
-/.claude/
-/.agents/
-/.sparkle-space/
-
-# Re-include agent-ish directories when they appear inside test fixtures.
-# Needed to override the user's global ~/.gitignore which typically
-# excludes .agents/, .claude/, .kiro/ everywhere.
-!tests/fixtures/**/.agents/
-!tests/fixtures/**/.claude/
-!tests/fixtures/**/.kiro/
-
 # Build output
 dist/
 

--- a/.gitignore
+++ b/.gitignore
@@ -46,11 +46,19 @@ yarn-error.log*
 *.swo
 *~
 
-# Agent-specific directories 
-.kiro/
-.claude/
-.agents/
-.sparkle-space/
+# Agent-specific directories (local dev installs at project root; fixtures
+# under tests/ may legitimately contain these for test setup).
+/.kiro/
+/.claude/
+/.agents/
+/.sparkle-space/
+
+# Re-include agent-ish directories when they appear inside test fixtures.
+# Needed to override the user's global ~/.gitignore which typically
+# excludes .agents/, .claude/, .kiro/ everywhere.
+!tests/fixtures/**/.agents/
+!tests/fixtures/**/.claude/
+!tests/fixtures/**/.kiro/
 
 # Build output
 dist/

--- a/md/SUMMARY.md
+++ b/md/SUMMARY.md
@@ -18,6 +18,7 @@
 # User's guide
 
 - [Installing Symposium](./install.md)
+- [Workspace skills](./workspace-skills.md)
 - [Custom plugin sources](./custom-plugin-source.md)
 
 # For crate authors

--- a/md/design/sync-agent-flow.md
+++ b/md/design/sync-agent-flow.md
@@ -17,9 +17,11 @@ Scans workspace dependencies, installs applicable skills into agent directories,
    - Drop a `.symposium` marker file into each installed skill directory so future syncs (and other tools) can recognize it as symposium-managed.
    - For every skill directory symposium creates along the way (the skill directory itself or its `skills/` parent), write a `.gitignore` containing a single `*` so symposium-managed files stay out of version control.
 
-6. **Reap stale skills** — across every known agent's skills parent directory, remove any subdirectory that contains the `.symposium` marker but wasn't installed this sync. Directories without the marker (user-managed) are left untouched.
+6. **Propagate user-authored skills (agents-syncing)** — if `agents-syncing` is enabled in the user config, mirror skills the user placed in `<workspace>/.agents/skills/` into each configured agent's own skill directory. A skill is "user-authored" when its directory contains `SKILL.md` but lacks the `.symposium` marker (symposium never writes markers into source skills). Propagated destinations receive the same marker and `*` `.gitignore` as plugin-installed skills, so they participate in the normal stale-skill reap: removing the source — or disabling `agents-syncing` — causes the destinations to be cleaned up on the next sync. A destination directory without a marker is user-managed and is never overwritten.
 
-7. **Register hooks** — ensure global hooks and MCP servers are registered for all configured agents. Unregister hooks for agents no longer in the config.
+7. **Reap stale skills** — across every known agent's skills parent directory, remove any subdirectory that contains the `.symposium` marker but wasn't installed this sync. Directories without the marker (user-managed) are left untouched.
+
+8. **Register hooks** — ensure global hooks and MCP servers are registered for all configured agents. Unregister hooks for agents no longer in the config.
 
 ## Marker file
 

--- a/md/reference/cargo-agents-sync.md
+++ b/md/reference/cargo-agents-sync.md
@@ -20,9 +20,11 @@ Must be run from within a Rust workspace. Performs the following steps:
 
 4. **Install skills** — for each configured agent, copies applicable `SKILL.md` files into the agent's expected skill directory (e.g., `.claude/skills/` for Claude Code, `.agents/skills/` for Copilot/Gemini/Codex). A `.gitignore` containing `*` is written into every new skill directory (and its `skills/` parent if new), and an empty `.symposium` marker file is dropped into each installed skill directory.
 
-5. **Clean up stale skills** — scans every agent's skills parent directory and removes any subdirectory containing the `.symposium` marker that wasn't installed this sync. Directories without the marker (user-managed) are left untouched.
+5. **Mirror workspace skills** — if `agents-syncing` is enabled (default), user-authored skills in `<workspace>/.agents/skills/` are propagated into the skill directories of any configured agent that doesn't natively use `.agents/skills/` (e.g., `.claude/skills/`, `.kiro/skills/`). See [Workspace skills](../workspace-skills.md).
 
-6. **Register hooks** — ensures hooks and MCP servers are registered for all configured agents. Registers both global hooks (for all projects) and project-specific hooks (for the current project). Unregisters hooks for agents no longer in the config.
+6. **Clean up stale skills** — scans every agent's skills parent directory and removes any subdirectory containing the `.symposium` marker that wasn't installed (or propagated) this sync. Directories without the marker (user-managed) are left untouched.
+
+7. **Register hooks** — ensures hooks and MCP servers are registered for all configured agents. Registers both global hooks (for all projects) and project-specific hooks (for the current project). Unregisters hooks for agents no longer in the config.
 
 ## Automatic sync
 

--- a/md/reference/configuration.md
+++ b/md/reference/configuration.md
@@ -52,7 +52,9 @@ Propagated destinations receive the same `.symposium` marker and `*` `.gitignore
 - Disabling `agents-syncing = false` also removes previously propagated copies on the next sync.
 - A pre-existing, user-managed file in the target directory (no marker) is never overwritten.
 
-When the only configured agents use `.agents/skills/` directly, the feature is a no-op (the source and target are the same directory).### Hook scope: control whether Symposium activates in all projects or only those you select
+When the only configured agents use `.agents/skills/` directly, the feature is a no-op (the source and target are the same directory).
+
+### Hook scope: control whether Symposium activates in all projects or only those you select
 
 Registering hooks globally ensures that Symposium activates whenever you use the selected agent, which means that it will work in any Rust project automatically.
 

--- a/md/reference/configuration.md
+++ b/md/reference/configuration.md
@@ -36,7 +36,7 @@ path = "my-plugins"
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `auto-sync` | bool | `true` | Automatically run `cargo agents sync` during hook invocations. When enabled, skills are kept in sync with workspace dependencies without manual intervention. |
-| `agents-syncing` | bool | `true` | Propagate user-authored skills from `.agents/skills/` into the per-agent skill directories of any configured agent that does not natively use `.agents/skills/` (such as `.claude/skills/` or `.kiro/skills/`). Skills that symposium itself installed — identified by the `.symposium` marker file — are not propagated. See [Agents syncing](#agents-syncing-mirror-user-authored-skills) below. |
+| `agents-syncing` | bool | `true` | Propagate user-authored skills from `.agents/skills/` into the per-agent skill directories of any configured agent that does not natively use `.agents/skills/` (such as `.claude/skills/` or `.kiro/skills/`). Skills that symposium itself installed — identified by the `.symposium` marker file — are not propagated. See [Workspace skills](../workspace-skills.md) for the user-guide overview, or [Agents syncing](#agents-syncing-mirror-user-authored-skills) below for details. |
 | `hook-scope` | string | `"global"` | Where agent hooks are installed. `"global"` writes to the user's home directory (e.g., `~/`). `"project"` writes to the project directory, keeping hooks local to the workspace. |
 
 ### Agents syncing: mirror user-authored skills

--- a/md/reference/configuration.md
+++ b/md/reference/configuration.md
@@ -6,6 +6,7 @@
 
 ```toml
 auto-sync = true
+agents-syncing = true
 hook-scope = "global"
 
 [[agent]]
@@ -35,9 +36,23 @@ path = "my-plugins"
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `auto-sync` | bool | `true` | Automatically run `cargo agents sync` during hook invocations. When enabled, skills are kept in sync with workspace dependencies without manual intervention. |
+| `agents-syncing` | bool | `true` | Propagate user-authored skills from `.agents/skills/` into the per-agent skill directories of any configured agent that does not natively use `.agents/skills/` (such as `.claude/skills/` or `.kiro/skills/`). Skills that symposium itself installed — identified by the `.symposium` marker file — are not propagated. See [Agents syncing](#agents-syncing-mirror-user-authored-skills) below. |
 | `hook-scope` | string | `"global"` | Where agent hooks are installed. `"global"` writes to the user's home directory (e.g., `~/`). `"project"` writes to the project directory, keeping hooks local to the workspace. |
 
-### Hook scope: control whether Symposium activates in all projects or only those you select
+### Agents syncing: mirror user-authored skills
+
+Agents such as Copilot, Gemini, Codex, Goose, and OpenCode all read skills from the vendor-neutral `.agents/skills/` directory, but Claude Code and Kiro use their own paths (`.claude/skills/` and `.kiro/skills/`). When `agents-syncing` is enabled, `cargo agents sync` mirrors any skill that *you* put in `.agents/skills/` into each configured agent's own skill directory, so a single authored copy is visible to every agent.
+
+A skill is treated as user-authored when its directory contains `SKILL.md` but does *not* contain the `.symposium` marker. Symposium never writes a marker into source skills, so the distinction between "user content" and "a copy symposium made" is unambiguous.
+
+Propagated destinations receive the same `.symposium` marker and `*` `.gitignore` that plugin-installed skills get, which means:
+
+- Updates to the source (`.agents/skills/<name>/`) are re-copied on each sync.
+- Removing the source removes the propagated copies on the next sync (via the normal stale-skill reap).
+- Disabling `agents-syncing = false` also removes previously propagated copies on the next sync.
+- A pre-existing, user-managed file in the target directory (no marker) is never overwritten.
+
+When the only configured agents use `.agents/skills/` directly, the feature is a no-op (the source and target are the same directory).### Hook scope: control whether Symposium activates in all projects or only those you select
 
 Registering hooks globally ensures that Symposium activates whenever you use the selected agent, which means that it will work in any Rust project automatically.
 

--- a/md/reference/skill-definition.md
+++ b/md/reference/skill-definition.md
@@ -2,10 +2,7 @@
 
 A skill is a `SKILL.md` file inside a skill directory. Skills follow the [agentskills.io](https://agentskills.io/specification.md) format.
 
-Skills are typically supplied by a [plugin](./plugin-definition.md), but
-you can also drop a `SKILL.md` directly into `<workspace>/.agents/skills/`
-to author a skill specific to a single project — see
-[Workspace skills](../workspace-skills.md).
+Skills can be supplied by a [plugin](./plugin-definition.md) or [by adding skills into the `.agents/skills` directory within the workspace](../workspace-skills.md).
 
 ## Directory layout
 

--- a/md/reference/skill-definition.md
+++ b/md/reference/skill-definition.md
@@ -2,6 +2,11 @@
 
 A skill is a `SKILL.md` file inside a skill directory. Skills follow the [agentskills.io](https://agentskills.io/specification.md) format.
 
+Skills are typically supplied by a [plugin](./plugin-definition.md), but
+you can also drop a `SKILL.md` directly into `<workspace>/.agents/skills/`
+to author a skill specific to a single project — see
+[Workspace skills](../workspace-skills.md).
+
 ## Directory layout
 
 ```text

--- a/md/workspace-skills.md
+++ b/md/workspace-skills.md
@@ -1,106 +1,38 @@
 # Workspace skills
 
-You can author your own skills directly inside a Rust workspace without
-publishing them to a plugin repository. Drop them into
-`.agents/skills/<skill-name>/` and `cargo agents sync` will make them
-available to every agent you use.
+In addition to adding skills based on your dependencies, Symposium will also copy any additional skills found in `.agents/skills` into the directory appropriate for your configured agent(s).
 
-## Why `.agents/skills/`
+This "skill-syncing" feature allows your project to add skills in one central location that will work for all developers, regardless of which agent they use (for example, Claude Code users will have the skills synced to `.claude/skills`).
 
-Different agents read skills from different locations. Copilot, Gemini,
-Codex, Goose, and OpenCode all look in the vendor-neutral `.agents/skills/`
-directory; Claude Code reads `.claude/skills/`; Kiro reads `.kiro/skills/`.
+The default skill location therefore varies depending on the intended audience:
 
-Symposium treats `.agents/skills/` as the canonical place for
-*workspace-local, user-authored* skills. When [`cargo agents sync`]
-runs, any skill you put there is mirrored into the directories used by
-your other configured agents, so you only have to write the skill once.
+| Skills intended for... | Go into... |
+| --- | --- |
+| Maintaining your crate | `.agents/skills` |
+| [Using your crate](./crate-authors/supporting-your-crate.md) | `.symposium/skills` |
 
-[`cargo agents sync`]: ./reference/cargo-agents-sync.md
+## Setting the "distribution" for `.symposium` skills
 
-## Authoring a skill
+Some projects do not like to check-in the `.agents` directory. An alternative is to add skills into `.symposium/skills` and set the `distribution` header to `workspace`:
 
-Create a directory named after your skill, with a `SKILL.md` following
-the [skill definition] format:
-
-```text
-<workspace-root>/
-  .agents/
-    skills/
-      our-coding-style/
-        SKILL.md
-        style-guide.md   # optional companion files are copied too
 ```
+# Example
+#
+# In .symposium/skills/integration-test/SKILL.md
 
-A minimal `SKILL.md`:
-
-```markdown
 ---
-name: our-coding-style
-description: Team coding conventions for this repository.
+name: Adding an integration test
+description: "Instructions for adding integration tests into this project"
+distribution: workspace
 ---
 
-Prefer `tracing::info!` over `println!`. See `style-guide.md` for the
-full guide.
+...
 ```
 
-Any sibling files inside the skill directory (references, scripts,
-examples) are copied along with `SKILL.md`.
+## Recommended git setup
 
-[skill definition]: ./reference/skill-definition.md
+We recommend you commit your `.agents/skills` or `.symposium/skills` into the repository. Symposium installs a `.gitignore` file into every skill that it creates, so automatically copied and installed skills should not dirty your git status.
 
-## What sync does
+## Pre-existing files
 
-Running `cargo agents sync` will:
-
-1. Leave `.agents/skills/our-coding-style/` untouched — that's your
-   working copy.
-2. Copy the skill into each configured agent's own skill directory
-   when it differs from `.agents/skills/`. For example, with Claude
-   and Kiro configured you'll get `.claude/skills/our-coding-style/`
-   and `.kiro/skills/our-coding-style/`.
-3. Record the propagated copies in each destination's
-   `.symposium.toml` manifest under a `propagated` list, so they can
-   be cleaned up later.
-
-If the only agents you use already read from `.agents/skills/` (e.g.,
-only Copilot or Codex), nothing extra needs to happen — the source
-directory already is every agent's skill directory.
-
-## Updating and removing skills
-
-- **Edit a skill** — edit the files under `.agents/skills/<name>/` and
-  run `cargo agents sync`. The propagated copies are overwritten with
-  your new content.
-- **Remove a skill** — delete `.agents/skills/<name>/` and run
-  `cargo agents sync`. The propagated copies are removed from the
-  other agent directories.
-- **Disable the feature** — set `agents-syncing = false` in
-  `~/.symposium/config.toml` (see [Configuration]). On the next sync,
-  previously propagated copies are removed as well.
-
-[Configuration]: ./reference/configuration.md
-
-## Workspace skills vs. plugins
-
-| Use a workspace skill when… | Use a plugin when… |
-|-----------------------------|--------------------|
-| The skill is specific to *this* repository. | The skill applies to any project depending on a given crate. |
-| You're iterating on the content and want it versioned alongside the code. | You want to share the skill with other repositories or organizations. |
-| You don't want to publish a skill source. | You're happy to publish to a git repository or the central recommendations repository. |
-
-For cross-project or cross-organization distribution, see
-[Custom plugin sources](./custom-plugin-source.md) and
-[Authoring a plugin](./crate-authors/authoring-a-plugin.md).
-
-## Safety notes
-
-- Symposium never touches skills in `.claude/skills/`, `.kiro/skills/`
-  etc. that it did not put there itself. If you previously hand-wrote a
-  skill with the same name as one in `.agents/skills/`, propagation is
-  skipped for that name and a warning is printed — your existing file
-  stays in place.
-- Symposium tracks what it installed vs. propagated through the
-  per-directory `.symposium.toml` manifest. Deleting that manifest
-  makes symposium forget what it owns, and it will stop cleaning up
-  after itself.
+Symposium never touches skills in `.claude/skills/`, `.kiro/skills/` etc. that it did not put there itself. If you previously hand-wrote a skill with the same name as one in `.agents/skills/`, propagation is skipped for that name and a warning is printed — your existing file stays in place.

--- a/md/workspace-skills.md
+++ b/md/workspace-skills.md
@@ -11,24 +11,6 @@ The default skill location therefore varies depending on the intended audience:
 | Maintaining your crate | `.agents/skills` |
 | [Using your crate](./crate-authors/supporting-your-crate.md) | `.symposium/skills` |
 
-## Setting the "distribution" for `.symposium` skills
-
-Some projects do not like to check-in the `.agents` directory. An alternative is to add skills into `.symposium/skills` and set the `distribution` header to `workspace`:
-
-```
-# Example
-#
-# In .symposium/skills/integration-test/SKILL.md
-
----
-name: Adding an integration test
-description: "Instructions for adding integration tests into this project"
-distribution: workspace
----
-
-...
-```
-
 ## Recommended git setup
 
 We recommend you commit your `.agents/skills` or `.symposium/skills` into the repository. Symposium installs a `.gitignore` file into every skill that it creates, so automatically copied and installed skills should not dirty your git status.

--- a/md/workspace-skills.md
+++ b/md/workspace-skills.md
@@ -1,0 +1,106 @@
+# Workspace skills
+
+You can author your own skills directly inside a Rust workspace without
+publishing them to a plugin repository. Drop them into
+`.agents/skills/<skill-name>/` and `cargo agents sync` will make them
+available to every agent you use.
+
+## Why `.agents/skills/`
+
+Different agents read skills from different locations. Copilot, Gemini,
+Codex, Goose, and OpenCode all look in the vendor-neutral `.agents/skills/`
+directory; Claude Code reads `.claude/skills/`; Kiro reads `.kiro/skills/`.
+
+Symposium treats `.agents/skills/` as the canonical place for
+*workspace-local, user-authored* skills. When [`cargo agents sync`]
+runs, any skill you put there is mirrored into the directories used by
+your other configured agents, so you only have to write the skill once.
+
+[`cargo agents sync`]: ./reference/cargo-agents-sync.md
+
+## Authoring a skill
+
+Create a directory named after your skill, with a `SKILL.md` following
+the [skill definition] format:
+
+```text
+<workspace-root>/
+  .agents/
+    skills/
+      our-coding-style/
+        SKILL.md
+        style-guide.md   # optional companion files are copied too
+```
+
+A minimal `SKILL.md`:
+
+```markdown
+---
+name: our-coding-style
+description: Team coding conventions for this repository.
+---
+
+Prefer `tracing::info!` over `println!`. See `style-guide.md` for the
+full guide.
+```
+
+Any sibling files inside the skill directory (references, scripts,
+examples) are copied along with `SKILL.md`.
+
+[skill definition]: ./reference/skill-definition.md
+
+## What sync does
+
+Running `cargo agents sync` will:
+
+1. Leave `.agents/skills/our-coding-style/` untouched — that's your
+   working copy.
+2. Copy the skill into each configured agent's own skill directory
+   when it differs from `.agents/skills/`. For example, with Claude
+   and Kiro configured you'll get `.claude/skills/our-coding-style/`
+   and `.kiro/skills/our-coding-style/`.
+3. Record the propagated copies in each destination's
+   `.symposium.toml` manifest under a `propagated` list, so they can
+   be cleaned up later.
+
+If the only agents you use already read from `.agents/skills/` (e.g.,
+only Copilot or Codex), nothing extra needs to happen — the source
+directory already is every agent's skill directory.
+
+## Updating and removing skills
+
+- **Edit a skill** — edit the files under `.agents/skills/<name>/` and
+  run `cargo agents sync`. The propagated copies are overwritten with
+  your new content.
+- **Remove a skill** — delete `.agents/skills/<name>/` and run
+  `cargo agents sync`. The propagated copies are removed from the
+  other agent directories.
+- **Disable the feature** — set `agents-syncing = false` in
+  `~/.symposium/config.toml` (see [Configuration]). On the next sync,
+  previously propagated copies are removed as well.
+
+[Configuration]: ./reference/configuration.md
+
+## Workspace skills vs. plugins
+
+| Use a workspace skill when… | Use a plugin when… |
+|-----------------------------|--------------------|
+| The skill is specific to *this* repository. | The skill applies to any project depending on a given crate. |
+| You're iterating on the content and want it versioned alongside the code. | You want to share the skill with other repositories or organizations. |
+| You don't want to publish a skill source. | You're happy to publish to a git repository or the central recommendations repository. |
+
+For cross-project or cross-organization distribution, see
+[Custom plugin sources](./custom-plugin-source.md) and
+[Authoring a plugin](./crate-authors/authoring-a-plugin.md).
+
+## Safety notes
+
+- Symposium never touches skills in `.claude/skills/`, `.kiro/skills/`
+  etc. that it did not put there itself. If you previously hand-wrote a
+  skill with the same name as one in `.agents/skills/`, propagation is
+  skipped for that name and a warning is printed — your existing file
+  stays in place.
+- Symposium tracks what it installed vs. propagated through the
+  per-directory `.symposium.toml` manifest. Deleting that manifest
+  makes symposium forget what it owns, and it will stop cleaning up
+  after itself.

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,13 @@ pub struct Config {
     #[serde(default = "default_true", rename = "auto-sync")]
     pub auto_sync: bool,
 
+    /// Propagate user-authored skills from `.agents/skills/` to each
+    /// configured agent's skill directory (e.g. `.claude/skills/`,
+    /// `.kiro/skills/`). Skills that symposium itself installed into
+    /// `.agents/skills/` are not propagated.
+    #[serde(default = "default_true", rename = "agents-syncing")]
+    pub agents_syncing: bool,
+
     /// Where to install agent hooks.
     #[serde(
         default,
@@ -80,6 +87,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             auto_sync: true,
+            agents_syncing: true,
             hook_scope: HookScope::default(),
             agents: Vec::new(),
             logging: LoggingConfig::default(),
@@ -533,6 +541,16 @@ mod tests {
         let config: Config = toml::from_str("").unwrap();
         assert!(config.agents.is_empty());
         assert!(config.auto_sync); // default true
+        assert!(config.agents_syncing); // default true
+    }
+
+    #[test]
+    fn parse_agents_syncing_disabled() {
+        let config: Config = toml::from_str(indoc! {"
+            agents-syncing = false
+        "})
+        .unwrap();
+        assert!(!config.agents_syncing);
     }
 
     #[test]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -59,6 +59,21 @@ fn skills_parent_dir(agent: Agent, project_root: &Path) -> PathBuf {
         .to_path_buf()
 }
 
+/// Mark a directory as symposium-generated: drop the `.symposium` marker
+/// and a `.gitignore` containing `*` so the directory is recognized on
+/// future syncs and kept out of version control.
+///
+/// Idempotent — overwrites any pre-existing marker or `.gitignore` in
+/// `dir`. Callers use this both for freshly-installed plugin skills and
+/// for skills propagated by the agents-syncing feature.
+fn mark_generated_skill_directory(dir: &Path) -> Result<()> {
+    fs::write(dir.join(MARKER_FILE), "")
+        .with_context(|| format!("write marker in {}", dir.display()))?;
+    fs::write(dir.join(".gitignore"), "*\n")
+        .with_context(|| format!("write .gitignore in {}", dir.display()))?;
+    Ok(())
+}
+
 /// Discover user-authored skills in `<project_root>/.agents/skills/`.
 ///
 /// A skill is user-authored iff its directory contains `SKILL.md` and does
@@ -136,13 +151,11 @@ fn propagate_user_skill(
     create_managed_dir_all(dest_dir, project_root)?;
     copy_dir_recursive(source_dir, dest_dir)?;
 
-    // Drop the marker and a wildcard .gitignore. These overwrite anything
-    // the source happened to contain, so the destination is uniformly
-    // symposium-managed regardless of what was in the source tree.
-    fs::write(dest_dir.join(MARKER_FILE), "")
-        .with_context(|| format!("write marker in {}", dest_dir.display()))?;
-    fs::write(dest_dir.join(".gitignore"), "*\n")
-        .with_context(|| format!("write .gitignore in {}", dest_dir.display()))?;
+    // The copy may have clobbered any marker or `.gitignore` written by
+    // `create_managed_dir_all`, so re-apply them. This also guarantees a
+    // uniform "symposium-managed" shape regardless of what the source
+    // skill directory happened to contain.
+    mark_generated_skill_directory(dest_dir)?;
     Ok(true)
 }
 
@@ -253,11 +266,11 @@ pub async fn sync(sym: &Symposium, cwd: &Path, out: &Output) -> Result<()> {
 
             match agent.install_skill(skill_source, &dest_dir) {
                 Ok(()) => {
-                    // Drop the marker so future syncs (and other tools) can
-                    // recognize this directory as symposium-managed.
-                    let marker = dest_dir.join(MARKER_FILE);
-                    if let Err(e) = fs::write(&marker, "") {
-                        out.warn(format!("failed to write {}: {e}", display_path(&marker)));
+                    // Mark the directory as symposium-managed (marker +
+                    // wildcard .gitignore). Kept as a warning on failure so
+                    // a broken install doesn't halt the whole sync.
+                    if let Err(e) = mark_generated_skill_directory(&dest_dir) {
+                        out.warn(format!("failed to mark {}: {e}", display_path(&dest_dir)));
                     }
                     installed_dirs.insert(dest_dir.clone());
                     tracing::info!(%skill_name, agent = %agent_name, dest = %dest_dir.display(), "installed skill");

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -74,6 +74,13 @@ fn mark_generated_skill_directory(dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Does `dir` contain the `.symposium` marker, i.e. is it a symposium-managed
+/// skill directory? Returns `false` for user-authored skills and for any
+/// directory symposium did not create.
+fn has_symposium_marker(dir: &Path) -> bool {
+    dir.join(MARKER_FILE).exists()
+}
+
 /// Discover user-authored skills in `<project_root>/.agents/skills/`.
 ///
 /// A skill is user-authored iff its directory contains `SKILL.md` and does
@@ -91,7 +98,7 @@ fn discover_user_authored_skills(project_root: &Path) -> Vec<PathBuf> {
         .map(|e| e.path())
         .filter(|p| p.is_dir())
         .filter(|p| p.join("SKILL.md").is_file())
-        .filter(|p| !p.join(MARKER_FILE).exists())
+        .filter(|p| !has_symposium_marker(p))
         .collect();
     skills.sort();
     skills
@@ -134,7 +141,7 @@ fn propagate_user_skill(
         return Ok(false);
     }
 
-    let target_is_managed = dest_dir.join(MARKER_FILE).exists();
+    let target_is_managed = has_symposium_marker(dest_dir);
     if dest_dir.exists() && !target_is_managed {
         out.warn(format!(
             "skipping propagation to {}: user-managed skill already present",
@@ -350,7 +357,7 @@ pub async fn sync(sym: &Symposium, cwd: &Path, out: &Output) -> Result<()> {
             if !path.is_dir() || installed_dirs.contains(&path) {
                 continue;
             }
-            if !path.join(MARKER_FILE).exists() {
+            if !has_symposium_marker(&path) {
                 continue;
             }
             match fs::remove_dir_all(&path) {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -59,6 +59,93 @@ fn skills_parent_dir(agent: Agent, project_root: &Path) -> PathBuf {
         .to_path_buf()
 }
 
+/// Discover user-authored skills in `<project_root>/.agents/skills/`.
+///
+/// A skill is user-authored iff its directory contains `SKILL.md` and does
+/// *not* contain the `.symposium` marker. Symposium never writes markers
+/// into source skills, so this unambiguously separates user content from
+/// copies symposium put there itself.
+fn discover_user_authored_skills(project_root: &Path) -> Vec<PathBuf> {
+    let agents_skills_dir = project_root.join(".agents").join("skills");
+    let Ok(entries) = fs::read_dir(&agents_skills_dir) else {
+        return Vec::new();
+    };
+
+    let mut skills: Vec<PathBuf> = entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .filter(|p| p.join("SKILL.md").is_file())
+        .filter(|p| !p.join(MARKER_FILE).exists())
+        .collect();
+    skills.sort();
+    skills
+}
+
+/// Recursively copy the contents of `src` into `dst`. Creates `dst` if
+/// missing. Regular files are copied with `fs::copy`; subdirectories are
+/// walked. Symlinks and other special files are ignored.
+fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
+    fs::create_dir_all(dst).with_context(|| format!("create {}", dst.display()))?;
+    for entry in fs::read_dir(src).with_context(|| format!("read {}", src.display()))? {
+        let entry = entry?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            copy_dir_recursive(&src_path, &dst_path)?;
+        } else if file_type.is_file() {
+            fs::copy(&src_path, &dst_path)
+                .with_context(|| format!("copy {} → {}", src_path.display(), dst_path.display()))?;
+        }
+    }
+    Ok(())
+}
+
+/// Propagate a user-authored skill from `.agents/skills/<name>/` to
+/// `dest_dir`, returning `Ok(true)` if propagation happened (so the caller
+/// should record `dest_dir` as installed).
+///
+/// Leaves `dest_dir` alone if it exists and lacks the `.symposium` marker —
+/// the user put something there by hand and we must not clobber it.
+fn propagate_user_skill(
+    source_dir: &Path,
+    dest_dir: &Path,
+    project_root: &Path,
+    out: &Output,
+) -> Result<bool> {
+    if dest_dir == source_dir {
+        // Agent reads from the same directory as the source — nothing to do.
+        return Ok(false);
+    }
+
+    let target_is_managed = dest_dir.join(MARKER_FILE).exists();
+    if dest_dir.exists() && !target_is_managed {
+        out.warn(format!(
+            "skipping propagation to {}: user-managed skill already present",
+            display_path(dest_dir)
+        ));
+        return Ok(false);
+    }
+
+    // Clear any prior symposium-managed copy so removed files don't linger.
+    if dest_dir.exists() {
+        fs::remove_dir_all(dest_dir).with_context(|| format!("remove {}", dest_dir.display()))?;
+    }
+
+    create_managed_dir_all(dest_dir, project_root)?;
+    copy_dir_recursive(source_dir, dest_dir)?;
+
+    // Drop the marker and a wildcard .gitignore. These overwrite anything
+    // the source happened to contain, so the destination is uniformly
+    // symposium-managed regardless of what was in the source tree.
+    fs::write(dest_dir.join(MARKER_FILE), "")
+        .with_context(|| format!("write marker in {}", dest_dir.display()))?;
+    fs::write(dest_dir.join(".gitignore"), "*\n")
+        .with_context(|| format!("write .gitignore in {}", dest_dir.display()))?;
+    Ok(true)
+}
+
 /// Run the full sync: discover applicable skills, install into agent dirs,
 /// clean up stale installations.
 pub async fn sync(sym: &Symposium, cwd: &Path, out: &Output) -> Result<()> {
@@ -181,6 +268,53 @@ pub async fn sync(sym: &Symposium, cwd: &Path, out: &Output) -> Result<()> {
                 }
                 Err(e) => {
                     out.warn(format!("failed to install skill {skill_name}: {e}"));
+                }
+            }
+        }
+    }
+
+    // Propagate user-authored skills from `.agents/skills/` into every
+    // configured agent that reads skills from a different directory. Skills
+    // are "user-authored" when they lack the `.symposium` marker — symposium
+    // never writes that marker into a source, so this never re-propagates
+    // symposium's own installs. See the agents-syncing feature docs.
+    if sym.config.agents_syncing {
+        let user_authored = discover_user_authored_skills(&project_root);
+        if !user_authored.is_empty() {
+            tracing::debug!(
+                count = user_authored.len(),
+                "propagating user-authored skills from .agents/skills/"
+            );
+            for agent_name in &agent_names {
+                let agent = Agent::from_config_name(agent_name)?;
+                for source_dir in &user_authored {
+                    let name = match source_dir.file_name().and_then(|n| n.to_str()) {
+                        Some(n) => n,
+                        None => continue,
+                    };
+                    let dest_dir = agent.project_skill_dir(&project_root, name);
+                    match propagate_user_skill(source_dir, &dest_dir, &project_root, out) {
+                        Ok(true) => {
+                            installed_dirs.insert(dest_dir.clone());
+                            tracing::info!(
+                                skill = %name,
+                                agent = %agent_name,
+                                dest = %dest_dir.display(),
+                                "propagated skill from .agents/skills/"
+                            );
+                            out.done(format!(
+                                "propagated skill {name} → {}",
+                                display_path(&dest_dir)
+                            ));
+                        }
+                        Ok(false) => {}
+                        Err(e) => {
+                            out.warn(format!(
+                                "failed to propagate skill {name} to {}: {e}",
+                                display_path(&dest_dir)
+                            ));
+                        }
+                    }
                 }
             }
         }

--- a/tests/fixtures/user-skills0/.agents/skills/user-authored-skill/REFERENCE.md
+++ b/tests/fixtures/user-skills0/.agents/skills/user-authored-skill/REFERENCE.md
@@ -1,0 +1,4 @@
+# Reference material
+
+Auxiliary file shipped alongside the user-authored skill. Propagation
+should copy this file too.

--- a/tests/fixtures/user-skills0/.agents/skills/user-authored-skill/SKILL.md
+++ b/tests/fixtures/user-skills0/.agents/skills/user-authored-skill/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: user-authored-skill
+description: A skill authored directly by the user in .agents/skills/
+---
+
+# User-authored skill body
+
+This skill was not installed by symposium. It was placed in
+`.agents/skills/` by the user and should be propagated to other configured
+agents' skill directories.

--- a/tests/init_sync.rs
+++ b/tests/init_sync.rs
@@ -687,3 +687,207 @@ async fn sync_installations_are_gitignored() {
     .await
     .unwrap();
 }
+
+// ---------------------------------------------------------------------------
+// agents-syncing: propagate user-authored skills from `.agents/skills/`
+// ---------------------------------------------------------------------------
+
+/// User-authored skills in `.agents/skills/` are propagated to agents that
+/// read skills from a different directory (e.g. Claude → `.claude/skills/`).
+/// Companion files next to `SKILL.md` are copied too, and the destination
+/// receives a `.symposium` marker so future syncs recognize it as managed.
+#[tokio::test]
+async fn agents_syncing_propagates_user_authored_skill_to_claude() {
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["plugins0", "workspace0", "user-skills0"],
+        async |mut ctx| {
+            ctx.symposium(&["init", "--add-agent", "claude"]).await?;
+            ctx.symposium(&["sync"]).await?;
+
+            let workspace_root = ctx.workspace_root.as_ref().unwrap();
+
+            // Source is untouched. Notably, symposium does not drop a marker
+            // into source skills — that's what keeps them "user-authored".
+            let source = workspace_root.join(".agents/skills/user-authored-skill");
+            assert!(source.join("SKILL.md").exists(), "source SKILL.md stays");
+            assert!(
+                !source.join(".symposium").exists(),
+                "symposium must not mark source skills"
+            );
+
+            // Propagated copy exists with SKILL.md, companion files, marker,
+            // and wildcard gitignore.
+            let dest = workspace_root.join(".claude/skills/user-authored-skill");
+            assert!(dest.join("SKILL.md").exists(), "SKILL.md propagated");
+            assert!(
+                dest.join("REFERENCE.md").exists(),
+                "companion files propagated"
+            );
+            assert!(dest.join(".symposium").exists(), "marker present");
+            let gi = std::fs::read_to_string(dest.join(".gitignore"))?;
+            assert_eq!(gi.trim(), "*", "destination gitignore is wildcard");
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+}
+
+/// When only agents that natively read `.agents/skills/` are configured,
+/// propagation has no distinct target directory and is a no-op.
+#[tokio::test]
+async fn agents_syncing_noop_when_only_agents_path_used() {
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["plugins0", "workspace0", "user-skills0"],
+        async |mut ctx| {
+            ctx.symposium(&["init", "--add-agent", "copilot"]).await?;
+            ctx.symposium(&["sync"]).await?;
+
+            let workspace_root = ctx.workspace_root.as_ref().unwrap();
+
+            // Source stays in place, unmarked.
+            let source = workspace_root.join(".agents/skills/user-authored-skill");
+            assert!(source.join("SKILL.md").exists());
+            assert!(
+                !source.join(".symposium").exists(),
+                "source must remain unmarked"
+            );
+            // No other agent's skills dir should have been created.
+            assert!(!workspace_root.join(".claude/skills").exists());
+            assert!(!workspace_root.join(".kiro/skills").exists());
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+}
+
+/// Setting `agents-syncing = false` disables propagation entirely.
+#[tokio::test]
+async fn agents_syncing_disabled_skips_propagation() {
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["plugins0", "workspace0", "user-skills0"],
+        async |mut ctx| {
+            ctx.symposium(&["init", "--add-agent", "claude"]).await?;
+            ctx.sym.config.agents_syncing = false;
+            ctx.symposium(&["sync"]).await?;
+
+            let workspace_root = ctx.workspace_root.as_ref().unwrap();
+            assert!(
+                !workspace_root
+                    .join(".claude/skills/user-authored-skill")
+                    .exists(),
+                "propagation should not occur when agents-syncing is disabled"
+            );
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+}
+
+/// Removing a user-authored skill from `.agents/skills/` causes its
+/// previously propagated copy to be reaped by the next sync (the marker
+/// is still there, but it's no longer in the freshly-installed set).
+#[tokio::test]
+async fn agents_syncing_cleans_up_removed_user_skill() {
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["plugins0", "workspace0", "user-skills0"],
+        async |mut ctx| {
+            ctx.symposium(&["init", "--add-agent", "claude"]).await?;
+            ctx.symposium(&["sync"]).await?;
+
+            let workspace_root = ctx.workspace_root.clone().unwrap();
+            let propagated = workspace_root.join(".claude/skills/user-authored-skill");
+            assert!(propagated.exists(), "first sync should propagate");
+            assert!(propagated.join(".symposium").exists());
+
+            // User removes the source.
+            std::fs::remove_dir_all(workspace_root.join(".agents/skills/user-authored-skill"))?;
+
+            ctx.symposium(&["sync"]).await?;
+
+            assert!(
+                !propagated.exists(),
+                "second sync should reap propagated copy once source is removed"
+            );
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+}
+
+/// Turning `agents-syncing` off on a subsequent sync removes previously
+/// propagated copies — the feature self-heals when disabled.
+#[tokio::test]
+async fn agents_syncing_disabling_removes_previously_propagated_skills() {
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["plugins0", "workspace0", "user-skills0"],
+        async |mut ctx| {
+            ctx.symposium(&["init", "--add-agent", "claude"]).await?;
+            ctx.symposium(&["sync"]).await?;
+
+            let workspace_root = ctx.workspace_root.clone().unwrap();
+            let propagated = workspace_root.join(".claude/skills/user-authored-skill");
+            assert!(propagated.exists(), "first sync should propagate");
+
+            ctx.sym.config.agents_syncing = false;
+            ctx.symposium(&["sync"]).await?;
+
+            assert!(
+                !propagated.exists(),
+                "disabling agents-syncing should clean up previously propagated copies"
+            );
+            // Source must remain untouched.
+            assert!(
+                workspace_root
+                    .join(".agents/skills/user-authored-skill/SKILL.md")
+                    .exists()
+            );
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+}
+
+/// A pre-existing, user-managed directory in the target (no `.symposium`
+/// marker) is not overwritten even when a same-named skill exists in
+/// `.agents/skills/`.
+#[tokio::test]
+async fn agents_syncing_does_not_overwrite_user_managed_target() {
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["plugins0", "workspace0", "user-skills0"],
+        async |mut ctx| {
+            ctx.symposium(&["init", "--add-agent", "claude"]).await?;
+
+            let workspace_root = ctx.workspace_root.clone().unwrap();
+
+            // Pre-existing, user-managed file in the target with the same name.
+            let target_dir = workspace_root.join(".claude/skills/user-authored-skill");
+            std::fs::create_dir_all(&target_dir)?;
+            let preexisting = target_dir.join("SKILL.md");
+            std::fs::write(&preexisting, "pre-existing user content")?;
+
+            ctx.symposium(&["sync"]).await?;
+
+            // File untouched — propagation must not clobber user-managed content.
+            let content = std::fs::read_to_string(&preexisting)?;
+            assert_eq!(content, "pre-existing user content");
+            assert!(
+                !target_dir.join(".symposium").exists(),
+                "no marker should be dropped onto a user-managed directory"
+            );
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+}


### PR DESCRIPTION
## What does this PR do?

When enabled (default), sync mirrors skills the user places in `.agents/skills/<name>/` into each configured agent's own skill directory (e.g. `.claude/skills/`, `.kiro/skills/`). A skill is considered user-authored when it is not tracked by the `.symposium.toml` manifest in `.agents/skills/`.

SkillManifest gains a `propagated` set alongside `installed`; stale-cleanup now walks the union of both, so removing the source or turning the feature off removes previously propagated copies on the next sync. Pre-existing user-managed files in the target directory are never overwritten.

Controlled by a new `agents-syncing` bool in `~/.symposium/config.toml`, default true.
