### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/symposium-dev/symposium/compare/symposium-v0.3.0...symposium-v0.4.0) - 2026-05-14
+
+### Added
+
+- inject update nudge into session-start hook additionalContext
+- add self-update command and auto-update infrastructure
+
+### Fixed
+
+- normalize CURRENT_VERSION in test snapshots for release compatibility
+- use atomic rename in mock cargo install to avoid "Text file busy"
+- rustfmt formatting and switch version check to cargo search
+
+### Other
+
+- remove binary download, default auto-update to on, add init prompt
+- auto-update re-exec for both sync and hook invocations
+- end-to-end auto-update re-exec with mock cargo install
+- snapshot output for update check tests with expect_test
+- capture Output messages, assert update warning text
+- move auto-update check into cli::run, add integration tests
+- move cargo override from env var to Symposium field
+- cargo search, cargo_command() helper, tests, hook update behavior
+- SkillOrigin keyed on source location, readable Crate dirs
+- demotion to suffixed names when a new origin introduces a conflict
+- promotion to unsuffixed slot when origin conflict disappears
+- only suffix skill dirs with origin hash on conflict
+- dispatch on group source via single match in load_skills_for_group
+- SkillOrigin::Git keys on (repo, commit_sha, skill_path)
+- per-group disambiguator on SkillOrigin::Plugin; sha2 hash
+- introduce SkillOrigin and dedup skill installs by origin
+- add has_symposium_marker helper
+- address review comments
+- drop unimplemented 'distribution: workspace' section
+- rewrite workspace-skills page
+- Document workspace skills in user guide
+- Add agents-syncing: mirror user-authored skills across agent dirs
+
 ## [0.3.0](https://github.com/symposium-dev/symposium/compare/symposium-v0.2.1...symposium-v0.3.0) - 2026-05-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symposium"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symposium"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "AI the Rust Way"


### PR DESCRIPTION



## 🤖 New release

* `symposium`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `symposium` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Config.agents_syncing in /tmp/.tmpvk7zqe/symposium/src/config.rs:68
  field Config.auto_update in /tmp/.tmpvk7zqe/symposium/src/config.rs:84
  field ParsedPlugin.source_name in /tmp/.tmpvk7zqe/symposium/src/plugins.rs:298
  field ParsedPlugin.source_dir in /tmp/.tmpvk7zqe/symposium/src/plugins.rs:302

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type Output no longer derives Copy, in /tmp/.tmpvk7zqe/symposium/src/output.rs:11

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant Commands::CrateInfo 4 -> 5 in /tmp/.tmpvk7zqe/symposium/src/cli.rs:82

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant Commands:SelfUpdate in /tmp/.tmpvk7zqe/symposium/src/cli.rs:78

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/function_parameter_count_changed.ron

Failed in:
  symposium::init::find_workspace_root now takes 2 parameters instead of 1, in /tmp/.tmpvk7zqe/symposium/src/init.rs:199
  symposium::plugins::load_plugin now takes 3 parameters instead of 1, in /tmp/.tmpvk7zqe/symposium/src/plugins.rs:1324
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/symposium-dev/symposium/compare/symposium-v0.3.0...symposium-v0.4.0) - 2026-05-14

### Added

- inject update nudge into session-start hook additionalContext
- add self-update command and auto-update infrastructure

### Fixed

- normalize CURRENT_VERSION in test snapshots for release compatibility
- use atomic rename in mock cargo install to avoid "Text file busy"
- rustfmt formatting and switch version check to cargo search

### Other

- remove binary download, default auto-update to on, add init prompt
- auto-update re-exec for both sync and hook invocations
- end-to-end auto-update re-exec with mock cargo install
- snapshot output for update check tests with expect_test
- capture Output messages, assert update warning text
- move auto-update check into cli::run, add integration tests
- move cargo override from env var to Symposium field
- cargo search, cargo_command() helper, tests, hook update behavior
- SkillOrigin keyed on source location, readable Crate dirs
- demotion to suffixed names when a new origin introduces a conflict
- promotion to unsuffixed slot when origin conflict disappears
- only suffix skill dirs with origin hash on conflict
- dispatch on group source via single match in load_skills_for_group
- SkillOrigin::Git keys on (repo, commit_sha, skill_path)
- per-group disambiguator on SkillOrigin::Plugin; sha2 hash
- introduce SkillOrigin and dedup skill installs by origin
- add has_symposium_marker helper
- address review comments
- drop unimplemented 'distribution: workspace' section
- rewrite workspace-skills page
- Document workspace skills in user guide
- Add agents-syncing: mirror user-authored skills across agent dirs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).