### PR TITLE
Add global install option for cargo and add env vars for binaries and directories

### DIFF
--- a/md/reference/plugin-definition.md
+++ b/md/reference/plugin-definition.md
@@ -191,7 +191,7 @@ git = "https://github.com/example/tool"
 executable = "tool"   # required for git sources (crates.io is not consulted)
 ```
 
-To install into the user's global cargo location (`~/.cargo/bin`) instead of a symposium-managed cache, set `global = true`. No `--root` is passed; `$PATH` is not augmented (the binary is expected to already be on `$PATH`).
+To install into the user's global cargo location (`~/.cargo/bin`) instead of a symposium-managed cache, set `global = true`. No `--root` is passed; `$PATH` is not augmented (the binary is expected to already be on `$PATH`). This can be useful if you are using scripts which require globally-installed programs, or if you want to use tools separately in a CLI.
 
 ```toml
 [[installations]]

--- a/md/reference/plugin-definition.md
+++ b/md/reference/plugin-definition.md
@@ -53,7 +53,7 @@ crates = ["serde", "tokio"]  # Only active in projects using serde OR tokio
 crates = ["*"]
 ```
 
-If omitted, the plugin applies to all projects. Plugin-level filtering is combined with skill group filtering using AND logic — both must match for skills to be available.
+Plugin-level filtering is combined with skill group filtering using AND logic — both must match for skills to be available.
 
 ## `[[skills]]` groups
 
@@ -178,7 +178,7 @@ executable = "rg"      # the binary to run; if omitted and the crate has a singl
 args = ["--version"]   # optional default args
 ```
 
-Symposium attempts `cargo binstall` first, falls back to `cargo install`, and caches the result under `~/.symposium/cache/binaries/<crate>/<version>/bin/`. The chosen `executable` resolves to `<cache>/bin/<executable>`.
+Symposium attempts `cargo binstall` first, falls back to `cargo install`, and caches the result under `~/.symposium/cache/binaries/<crate>/<version>/bin/` (passing `--root` so the install doesn't pollute `~/.cargo/bin`). The chosen `executable` resolves to `<cache>/bin/<executable>`. Hooks that depend on this installation get `<cache>/bin/` prepended to `$PATH`, so scripts can invoke the binary by name.
 
 To install from a git repo instead of crates.io, set `git`:
 
@@ -189,6 +189,17 @@ source = "cargo"
 crate = "tool"
 git = "https://github.com/example/tool"
 executable = "tool"   # required for git sources (crates.io is not consulted)
+```
+
+To install into the user's global cargo location (`~/.cargo/bin`) instead of a symposium-managed cache, set `global = true`. No `--root` is passed; `$PATH` is not augmented (the binary is expected to already be on `$PATH`).
+
+```toml
+[[installations]]
+name = "rg"
+source = "cargo"
+crate = "ripgrep"
+executable = "rg"
+global = true
 ```
 
 #### `github`
@@ -377,6 +388,22 @@ script = "hooks/claude/rtk-rewrite.sh"
 ```
 
 Requirement installation is best-effort: failures are logged and dispatch continues.
+
+### Hook environment
+
+Hooks are spawned with the following extras on top of the parent environment:
+
+| Variable | When set | Value |
+|----------|----------|-------|
+| `$SYMPOSIUM_DIR_<name>` | Installation has a symposium-managed cache (scoped cargo, github) | Absolute path to the cache / clone directory. |
+| `$SYMPOSIUM_<name>` | Installation resolves to a runnable with an absolute path | Absolute path to the resolved executable / script. |
+| `$PATH` | One or more dependencies contribute a runnable with an absolute path | Each runnable's parent dir is prepended, with the hook's `command` first. |
+
+`<name>` is the installation name with non-alphanumeric characters replaced by `_` (e.g. `rtk-hooks` → `SYMPOSIUM_DIR_rtk_hooks`). Both the hook's `command` installation and every requirement (recursively, one level via installation-level requirements) contribute.
+
+Global cargo installs (`global = true`) don't set `$SYMPOSIUM_DIR_<name>` or augment `$PATH` — the binary is expected to already be on the user's `$PATH` via `~/.cargo/bin`.
+
+> **`install_commands` runs before env vars are set.** The `$SYMPOSIUM_*` vars and the augmented `$PATH` are only available to the hook's spawned process. `install_commands` runs earlier, inside the symposium dispatch process, so it cannot reference its own (or any other) installation's env vars. Use absolute paths in `install_commands` instead.
 
 ### Supported hook events
 

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -5,7 +5,11 @@ use std::{
     process::{Command, ExitCode, Stdio},
 };
 
-use crate::installation::{install_requirement, resolve_runnable};
+use symposium_install::Runnable;
+
+use crate::installation::{
+    AcquiredInstallation, AcquiredRunnable, acquire_installation, resolve_runnable,
+};
 use crate::plugins::{HookFormat, Installation};
 use crate::{
     config::Symposium,
@@ -19,7 +23,6 @@ use crate::{
     plugins::load_registry,
     subcommand_dispatch::applicable_subcommands,
 };
-use symposium_install::Runnable;
 
 /// A hook prepared for dispatch — installation names looked up to concrete
 /// `Installation` entries, so the dispatch loop never has to scan the plugin's
@@ -68,50 +71,141 @@ impl ResolvedHook {
     }
 }
 
+/// Sanitize an installation name for use as part of an env var name.
+/// Replaces non-alphanumeric chars with underscore.
+fn env_safe(name: &str) -> String {
+    name.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect()
+}
+
+/// Build the env vars (including augmented PATH) for the spawn.
+///
+/// Iterates `acquired` in order; the parent directory of each absolute
+/// `runnable` is prepended to `$PATH` so later entries take precedence over
+/// earlier ones (the command's own parent ends up first since it's pushed
+/// last and prepended).
+fn build_env(acquired: &[AcquiredInstallation]) -> Vec<(String, String)> {
+    let mut env = Vec::new();
+    let mut path_prefix: Vec<String> = Vec::new();
+
+    for a in acquired {
+        let key = env_safe(&a.name);
+        if let Some(base) = &a.base {
+            env.push((format!("SYMPOSIUM_DIR_{key}"), base.display().to_string()));
+        }
+        if let Some(
+            AcquiredRunnable::ResolvedScript { path, .. } | AcquiredRunnable::ResolvedExec { path },
+        ) = &a.runnable
+        {
+            env.push((format!("SYMPOSIUM_{key}"), path.display().to_string()));
+            if let Some(parent) = path.parent() {
+                let parent_str = parent.display().to_string();
+                if !parent_str.is_empty() {
+                    path_prefix.push(parent_str);
+                }
+            }
+        }
+    }
+
+    // Command was pushed last into `acquired`; reverse so its bin dir wins
+    // PATH lookup over requirements' bin dirs.
+    path_prefix.reverse();
+
+    if !path_prefix.is_empty() {
+        let existing = std::env::var("PATH").unwrap_or_default();
+        let joined = if existing.is_empty() {
+            path_prefix.join(":")
+        } else {
+            format!("{}:{}", path_prefix.join(":"), existing)
+        };
+        env.push(("PATH".to_string(), joined));
+    }
+
+    env
+}
+
 enum SpawnSpec {
-    Exec { path: PathBuf, args: Vec<String> },
-    Script { path: PathBuf, args: Vec<String> },
+    Exec {
+        path: PathBuf,
+        args: Vec<String>,
+        env: Vec<(String, String)>,
+    },
+    Script {
+        path: PathBuf,
+        args: Vec<String>,
+        env: Vec<(String, String)>,
+    },
 }
 
 async fn build_spawn_spec(sym: &Symposium, hook: &ResolvedHook) -> anyhow::Result<SpawnSpec> {
-    let label = format!("hook `{}`", hook.hook_name);
-    let runnable = resolve_runnable(
+    // Acquire requirements first so the command's PATH sees them.
+    let mut acquired: Vec<AcquiredInstallation> = Vec::new();
+    for requirement in &hook.requirements {
+        match acquire_installation(sym, requirement, None, None).await {
+            Ok(a) => acquired.push(a),
+            Err(e) => {
+                tracing::error!(
+                    name = %requirement.name,
+                    error = %e,
+                    "failed to install hook requirement"
+                );
+            }
+        }
+    }
+
+    let command_acquired = acquire_installation(
         sym,
         &hook.command,
         hook.hook_executable.as_deref(),
         hook.hook_script.as_deref(),
-        &label,
     )
     .await?;
 
+    acquired.push(command_acquired.clone());
+    let env = build_env(&acquired);
+
+    let label = format!("hook `{}`", hook.hook_name);
+    let runnable = resolve_runnable(command_acquired, &label)?;
+
     Ok(match runnable {
-        Runnable::Exec(path) => SpawnSpec::Exec {
-            path,
-            args: hook.args.clone(),
-        },
         Runnable::Script(path) => SpawnSpec::Script {
             path,
             args: hook.args.clone(),
+            env,
         },
-        _ => anyhow::bail!("hook `{}`: unsupported runnable kind", hook.hook_name),
+        Runnable::Exec(path) => SpawnSpec::Exec {
+            path,
+            args: hook.args.clone(),
+            env,
+        },
     })
 }
 
 fn spawn_from_spec(spec: SpawnSpec) -> std::io::Result<std::process::Child> {
     match spec {
-        SpawnSpec::Script { path, args } => Command::new("sh")
-            .arg(path)
-            .args(args)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn(),
-        SpawnSpec::Exec { path, args } => Command::new(path)
-            .args(args)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn(),
+        SpawnSpec::Script { path, args, env } => {
+            let mut cmd = Command::new("sh");
+            cmd.arg(path).args(args);
+            for (k, v) in env {
+                cmd.env(k, v);
+            }
+            cmd.stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+        }
+        SpawnSpec::Exec { path, args, env } => {
+            let mut cmd = Command::new(path);
+            cmd.args(args);
+            for (k, v) in env {
+                cmd.env(k, v);
+            }
+            cmd.stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+        }
     }
 }
 
@@ -407,13 +501,6 @@ pub async fn dispatch_plugin_hooks(
             "running plugin hook"
         );
 
-        // Acquire each requirement (best-effort).
-        for requirement in &hook.requirements {
-            if let Err(e) = install_requirement(sym, requirement).await {
-                tracing::error!(name = %requirement.name, error = %e, "failed to install hook requirement");
-            }
-        }
-
         // Determine stdin for the plugin based on its declared format.
         // After format selection, the only two cases are:
         // - native (matches host agent) → pass through original input
@@ -599,6 +686,90 @@ fn dispatched_hooks_for_payload(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn env_safe_sanitizes_punctuation() {
+        assert_eq!(env_safe("rtk"), "rtk");
+        assert_eq!(env_safe("rtk-hooks"), "rtk_hooks");
+        assert_eq!(env_safe("a.b-c"), "a_b_c");
+        assert_eq!(env_safe("name__req_0"), "name__req_0");
+    }
+
+    #[test]
+    fn build_env_sets_dir_and_name_vars() {
+        // [req (rtk), command (no-source)] order — command was pushed last,
+        // so PATH should put its bin dir first.
+        let acquired = vec![
+            AcquiredInstallation {
+                name: "rtk".to_string(),
+                base: Some(PathBuf::from("/cache/rtk/1.0")),
+                runnable: Some(AcquiredRunnable::ResolvedExec {
+                    path: PathBuf::from("/cache/rtk/1.0/bin/rtk"),
+                }),
+            },
+            AcquiredInstallation {
+                name: "no-source".to_string(),
+                base: None,
+                runnable: Some(AcquiredRunnable::ResolvedExec {
+                    path: PathBuf::from("/usr/local/bin/tool"),
+                }),
+            },
+        ];
+        let env: std::collections::HashMap<_, _> = build_env(&acquired).into_iter().collect();
+        assert_eq!(
+            env.get("SYMPOSIUM_DIR_rtk").map(String::as_str),
+            Some("/cache/rtk/1.0")
+        );
+        assert_eq!(
+            env.get("SYMPOSIUM_rtk").map(String::as_str),
+            Some("/cache/rtk/1.0/bin/rtk")
+        );
+        // No source means no _DIR, but absolute runnable path → SYMPOSIUM_<name> set.
+        assert_eq!(env.get("SYMPOSIUM_DIR_no_source"), None);
+        assert_eq!(
+            env.get("SYMPOSIUM_no_source").map(String::as_str),
+            Some("/usr/local/bin/tool")
+        );
+        // Command (pushed last) wins PATH lookup, so its parent comes first.
+        let path = env.get("PATH").expect("PATH set");
+        assert!(path.starts_with("/usr/local/bin"), "PATH = {path}");
+        assert!(path.contains("/cache/rtk/1.0/bin"), "PATH = {path}");
+    }
+
+    #[test]
+    fn build_env_no_runnable_no_vars() {
+        // Pure-setup installation: no runnable means no SYMPOSIUM_<name>
+        // and no PATH contribution. SYMPOSIUM_DIR_<name> still gets set
+        // when there's a managed base dir.
+        let acquired = vec![AcquiredInstallation {
+            name: "setup".to_string(),
+            base: Some(PathBuf::from("/cache/setup")),
+            runnable: None,
+        }];
+        let env: std::collections::HashMap<_, _> = build_env(&acquired).into_iter().collect();
+        assert_eq!(
+            env.get("SYMPOSIUM_DIR_setup").map(String::as_str),
+            Some("/cache/setup")
+        );
+        assert!(env.get("SYMPOSIUM_setup").is_none());
+        assert!(env.get("PATH").is_none());
+    }
+
+    #[test]
+    fn build_env_global_cargo_skips_env_and_path() {
+        // Global cargo: PathLookup runnable. Nothing exposed.
+        let acquired = vec![AcquiredInstallation {
+            name: "rg".to_string(),
+            base: None,
+            runnable: Some(AcquiredRunnable::GlobalExec {
+                path: PathBuf::from("rg".to_string()),
+            }),
+        }];
+        let env: std::collections::HashMap<_, _> = build_env(&acquired).into_iter().collect();
+        assert!(env.get("SYMPOSIUM_DIR_rg").is_none());
+        assert!(env.get("SYMPOSIUM_rg").is_none());
+        assert!(env.get("PATH").is_none());
+    }
 
     #[tokio::test]
     async fn builtin_pre_tool_use_returns_empty() {

--- a/src/installation.rs
+++ b/src/installation.rs
@@ -28,39 +28,60 @@ pub async fn run_install_commands(commands: &[String]) -> Result<()> {
     Ok(())
 }
 
-/// Acquire an installation as a requirement: run its kind-specific source
-/// step (if any), then any declared `install_commands`. Does NOT resolve to
-/// a runnable — requirements are only ever "ensure on disk".
-pub async fn install_requirement(sym: &Symposium, install: &Installation) -> Result<()> {
-    if let Some(source) = &install.source {
-        acquire_source(
-            &sym.install_context(),
-            source,
-            install.executable.as_deref(),
-        )
-        .await?;
-    }
-    run_install_commands(&install.install_commands).await
+/// Per-installation snapshot the dispatcher builds for the command and each
+/// requirement. Drives env-var wiring for the spawned hook process:
+/// `$SYMPOSIUM_DIR_<name>`, `$SYMPOSIUM_<name>`, and the `$PATH` prefix.
+///
+/// One layer above [`AcquiredSource`]: that's the raw source-acquisition
+/// result (where the bits landed + how to resolve names within them);
+/// `AcquiredInstallation` is what we keep after layering on the installation's
+/// `install_commands`, `executable`/`script` resolution, and the no-source
+/// case where there's nothing to acquire at all. The dispatcher only cares
+/// about the resolved form, so this is what flows from
+/// [`acquire_installation`] into [`build_env`] and [`build_spawn_spec`].
+#[derive(Clone, Debug)]
+pub struct AcquiredInstallation {
+    /// Installation name as declared in the manifest. Sanitized via
+    /// [`env_safe`] when used in env var keys.
+    pub name: String,
+    /// Cache or clone directory the source landed in. `None` for no-source
+    /// installations and for global cargo (which lives in the user's
+    /// `~/.cargo/bin`, outside symposium's management).
+    pub base: Option<PathBuf>,
+    /// What this installation resolves to at spawn time, or `None` when the
+    /// installation has nothing runnable (pure setup).
+    pub runnable: Option<AcquiredRunnable>,
 }
 
-/// Acquire an installation's source (if any), run its `install_commands`, and
-/// pick a `Runnable` from (`installation.executable`/`script`) with the
-/// caller's overrides used when the installation leaves them unset.
+/// How `Command::new` should be invoked for an installation that resolved
+/// to *something* runnable.
+#[derive(Clone, Debug)]
+pub enum AcquiredRunnable {
+    /// Symposium-resolved absolute path. Exposed as `$SYMPOSIUM_<name>` and
+    /// its parent dir is prepended to `$PATH`.
+    ResolvedScript { path: PathBuf },
+    /// Symposium-resolved absolute path. Exposed as `$SYMPOSIUM_<name>` and
+    /// its parent dir is prepended to `$PATH`.
+    ResolvedExec { path: PathBuf },
+    /// Bare binary name, relying on `$PATH` lookup at spawn time (global
+    /// cargo). Not exposed in env vars and doesn't contribute to `$PATH` —
+    /// the installation is intentionally outside symposium's view.
+    GlobalExec { path: PathBuf },
+}
+
+/// Acquire an installation: run its source step (if any), run
+/// `install_commands`, and resolve its runnable using the installation's
+/// own `executable`/`script` plus any hook-level overrides.
 ///
-/// `label` is the caller's identifier for error messages (e.g. `"hook `foo`"`
-/// or `"subcommand `bar`"`). Used purely for diagnostics; does not affect
-/// resolution.
-///
-/// Validation (in `plugins.rs`) guarantees that across the installation and
-/// the caller-side overrides, at most one of `executable`/`script` is set,
-/// so this function does not re-check that invariant.
-pub async fn resolve_runnable(
+/// `plugin_dir` is the directory containing the plugin's manifest;
+/// relative `executable` / `script` paths on no-source installations
+/// resolve against it.
+pub async fn acquire_installation(
     sym: &Symposium,
     installation: &Installation,
     override_executable: Option<&str>,
     override_script: Option<&str>,
-    label: &str,
-) -> Result<Runnable> {
+) -> anyhow::Result<AcquiredInstallation> {
     let exec_choice = installation.executable.as_deref().or(override_executable);
     let script_choice = installation.script.as_deref().or(override_script);
 
@@ -71,28 +92,58 @@ pub async fn resolve_runnable(
 
     run_install_commands(&installation.install_commands).await?;
 
-    let runnable = match (acquired, exec_choice, script_choice) {
-        (Some(a), Some(name), None) => Runnable::Exec(a.executable_named(name)),
-        (Some(a), None, Some(name)) => Runnable::Script(a.script_named(name)),
-        (Some(a), None, None) => {
-            if let Some(name) = a.resolved_executable.as_deref() {
-                Runnable::Exec(a.executable_named(name))
-            } else {
-                bail!("{label}: command resolved to no executable or script");
-            }
+    let runnable = match (&acquired, exec_choice, script_choice) {
+        // Unmanaged source (global cargo): bare name, $PATH lookup at spawn.
+        // Validation guarantees `exec_choice` is set for cargo + global.
+        (Some(a), _, _) if a.base.is_none() => {
+            let name = exec_choice
+                .or(a.resolved_executable.as_deref())
+                .expect("global cargo validation enforces an executable name")
+                .to_string();
+            Some(AcquiredRunnable::GlobalExec {
+                path: PathBuf::from(name),
+            })
         }
-        (None, Some(name), None) => Runnable::Exec(PathBuf::from(name)),
-        (None, None, Some(name)) => Runnable::Script(PathBuf::from(name)),
-        (None, None, None) => bail!("{label}: command resolved to no executable or script"),
+        (Some(a), Some(name), None) => Some(AcquiredRunnable::ResolvedExec {
+            path: a.executable_named(name),
+        }),
+        (Some(a), None, Some(name)) => Some(AcquiredRunnable::ResolvedScript {
+            path: a.script_named(name),
+        }),
+        (Some(a), None, None) if let Some(path) = a.executable() => {
+            Some(AcquiredRunnable::ResolvedExec { path })
+        }
+        (Some(_), None, None) => None,
+        // For both of these: if there is no source, then the exec/script must *obviously* be global
+        (None, Some(name), None) => Some(AcquiredRunnable::ResolvedExec {
+            path: PathBuf::from(name),
+        }),
+        (None, None, Some(name)) => Some(AcquiredRunnable::ResolvedScript {
+            path: PathBuf::from(name),
+        }),
+        (None, None, None) => None,
         (_, Some(_), Some(_)) => unreachable!("validation forbids both executable and script"),
     };
 
-    match &runnable {
-        Runnable::Exec(path) => {
-            make_executable(path).ok();
-        }
-        Runnable::Script(_) => {}
-        _ => bail!("{label}: unsupported runnable kind"),
+    if let Some(AcquiredRunnable::ResolvedExec { path }) = &runnable {
+        make_executable(path).ok();
     }
+
+    Ok(AcquiredInstallation {
+        name: installation.name.clone(),
+        base: acquired.as_ref().and_then(|a| a.base.clone()),
+        runnable,
+    })
+}
+
+pub fn resolve_runnable(installation: AcquiredInstallation, label: &str) -> Result<Runnable> {
+    let Some(runnable) = installation.runnable else {
+        bail!("{label} has no executable or script");
+    };
+    let runnable = match runnable {
+        AcquiredRunnable::ResolvedScript { path } => Runnable::Script(path),
+        AcquiredRunnable::ResolvedExec { path } => Runnable::Exec(path),
+        AcquiredRunnable::GlobalExec { path } => Runnable::Exec(path),
+    };
     Ok(runnable)
 }

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -547,15 +547,22 @@ fn validate_installation(install: &Installation) -> Result<()> {
             install.name
         );
     }
-    if let Some(Source::Cargo(c)) = &install.source
-        && c.git.is_some()
-        && install.executable.is_none()
-    {
-        bail!(
-            "installation `{}`: cargo source with `git` requires `executable` to be set \
-             (crates.io is not consulted, so the binary name is unknown)",
-            install.name
-        );
+    if let Some(Source::Cargo(c)) = &install.source {
+        if c.git.is_some() && install.executable.is_none() {
+            bail!(
+                "installation `{}`: cargo source with `git` requires `executable` to be set \
+                 (crates.io is not consulted, so the binary name is unknown)",
+                install.name
+            );
+        }
+        if c.global && install.executable.is_none() {
+            bail!(
+                "installation `{}`: cargo source with `global = true` requires `executable` to \
+                 be set (the binary is spawned by name via `$PATH` lookup, so we don't infer \
+                 it from crates.io)",
+                install.name
+            );
+        }
     }
     Ok(())
 }
@@ -2752,6 +2759,65 @@ mod tests {
             command = "rg"
         "#};
         from_str(toml).expect("parse");
+    }
+
+    /// `global = true` on cargo source round-trips through validation.
+    #[test]
+    fn cargo_global_field_round_trips() {
+        let toml = indoc! {r#"
+            name = "p"
+            crates = ["*"]
+
+            [[installations]]
+            name = "rg"
+            source = "cargo"
+            crate = "ripgrep"
+            executable = "rg"
+            global = true
+
+            [[hooks]]
+            name = "h"
+            event = "PreToolUse"
+            command = "rg"
+        "#};
+        let plugin = from_str(toml).expect("parse");
+        let install = plugin
+            .installations
+            .iter()
+            .find(|i| i.name == "rg")
+            .unwrap();
+        match &install.source {
+            Some(Source::Cargo(c)) => assert!(c.global),
+            _ => panic!("expected cargo source"),
+        }
+    }
+
+    /// Cargo source with `global = true` and no `executable` is rejected at
+    /// parse time — we don't infer the binary from crates.io for global
+    /// installs, so the user must say what to spawn.
+    #[test]
+    fn cargo_global_without_executable_errors() {
+        let toml = indoc! {r#"
+            name = "p"
+            crates = ["*"]
+
+            [[installations]]
+            name = "rg"
+            source = "cargo"
+            crate = "ripgrep"
+            global = true
+
+            [[hooks]]
+            name = "h"
+            event = "PreToolUse"
+            command = "rg"
+        "#};
+        let err = from_str(toml).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("`global = true` requires `executable`"),
+            "got: {err}"
+        );
     }
 
     /// `git` field on cargo source round-trips through validation.

--- a/src/subcommand_dispatch.rs
+++ b/src/subcommand_dispatch.rs
@@ -11,7 +11,7 @@ use std::{ffi::OsString, path::Path, process::ExitStatus};
 use crate::{
     config::Symposium,
     crate_sources::{WorkspaceCrate, workspace_crates},
-    installation::resolve_runnable,
+    installation::{acquire_installation, resolve_runnable},
     plugins::{self, ParsedPlugin, Plugin, PluginRegistry, Subcommand},
 };
 use anyhow::{Context, Result, bail};
@@ -117,13 +117,9 @@ pub async fn dispatch_external(
         })?;
 
     let runnable = resolve_runnable(
-        sym,
-        installation,
-        None,
-        None,
+        acquire_installation(sym, installation, None, None).await?,
         &format!("subcommand `{name}`"),
-    )
-    .await?;
+    )?;
 
     spawn(runnable, &installation.args, &forwarded).await
 }
@@ -140,7 +136,6 @@ async fn spawn(
             cmd.arg(path_buf);
             cmd
         }
-        _ => bail!("unsupported runnable kind"),
     };
 
     cmd.args(install_args).args(forwarded);

--- a/symposium-install/src/lib.rs
+++ b/symposium-install/src/lib.rs
@@ -103,6 +103,17 @@ pub struct CargoSource {
     /// crates.io is not consulted to discover binary names.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub git: Option<String>,
+    /// Install into the user's global cargo location (`~/.cargo/bin`) instead
+    /// of a symposium-managed cache. The default (`false`) uses
+    /// `cargo install --root <symposium-cache>` so binaries don't pollute the
+    /// global namespace; hook execution adds the cache `bin/` to `$PATH` so
+    /// scripts can still invoke them by name.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub global: bool,
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 impl CargoSource {
@@ -113,6 +124,7 @@ impl CargoSource {
             crate_name: crate_name.into(),
             version: None,
             git: None,
+            global: false,
         }
     }
 
@@ -245,12 +257,15 @@ async fn query_crate_binaries(
 }
 
 /// Install a crate using cargo binstall (fast) or cargo install (fallback).
+///
+/// `cache_dir` is `Some` for scoped installs (passed via `--root`) and `None`
+/// for global installs (uses cargo's default location).
 async fn install_cargo_crate(
     ctx: &InstallContext,
     crate_name: &str,
     version: &str,
     binary_name: Option<String>,
-    cache_dir: PathBuf,
+    cache_dir: Option<PathBuf>,
     git: Option<String>,
 ) -> Result<()> {
     let ctx = ctx.clone();
@@ -258,7 +273,14 @@ async fn install_cargo_crate(
     let version = version.to_string();
 
     tokio::task::spawn_blocking(move || {
-        install_cargo_crate_sync(&ctx, &crate_name, &version, binary_name, &cache_dir, git)
+        install_cargo_crate_sync(
+            &ctx,
+            &crate_name,
+            &version,
+            binary_name,
+            cache_dir.as_deref(),
+            git,
+        )
     })
     .await
     .context("Cargo install task panicked")?
@@ -269,40 +291,53 @@ fn install_cargo_crate_sync(
     crate_name: &str,
     version: &str,
     binary_name: Option<String>,
-    cache_dir: &Path,
+    cache_dir: Option<&Path>,
     git: Option<String>,
 ) -> Result<()> {
     use std::fs;
 
-    if let Some(parent) = cache_dir.parent()
-        && parent.exists()
-    {
-        for entry in fs::read_dir(parent)? {
-            let entry = entry?;
-            let path = entry.path();
-            if path != cache_dir && path.is_dir() {
-                fs::remove_dir_all(&path).ok();
+    if let Some(cache_dir) = cache_dir {
+        if let Some(parent) = cache_dir.parent()
+            && parent.exists()
+        {
+            for entry in fs::read_dir(parent)? {
+                let entry = entry?;
+                let path = entry.path();
+                if path != cache_dir && path.is_dir() {
+                    fs::remove_dir_all(&path).ok();
+                }
             }
         }
+        fs::create_dir_all(cache_dir)?;
     }
 
-    fs::create_dir_all(cache_dir)?;
-
-    let crate_spec = format!("{}@{}", crate_name, version);
+    // Empty version → just the crate name. Avoids `cargo install rtk@` which
+    // cargo rejects.
+    let crate_spec = if version.is_empty() {
+        crate_name.to_string()
+    } else {
+        format!("{}@{}", crate_name, version)
+    };
+    let cache_dir_str = cache_dir.map(|p| p.to_str().unwrap().to_string());
 
     // Try cargo binstall first (faster, uses prebuilt binaries).
     tracing::info!("Attempting cargo binstall for {}", crate_spec);
-    let mut binstall_args = vec!["binstall", "--no-confirm", "--root"];
+    let mut binstall_args: Vec<&str> = vec!["binstall", "--no-confirm"];
+    if let Some(dir) = cache_dir_str.as_deref() {
+        binstall_args.push("--root");
+        binstall_args.push(dir);
+    }
     if let Some(git) = &git {
         binstall_args.push("--git");
         binstall_args.push(git);
     }
-    binstall_args.extend([cache_dir.to_str().unwrap(), &crate_spec]);
+    binstall_args.push(&crate_spec);
     let binstall_result = ctx.cargo_command().args(binstall_args).output();
 
-    let binary_path = binary_name
-        .as_ref()
-        .map(|bin| cache_dir.join("bin").join(platform_binary_exe(bin)));
+    let binary_path = match (cache_dir, binary_name.as_ref()) {
+        (Some(dir), Some(bin)) => Some(dir.join("bin").join(platform_binary_exe(bin))),
+        _ => None,
+    };
 
     match binstall_result {
         Ok(output) if output.status.success() => {
@@ -328,15 +363,19 @@ fn install_cargo_crate_sync(
     }
 
     tracing::info!("Falling back to cargo install for {}", crate_spec);
-    let mut args = vec!["install", "--root"];
+    let mut args: Vec<&str> = vec!["install"];
+    if let Some(dir) = cache_dir_str.as_deref() {
+        args.push("--root");
+        args.push(dir);
+    }
     if let Some(git) = &git {
         args.push("--git");
         args.push(git);
     }
-    args.extend([cache_dir.to_str().unwrap(), &crate_spec]);
+    args.push(&crate_spec);
     let install_result = ctx
         .cargo_command()
-        .args(args)
+        .args(&args)
         .output()
         .context("Failed to run cargo install")?;
 
@@ -369,13 +408,50 @@ fn git_cache_version(git_url: &str, version: Option<&str>) -> String {
     format!("{:016x}", hasher.finish())
 }
 
-/// Acquire a cargo installation: install if missing, return the cache dir
-/// plus the resolved binary name (when discoverable from crates.io).
+/// Outcome of acquiring a cargo source.
+struct AcquiredCargo {
+    /// Symposium-managed cache dir, or `None` for global installs (no --root).
+    cache_dir: Option<PathBuf>,
+    /// The resolved binary name, when known.
+    resolved_executable: Option<String>,
+}
+
+/// Acquire a cargo installation: install if missing.
+///
+/// Three branches, in priority order:
+/// - `global = true`: skip crates.io, install with no `--root` (binary lands
+///   in the user's `$CARGO_HOME/bin`). Validation guarantees the caller has
+///   set `executable`, so no inference needed. `cache_dir = None` is the
+///   signal that the source is unmanaged.
+/// - `git` source: skip crates.io, install with `--root <cache>` and
+///   `--git <url>`. Validation guarantees `executable`.
+/// - Plain crates.io: query for version + bin_names; auto-infer the binary
+///   when the crate has exactly one.
 async fn acquire_cargo(
     ctx: &InstallContext,
     cargo: &CargoSource,
     executable_hint: Option<&str>,
-) -> Result<(PathBuf, Option<String>)> {
+) -> Result<AcquiredCargo> {
+    if cargo.global {
+        // Validation requires `executable` for global cargo.
+        let resolved = executable_hint
+            .expect("validate_installation enforces `executable` for cargo + global")
+            .to_string();
+        install_cargo_crate(
+            ctx,
+            &cargo.crate_name,
+            cargo.version.as_deref().unwrap_or(""),
+            Some(resolved.clone()),
+            None,
+            cargo.git.clone(),
+        )
+        .await?;
+        return Ok(AcquiredCargo {
+            cache_dir: None,
+            resolved_executable: Some(resolved),
+        });
+    }
+
     if let Some(git_url) = cargo.git.as_deref() {
         let resolved = match executable_hint {
             Some(name) => name.to_string(),
@@ -394,12 +470,15 @@ async fn acquire_cargo(
                 &cargo.crate_name,
                 cargo.version.as_deref().unwrap_or(""),
                 Some(resolved.clone()),
-                cache_dir.clone(),
+                Some(cache_dir.clone()),
                 Some(git_url.to_string()),
             )
             .await?;
         }
-        return Ok((cache_dir, Some(resolved)));
+        return Ok(AcquiredCargo {
+            cache_dir: Some(cache_dir),
+            resolved_executable: Some(resolved),
+        });
     }
 
     let (version, bin_names) =
@@ -430,13 +509,16 @@ async fn acquire_cargo(
             &cargo.crate_name,
             &version,
             resolved.clone(),
-            cache_dir.clone(),
+            Some(cache_dir.clone()),
             None,
         )
         .await?;
     }
 
-    Ok((cache_dir, resolved))
+    Ok(AcquiredCargo {
+        cache_dir: Some(cache_dir),
+        resolved_executable: resolved,
+    })
 }
 
 /// Acquire a github source: returns the cache directory containing the repo
@@ -446,19 +528,24 @@ async fn acquire_github(ctx: &InstallContext, git: &GithubSource) -> Result<Path
     cache_mgr.fetch_url(&git.url, UpdateLevel::Check).await
 }
 
-/// Acquired source — where files ended up on disk, plus the kind so
-/// `executable` / `script` can be resolved correctly relative to it.
-#[non_exhaustive]
-#[derive(Debug)]
+/// Intermediate result of acquiring a `Source`: where the bits landed and
+/// the layout-specific hooks needed to turn an `executable` / `script` name
+/// into a concrete path. Consumed by `hook::acquire_installation`, which
+/// wraps this together with the installation's name, `install_commands`,
+/// and (for no-source installs) absolute path defaults to produce the
+/// fully-resolved `AcquiredInstallation`.
 pub struct AcquiredSource {
-    /// Root directory where the acquired files reside.
-    pub base: PathBuf,
-    /// How the source was acquired (affects path resolution).
-    pub kind: AcquiredKind,
-    /// For cargo, the binary name we ended up with (from `executable_hint`
-    /// or by inferring the crate's sole binary). Used as the fallback when
-    /// the hook command supplies no explicit executable. `None` for github.
+    /// Where bits landed. `None` for global cargo (binary is in
+    /// `~/.cargo/bin`, which we don't manage).
+    pub base: Option<PathBuf>,
+    /// For cargo, the binary name that was installed. Used as the fallback
+    /// when neither the installation nor the hook supplies an explicit
+    /// `executable`. `None` for github (which has no notion of "default
+    /// binary").
     pub resolved_executable: Option<String>,
+    /// Layout discriminator — cargo binaries live under `<base>/bin/`,
+    /// github paths live under `<base>/` directly.
+    pub kind: AcquiredKind,
 }
 
 /// How an [`AcquiredSource`] was obtained.
@@ -484,23 +571,32 @@ impl AcquiredSource {
 
     /// Path of an `executable` declared on installation/hook.
     pub fn executable_named(&self, name: &str) -> PathBuf {
+        let base = self
+            .base
+            .as_ref()
+            .expect("resolve_executable called on unmanaged source");
+
         match self.kind {
-            AcquiredKind::Cargo => self.base.join("bin").join(platform_binary_exe(name)),
-            AcquiredKind::Github => self.base.join(name.trim_start_matches("./")),
+            AcquiredKind::Cargo => base.join("bin").join(platform_binary_exe(name)),
+            AcquiredKind::Github => base.join(name.trim_start_matches("./")),
         }
     }
 
     /// Path of a `script` declared on installation/hook.
     pub fn script_named(&self, name: &str) -> PathBuf {
+        let base = self
+            .base
+            .as_ref()
+            .expect("resolve_executable called on unmanaged source");
+
         match self.kind {
-            AcquiredKind::Cargo => self.base.join("bin").join(name.trim_start_matches("./")),
-            AcquiredKind::Github => self.base.join(name.trim_start_matches("./")),
+            AcquiredKind::Cargo => base.join("bin").join(name.trim_start_matches("./")),
+            AcquiredKind::Github => base.join(name.trim_start_matches("./")),
         }
     }
 }
 
-/// Acquire a source, downloading / installing as needed. The returned
-/// `AcquiredSource` is used to resolve `executable` / `script` paths.
+/// Acquire a source, downloading / installing as needed.
 ///
 /// `executable_hint` is only used for cargo (to pick which binary to install
 /// for multi-binary crates, or as the binary name when using a git source).
@@ -511,23 +607,22 @@ pub async fn acquire_source(
 ) -> Result<AcquiredSource> {
     match source {
         Source::Cargo(c) => {
-            let (base, resolved) = acquire_cargo(ctx, c, executable_hint).await?;
+            let acquired = acquire_cargo(ctx, c, executable_hint).await?;
             Ok(AcquiredSource {
-                base,
+                base: acquired.cache_dir,
+                resolved_executable: acquired.resolved_executable,
                 kind: AcquiredKind::Cargo,
-                resolved_executable: resolved,
             })
         }
         Source::Github(g) => Ok(AcquiredSource {
-            base: acquire_github(ctx, g).await?,
-            kind: AcquiredKind::Github,
+            base: Some(acquire_github(ctx, g).await?),
             resolved_executable: None,
+            kind: AcquiredKind::Github,
         }),
     }
 }
 
 /// What an installation resolves to once acquired.
-#[non_exhaustive]
 #[derive(Debug)]
 pub enum Runnable {
     /// Run as a binary: `path args...`.

--- a/tests/fixtures/plugin-hooks0/dot-symposium/plugins/test-plugin/SYMPOSIUM.toml
+++ b/tests/fixtures/plugin-hooks0/dot-symposium/plugins/test-plugin/SYMPOSIUM.toml
@@ -80,3 +80,19 @@ matcher = "Task"
 command = "bare-setup"
 script = "$TEST_DIR/dot-symposium/plugins/test-plugin/scripts/hook-supplied.sh"
 format = "symposium"
+
+# Env-var test: a no-source requirement with an absolute `executable` exposes
+# `$SYMPOSIUM_helper` to the hook script. The script echoes the env var so the
+# integration test can assert the wiring.
+[[installations]]
+name = "helper"
+executable = "$TEST_DIR/helper-bin"
+install_commands = ["echo helper-payload > $TEST_DIR/helper-bin"]
+
+[[hooks]]
+name = "env-var-test"
+event = "PreToolUse"
+matcher = "TodoWrite"
+requirements = ["helper"]
+command = { script = "$TEST_DIR/dot-symposium/plugins/test-plugin/scripts/echo-helper-env.sh" }
+format = "symposium"

--- a/tests/fixtures/plugin-hooks0/dot-symposium/plugins/test-plugin/scripts/echo-helper-env.sh
+++ b/tests/fixtures/plugin-hooks0/dot-symposium/plugins/test-plugin/scripts/echo-helper-env.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+printf '{"PreToolUse":{"additionalContext":"helper-env:%s"}}\n' "$SYMPOSIUM_helper"

--- a/tests/plugin_dispatch.rs
+++ b/tests/plugin_dispatch.rs
@@ -222,6 +222,43 @@ async fn hook_supplies_script_against_bare_installation() {
     .unwrap();
 }
 
+/// `$SYMPOSIUM_<name>` is set in the hook's environment, pointing at the
+/// requirement's resolved executable. The script echoes the env var; the
+/// expected value is the absolute path the fixture's `executable` resolves to.
+#[tokio::test(flavor = "multi_thread")]
+async fn helper_env_var_is_set_for_hook() {
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["plugin-hooks0"],
+        async |mut ctx| {
+            let result = ctx
+                .prompt_or_hook(
+                    "ignored",
+                    &[HookStep::PreToolUse {
+                        tool_name: "TodoWrite".to_string(),
+                        tool_input: json!({"todos": []}),
+                    }],
+                    HookAgent::Claude,
+                )
+                .await?;
+
+            // The fixture's `helper` installation has `executable = "$TEST_DIR/helper-bin"`,
+            // expanded to an absolute path before the script runs. We assert the
+            // env var made it through with the `/helper-bin` suffix.
+            assert!(
+                result.has_context_containing("helper-env:")
+                    && result.has_context_containing("/helper-bin"),
+                "expected hook env to contain `$SYMPOSIUM_helper` ending in /helper-bin, \
+                 got: {:#?}",
+                result.outputs_for(HookEvent::PreToolUse),
+            );
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+}
+
 /// The `matcher` field filters hooks by tool name. Firing a tool no hook
 /// matches produces no `additionalContext` in the merged output.
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## What does this PR do?

Two main things here:
- Add a `global` option to installs of `source = "cargo"`, where we don't use `--root` and instead install into the user's PATH
- Add `SYMPOSIUM_<name>` and `SYMPOSIUM_DIR_<name>` environment variables for the executable (or script) and the install directory for scripts to be able to use

<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

* The AI tool authored large parts of the code

</details>
