### PR TITLE
feat: add self-update command and auto-update infrastructure

### DIFF
--- a/md/SUMMARY.md
+++ b/md/SUMMARY.md
@@ -32,6 +32,7 @@
   - [The `cargo agents` command](./reference/cargo-agents.md)
     - [`cargo agents init`](./reference/cargo-agents-init.md)
     - [`cargo agents sync`](./reference/cargo-agents-sync.md)
+    - [`cargo agents self-update`](./reference/cargo-agents-self-update.md)
     - [`cargo agents plugin`](./reference/cargo-agents-plugin.md)
     - [Unstable agent commands](./reference/cargo-agents-unstable.md)
       - [`cargo agents crate-info`](./reference/cargo-agents-crate-info.md)

--- a/md/design/module-structure.md
+++ b/md/design/module-structure.md
@@ -6,7 +6,7 @@ Symposium is a Rust crate with both a library (`src/lib.rs`) and a binary (`src/
 
 Everything hangs off the `Symposium` struct, which wraps the parsed `Config` with resolved paths for config, cache, and log directories. Two constructors: `from_environment()` for production and `from_dir()` for tests.
 
-Defines the user-wide `Config` (stored at `~/.symposium/config.toml`) with `[[agent]]` entries, logging, plugin sources, and defaults. Provides `plugin_sources()` to resolve the effective list of plugin source directories.
+Defines the user-wide `Config` (stored at `~/.symposium/config.toml`) with `[[agent]]` entries, logging, plugin sources, defaults, and `auto-update` (off/warn/on, default warn). Provides `plugin_sources()` to resolve the effective list of plugin source directories.
 
 ### `agents.rs` — agent abstraction
 
@@ -48,6 +48,14 @@ Each applicable skill carries a `SkillOrigin` describing *where its bytes live*,
 ### `hook.rs` — hook handling
 
 Handles the hook pipeline: parse agent wire-format input → auto-sync → builtin dispatch → plugin hook dispatch → serialize output. The dispatch path matches plugin `Hook`s against the event, builds a `ResolvedHook` per match (looking up the named installations on the plugin), then for each `ResolvedHook`: acquires its `requirements` (best-effort), runs `install_commands` after the source step, picks a `Runnable` from (hook-or-install) `executable`/`script`, and spawns it (binary directly for `Exec`, via `sh <path>` for `Script`). Format routing converts hook output between agent wire formats and the symposium canonical format.
+
+### `state.rs` — persistent state
+
+Manages `state.toml` in the config directory. Tracks the semver of the binary that last touched the directory (for future migration hooks) and the timestamp of the last update check (to throttle crates.io queries to once per 24 hours). `ensure_current()` is called on startup to silently stamp the current version. `should_check_for_update()` / `record_update_check()` gate the auto-update flow.
+
+### `self_update.rs` — self-update
+
+Implements `cargo agents self-update`. Queries crates.io for the latest published version, then downloads the prebuilt binary from the GitHub release (`cargo-agents-{target}.tar.gz`), extracts it, and atomically replaces the installed binary. Falls back to `cargo install` when no prebuilt binary is available for the current platform. Also provides `re_exec()` which replaces the current process with the newly installed binary (Unix `exec`, spawn-and-exit on Windows) — used by the `auto-update = "on"` startup path.
 
 ### `crate_command.rs` — crate source lookup
 

--- a/md/design/module-structure.md
+++ b/md/design/module-structure.md
@@ -55,7 +55,7 @@ Manages `state.toml` in the config directory. Tracks the semver of the binary th
 
 ### `self_update.rs` — self-update
 
-Implements `cargo agents self-update`. Queries crates.io for the latest published version, then downloads the prebuilt binary from the GitHub release (`cargo-agents-{target}.tar.gz`), extracts it, and atomically replaces the installed binary. Falls back to `cargo install` when no prebuilt binary is available for the current platform. Also provides `re_exec()` which replaces the current process with the newly installed binary (Unix `exec`, spawn-and-exit on Windows) — used by the `auto-update = "on"` startup path.
+Implements `cargo agents self-update`. Queries the registry for the latest published version via `cargo search`, then installs it via `cargo install symposium --force`. Also provides `re_exec()` which replaces the current process with the newly installed binary (Unix `exec`, spawn-and-exit on Windows) — used by the `auto-update = "on"` startup path. Contains `maybe_warn_for_update()` (sync, for the `warn` library path) and `maybe_check_for_update()` (async, for the binary `on` + re-exec path).
 
 ### `crate_command.rs` — crate source lookup
 

--- a/md/reference/cargo-agents-self-update.md
+++ b/md/reference/cargo-agents-self-update.md
@@ -1,0 +1,85 @@
+# `cargo agents self-update`
+
+Update symposium to the latest version.
+
+## Usage
+
+```bash
+cargo agents self-update
+```
+
+## Behavior
+
+1. **Check for updates** — runs `cargo search` against the configured registry to find the latest published version of symposium. If the installed version is already current, prints a message and exits.
+
+2. **Download** — by default (`self-update-source = "binary"`), downloads a prebuilt binary from the GitHub release for the current platform. If the download fails (e.g., no prebuilt binary for the platform), falls back to `cargo install`.
+
+3. **Install** — extracts the binary and atomically replaces the installed copy in `$CARGO_HOME/bin/` (or `~/.cargo/bin/`). When using the source fallback, runs `cargo install symposium --force`.
+
+### Supported platforms (prebuilt binaries)
+
+| Target | Archive format |
+|--------|---------------|
+| `aarch64-apple-darwin` | `.tar.gz` |
+| `x86_64-unknown-linux-musl` | `.tar.gz` |
+| `aarch64-unknown-linux-musl` | `.tar.gz` |
+| `x86_64-pc-windows-msvc` | `.zip` |
+
+Other platforms can use `self-update-source = "source"` to build from source.
+
+## Configuration
+
+Two keys in `~/.symposium/config.toml` control update behavior:
+
+### `auto-update`
+
+| Value | Behavior |
+|-------|----------|
+| `"off"` | Never check for updates. |
+| `"warn"` (default) | Check the registry at most once per 24 hours. Print a message when a newer version is available. |
+| `"on"` | Check the registry at most once per 24 hours. When a newer version is found, automatically download it and re-execute the current command with the new binary. |
+
+The 24-hour throttle is tracked in `~/.symposium/state.toml`. The check is skipped for hook invocations and for `self-update` itself (which always checks unconditionally).
+
+### `self-update-source`
+
+| Value | Behavior |
+|-------|----------|
+| `"binary"` (default) | Download a prebuilt binary from the GitHub release. Falls back to `cargo install` if the download fails. |
+| `"source"` | Build from source via `cargo install symposium --force`. |
+
+## State file
+
+`~/.symposium/state.toml` tracks:
+
+- `version` — the semver of the binary that last ran. Updated on every invocation. Future versions can use a version mismatch to trigger migrations.
+- `last-update-check` — timestamp of the last registry query. Used to throttle checks to once per 24 hours.
+
+## Examples
+
+Manual update:
+
+```bash
+cargo agents self-update
+```
+
+Disable all update checks:
+
+```toml
+# ~/.symposium/config.toml
+auto-update = "off"
+```
+
+Auto-update on every invocation (within the 24-hour window):
+
+```toml
+# ~/.symposium/config.toml
+auto-update = "on"
+```
+
+Force building from source:
+
+```toml
+# ~/.symposium/config.toml
+self-update-source = "source"
+```

--- a/md/reference/cargo-agents-self-update.md
+++ b/md/reference/cargo-agents-self-update.md
@@ -12,41 +12,21 @@ cargo agents self-update
 
 1. **Check for updates** — runs `cargo search` against the configured registry to find the latest published version of symposium. If the installed version is already current, prints a message and exits.
 
-2. **Download** — by default (`self-update-source = "binary"`), downloads a prebuilt binary from the GitHub release for the current platform. If the download fails (e.g., no prebuilt binary for the platform), falls back to `cargo install`.
-
-3. **Install** — extracts the binary and atomically replaces the installed copy in `$CARGO_HOME/bin/` (or `~/.cargo/bin/`). When using the source fallback, runs `cargo install symposium --force`.
-
-### Supported platforms (prebuilt binaries)
-
-| Target | Archive format |
-|--------|---------------|
-| `aarch64-apple-darwin` | `.tar.gz` |
-| `x86_64-unknown-linux-musl` | `.tar.gz` |
-| `aarch64-unknown-linux-musl` | `.tar.gz` |
-| `x86_64-pc-windows-msvc` | `.zip` |
-
-Other platforms can use `self-update-source = "source"` to build from source.
+2. **Install** — runs `cargo install symposium --force` to build and install the latest version.
 
 ## Configuration
 
-Two keys in `~/.symposium/config.toml` control update behavior:
+The `auto-update` key in `~/.symposium/config.toml` controls update behavior. It is also configurable during `cargo agents init`.
 
 ### `auto-update`
 
 | Value | Behavior |
 |-------|----------|
+| `"on"` (default) | Check the registry at most once per 24 hours. When a newer version is found, automatically install it and re-execute the current command with the new binary. |
+| `"warn"` | Check the registry at most once per 24 hours. Print a message when a newer version is available. During hook invocations, the nudge is included in the session-start hook's `additionalContext`. |
 | `"off"` | Never check for updates. |
-| `"warn"` (default) | Check the registry at most once per 24 hours. Print a message when a newer version is available. |
-| `"on"` | Check the registry at most once per 24 hours. When a newer version is found, automatically download it and re-execute the current command with the new binary. |
 
-The 24-hour throttle is tracked in `~/.symposium/state.toml`. The check is skipped for hook invocations and for `self-update` itself (which always checks unconditionally).
-
-### `self-update-source`
-
-| Value | Behavior |
-|-------|----------|
-| `"binary"` (default) | Download a prebuilt binary from the GitHub release. Falls back to `cargo install` if the download fails. |
-| `"source"` | Build from source via `cargo install symposium --force`. |
+The 24-hour throttle is tracked in `~/.symposium/state.toml`. The check is skipped for `self-update` itself (which always checks unconditionally).
 
 ## State file
 
@@ -70,16 +50,9 @@ Disable all update checks:
 auto-update = "off"
 ```
 
-Auto-update on every invocation (within the 24-hour window):
+Warn instead of auto-updating:
 
 ```toml
 # ~/.symposium/config.toml
-auto-update = "on"
-```
-
-Force building from source:
-
-```toml
-# ~/.symposium/config.toml
-self-update-source = "source"
+auto-update = "warn"
 ```

--- a/md/reference/cargo-agents.md
+++ b/md/reference/cargo-agents.md
@@ -9,6 +9,7 @@
 | [`cargo agents init`](./cargo-agents-init.md) | Set up user-wide configuration |
 | [`cargo agents sync`](./cargo-agents-sync.md) | Synchronize skills with workspace dependencies |
 | [`cargo agents plugin`](./cargo-agents-plugin.md) | Manage plugin sources |
+| `cargo agents self-update` | Update symposium to the latest version |
 
 ## Global options
 

--- a/md/reference/cargo-agents.md
+++ b/md/reference/cargo-agents.md
@@ -9,7 +9,7 @@
 | [`cargo agents init`](./cargo-agents-init.md) | Set up user-wide configuration |
 | [`cargo agents sync`](./cargo-agents-sync.md) | Synchronize skills with workspace dependencies |
 | [`cargo agents plugin`](./cargo-agents-plugin.md) | Manage plugin sources |
-| `cargo agents self-update` | Update symposium to the latest version |
+| [`cargo agents self-update`](./cargo-agents-self-update.md) | Update symposium to the latest version |
 
 ## Global options
 

--- a/md/reference/configuration.md
+++ b/md/reference/configuration.md
@@ -8,8 +8,7 @@
 auto-sync = true
 agents-syncing = true
 hook-scope = "global"
-auto-update = "warn"
-self-update-source = "binary"
+auto-update = "on"
 
 [[agent]]
 name = "claude"
@@ -40,8 +39,7 @@ path = "my-plugins"
 | `auto-sync` | bool | `true` | Automatically run `cargo agents sync` during hook invocations. When enabled, skills are kept in sync with workspace dependencies without manual intervention. |
 | `agents-syncing` | bool | `true` | Propagate user-authored skills from `.agents/skills/` into the per-agent skill directories of any configured agent that does not natively use `.agents/skills/` (such as `.claude/skills/` or `.kiro/skills/`). Skills that symposium itself installed — identified by the `.symposium` marker file — are not propagated. See [Workspace skills](../workspace-skills.md) for the user-guide overview, or [Agents syncing](#agents-syncing-mirror-user-authored-skills) below for details. |
 | `hook-scope` | string | `"global"` | Where agent hooks are installed. `"global"` writes to the user's home directory (e.g., `~/`). `"project"` writes to the project directory, keeping hooks local to the workspace. |
-| `auto-update` | string | `"warn"` | Controls automatic update behavior. `"off"` disables update checks entirely. `"warn"` checks crates.io (at most once per 24 hours) and prints a message when a newer version is available. `"on"` automatically downloads and installs the update, then re-executes the command with the new binary. |
-| `self-update-source` | string | `"binary"` | Where `self-update` fetches the new version from. `"binary"` downloads a prebuilt binary from the GitHub release (fast, no build tools needed). `"source"` builds from source via `cargo install` (useful if no prebuilt binary exists for your platform). When set to `"binary"`, falls back to `cargo install` if the download fails. |
+| `auto-update` | string | `"on"` | Controls automatic update behavior. `"off"` disables update checks entirely. `"warn"` checks the registry (at most once per 24 hours) and prints a message when a newer version is available. `"on"` automatically installs the update via `cargo install` and re-executes the command with the new binary. |
 
 ### Agents syncing: mirror user-authored skills
 

--- a/md/reference/configuration.md
+++ b/md/reference/configuration.md
@@ -8,6 +8,8 @@
 auto-sync = true
 agents-syncing = true
 hook-scope = "global"
+auto-update = "warn"
+self-update-source = "binary"
 
 [[agent]]
 name = "claude"
@@ -38,6 +40,8 @@ path = "my-plugins"
 | `auto-sync` | bool | `true` | Automatically run `cargo agents sync` during hook invocations. When enabled, skills are kept in sync with workspace dependencies without manual intervention. |
 | `agents-syncing` | bool | `true` | Propagate user-authored skills from `.agents/skills/` into the per-agent skill directories of any configured agent that does not natively use `.agents/skills/` (such as `.claude/skills/` or `.kiro/skills/`). Skills that symposium itself installed — identified by the `.symposium` marker file — are not propagated. See [Workspace skills](../workspace-skills.md) for the user-guide overview, or [Agents syncing](#agents-syncing-mirror-user-authored-skills) below for details. |
 | `hook-scope` | string | `"global"` | Where agent hooks are installed. `"global"` writes to the user's home directory (e.g., `~/`). `"project"` writes to the project directory, keeping hooks local to the workspace. |
+| `auto-update` | string | `"warn"` | Controls automatic update behavior. `"off"` disables update checks entirely. `"warn"` checks crates.io (at most once per 24 hours) and prints a message when a newer version is available. `"on"` automatically downloads and installs the update, then re-executes the command with the new binary. |
+| `self-update-source` | string | `"binary"` | Where `self-update` fetches the new version from. `"binary"` downloads a prebuilt binary from the GitHub release (fast, no build tools needed). `"source"` builds from source via `cargo install` (useful if no prebuilt binary exists for your platform). When set to `"binary"`, falls back to `cargo install` if the download fails. |
 
 ### Agents syncing: mirror user-authored skills
 
@@ -111,6 +115,7 @@ User-wide data lives under `~/.symposium/` by default. Override with environment
 | Path | Purpose |
 |------|---------|
 | `~/.symposium/config.toml` | User configuration |
+| `~/.symposium/state.toml` | Persistent state (binary version stamp, last update check) |
 | `~/.symposium/plugins/` | User-defined plugins |
 | `~/.symposium/cache/` | Cache directory (crate sources, plugin sources) |
 | `~/.symposium/logs/` | Log files (one per invocation, timestamped) |

--- a/src/bin/cargo-agents.rs
+++ b/src/bin/cargo-agents.rs
@@ -57,16 +57,17 @@ async fn main() -> ExitCode {
     // Ensure git-based plugin sources are up to date (non-blocking on failure).
     plugins::ensure_plugin_sources(&sym, cli.update).await;
 
-    // Auto-update check (skip for hooks and self-update itself).
-    if !is_hook
-        && !matches!(cli.command, Some(Commands::SelfUpdate))
+    // Auto-update check (skip for self-update itself, which always checks).
+    // For hooks: "warn" is skipped (stderr isn't visible to the agent), but
+    // "on" still auto-updates silently so the next invocation uses the new binary.
+    if !matches!(cli.command, Some(Commands::SelfUpdate))
         && sym.config.auto_update != AutoUpdate::Off
         && state::should_check_for_update(sym.config_dir())
     {
         state::record_update_check(sym.config_dir());
         match sym.config.auto_update {
             AutoUpdate::Off => unreachable!(),
-            AutoUpdate::Warn => {
+            AutoUpdate::Warn if !is_hook => {
                 if let Ok(Some(latest)) = self_update::check_upgrade() {
                     out.warn(format!(
                         "symposium {} is available (current: {}). \
@@ -78,19 +79,24 @@ async fn main() -> ExitCode {
             }
             AutoUpdate::On => {
                 if let Ok(Some(latest)) = self_update::check_upgrade() {
-                    out.info(format!(
-                        "auto-updating symposium {} → {latest}...",
-                        state::CURRENT_VERSION,
-                    ));
+                    if !is_hook {
+                        out.info(format!(
+                            "auto-updating symposium {} → {latest}...",
+                            state::CURRENT_VERSION,
+                        ));
+                    }
                     if let Err(e) =
                         self_update::self_update(&Output::quiet(), sym.config.update_source).await
                     {
-                        out.warn(format!("auto-update failed: {e}"));
+                        if !is_hook {
+                            out.warn(format!("auto-update failed: {e}"));
+                        }
                     } else {
                         self_update::re_exec();
                     }
                 }
             }
+            _ => {}
         }
     }
 

--- a/src/bin/cargo-agents.rs
+++ b/src/bin/cargo-agents.rs
@@ -57,13 +57,12 @@ async fn main() -> ExitCode {
     // Ensure git-based plugin sources are up to date (non-blocking on failure).
     plugins::ensure_plugin_sources(&sym, cli.update).await;
 
-    // For hook invocations, run the auto-update check here (hooks don't go
-    // through cli::run which handles it for other commands).  Only the
-    // auto-update = "on" re-exec path lives in the binary; the warn path
-    // is handled inside cli::run / maybe_check_for_update.
-    // Hooks don't go through cli::run(), so run the update check here.
-    // If auto-update = "on" succeeded, re-exec into the new binary.
-    if is_hook && self_update::maybe_check_for_update(&sym, &Output::quiet()).await {
+    // Auto-update = "on": check for updates and re-exec if a new binary was
+    // installed.  Skipped for self-update (which always checks explicitly).
+    // The warn path is handled inside cli::run via maybe_warn_for_update.
+    if !matches!(cli.command, Some(Commands::SelfUpdate))
+        && self_update::maybe_check_for_update(&sym, &out).await
+    {
         self_update::re_exec();
     }
 

--- a/src/bin/cargo-agents.rs
+++ b/src/bin/cargo-agents.rs
@@ -2,10 +2,12 @@ use clap::Parser;
 use std::process::ExitCode;
 
 use symposium::cli::{Cli, Commands, PluginCommand};
-use symposium::config;
+use symposium::config::{self, AutoUpdate};
 use symposium::hook;
 use symposium::output::Output;
 use symposium::plugins;
+use symposium::self_update;
+use symposium::state;
 
 #[tokio::main]
 async fn main() -> ExitCode {
@@ -34,11 +36,15 @@ async fn main() -> ExitCode {
         Some(Commands::Hook { agent, event }) => {
             tracing::debug!(?agent, ?event, "cargo agents hook");
         }
+        Some(Commands::SelfUpdate) => tracing::info!("cargo agents self-update"),
         Some(Commands::CrateInfo { name, version }) => {
             tracing::debug!(%name, version = ?version, "cargo agents crate-info");
         }
         None => {}
     }
+
+    // Stamp state.toml with the running binary version (silently updates on mismatch).
+    state::ensure_current(sym.config_dir());
 
     // Hook commands are quiet by default (they're invoked by the agent, not the user)
     let is_hook = matches!(cli.command, Some(Commands::Hook { .. }));
@@ -50,6 +56,41 @@ async fn main() -> ExitCode {
 
     // Ensure git-based plugin sources are up to date (non-blocking on failure).
     plugins::ensure_plugin_sources(&sym, cli.update).await;
+
+    // Auto-update check (skip for hooks and self-update itself).
+    if !is_hook
+        && !matches!(cli.command, Some(Commands::SelfUpdate))
+        && sym.config.auto_update != AutoUpdate::Off
+        && state::should_check_for_update(sym.config_dir())
+    {
+        state::record_update_check(sym.config_dir());
+        match sym.config.auto_update {
+            AutoUpdate::Off => unreachable!(),
+            AutoUpdate::Warn => {
+                if let Ok(Some(latest)) = self_update::check_upgrade().await {
+                    out.warn(format!(
+                        "symposium {} is available (current: {}). \
+                         Run `cargo agents self-update` to upgrade.",
+                        latest,
+                        state::CURRENT_VERSION,
+                    ));
+                }
+            }
+            AutoUpdate::On => {
+                if let Ok(Some(latest)) = self_update::check_upgrade().await {
+                    out.info(format!(
+                        "auto-updating symposium {} → {latest}...",
+                        state::CURRENT_VERSION,
+                    ));
+                    if let Err(e) = self_update::self_update(&Output::quiet(), sym.config.update_source).await {
+                        out.warn(format!("auto-update failed: {e}"));
+                    } else {
+                        self_update::re_exec();
+                    }
+                }
+            }
+        }
+    }
 
     let cwd = std::env::current_dir().expect("failed to get current directory");
 

--- a/src/bin/cargo-agents.rs
+++ b/src/bin/cargo-agents.rs
@@ -67,7 +67,7 @@ async fn main() -> ExitCode {
         match sym.config.auto_update {
             AutoUpdate::Off => unreachable!(),
             AutoUpdate::Warn => {
-                if let Ok(Some(latest)) = self_update::check_upgrade().await {
+                if let Ok(Some(latest)) = self_update::check_upgrade() {
                     out.warn(format!(
                         "symposium {} is available (current: {}). \
                          Run `cargo agents self-update` to upgrade.",
@@ -77,12 +77,14 @@ async fn main() -> ExitCode {
                 }
             }
             AutoUpdate::On => {
-                if let Ok(Some(latest)) = self_update::check_upgrade().await {
+                if let Ok(Some(latest)) = self_update::check_upgrade() {
                     out.info(format!(
                         "auto-updating symposium {} → {latest}...",
                         state::CURRENT_VERSION,
                     ));
-                    if let Err(e) = self_update::self_update(&Output::quiet(), sym.config.update_source).await {
+                    if let Err(e) =
+                        self_update::self_update(&Output::quiet(), sym.config.update_source).await
+                    {
                         out.warn(format!("auto-update failed: {e}"));
                     } else {
                         self_update::re_exec();

--- a/src/bin/cargo-agents.rs
+++ b/src/bin/cargo-agents.rs
@@ -68,7 +68,7 @@ async fn main() -> ExitCode {
         match sym.config.auto_update {
             AutoUpdate::Off => unreachable!(),
             AutoUpdate::Warn if !is_hook => {
-                if let Ok(Some(latest)) = self_update::check_upgrade() {
+                if let Ok(Some(latest)) = self_update::check_upgrade(&sym) {
                     out.warn(format!(
                         "symposium {} is available (current: {}). \
                          Run `cargo agents self-update` to upgrade.",
@@ -78,16 +78,14 @@ async fn main() -> ExitCode {
                 }
             }
             AutoUpdate::On => {
-                if let Ok(Some(latest)) = self_update::check_upgrade() {
+                if let Ok(Some(latest)) = self_update::check_upgrade(&sym) {
                     if !is_hook {
                         out.info(format!(
                             "auto-updating symposium {} → {latest}...",
                             state::CURRENT_VERSION,
                         ));
                     }
-                    if let Err(e) =
-                        self_update::self_update(&Output::quiet(), sym.config.update_source).await
-                    {
+                    if let Err(e) = self_update::self_update(&sym, &Output::quiet()).await {
                         if !is_hook {
                             out.warn(format!("auto-update failed: {e}"));
                         }

--- a/src/bin/cargo-agents.rs
+++ b/src/bin/cargo-agents.rs
@@ -58,12 +58,17 @@ async fn main() -> ExitCode {
     plugins::ensure_plugin_sources(&sym, cli.update).await;
 
     // Auto-update = "on": check for updates and re-exec if a new binary was
-    // installed.  Skipped for self-update (which always checks explicitly).
-    // The warn path is handled inside cli::run via maybe_warn_for_update.
-    if !matches!(cli.command, Some(Commands::SelfUpdate))
-        && self_update::maybe_check_for_update(&sym, &out).await
-    {
-        self_update::re_exec();
+    // installed.  Skipped for self-update (which always checks explicitly)
+    // and for hooks (session-start injects the warn nudge into hook output;
+    // the "on" re-exec for hooks is handled here).
+    if !matches!(cli.command, Some(Commands::SelfUpdate)) && !is_hook {
+        if self_update::maybe_check_for_update(&sym, &out).await {
+            self_update::re_exec();
+        }
+    } else if is_hook && sym.config.auto_update == config::AutoUpdate::On {
+        if self_update::maybe_check_for_update(&sym, &Output::quiet()).await {
+            self_update::re_exec();
+        }
     }
 
     let cwd = std::env::current_dir().expect("failed to get current directory");

--- a/src/bin/cargo-agents.rs
+++ b/src/bin/cargo-agents.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use std::process::ExitCode;
 
 use symposium::cli::{Cli, Commands, PluginCommand};
-use symposium::config::{self, AutoUpdate};
+use symposium::config;
 use symposium::hook;
 use symposium::output::Output;
 use symposium::plugins;
@@ -57,45 +57,14 @@ async fn main() -> ExitCode {
     // Ensure git-based plugin sources are up to date (non-blocking on failure).
     plugins::ensure_plugin_sources(&sym, cli.update).await;
 
-    // Auto-update check (skip for self-update itself, which always checks).
-    // For hooks: "warn" is skipped (stderr isn't visible to the agent), but
-    // "on" still auto-updates silently so the next invocation uses the new binary.
-    if !matches!(cli.command, Some(Commands::SelfUpdate))
-        && sym.config.auto_update != AutoUpdate::Off
-        && state::should_check_for_update(sym.config_dir())
-    {
-        state::record_update_check(sym.config_dir());
-        match sym.config.auto_update {
-            AutoUpdate::Off => unreachable!(),
-            AutoUpdate::Warn if !is_hook => {
-                if let Ok(Some(latest)) = self_update::check_upgrade(&sym) {
-                    out.warn(format!(
-                        "symposium {} is available (current: {}). \
-                         Run `cargo agents self-update` to upgrade.",
-                        latest,
-                        state::CURRENT_VERSION,
-                    ));
-                }
-            }
-            AutoUpdate::On => {
-                if let Ok(Some(latest)) = self_update::check_upgrade(&sym) {
-                    if !is_hook {
-                        out.info(format!(
-                            "auto-updating symposium {} → {latest}...",
-                            state::CURRENT_VERSION,
-                        ));
-                    }
-                    if let Err(e) = self_update::self_update(&sym, &Output::quiet()).await {
-                        if !is_hook {
-                            out.warn(format!("auto-update failed: {e}"));
-                        }
-                    } else {
-                        self_update::re_exec();
-                    }
-                }
-            }
-            _ => {}
-        }
+    // For hook invocations, run the auto-update check here (hooks don't go
+    // through cli::run which handles it for other commands).  Only the
+    // auto-update = "on" re-exec path lives in the binary; the warn path
+    // is handled inside cli::run / maybe_check_for_update.
+    // Hooks don't go through cli::run(), so run the update check here.
+    // If auto-update = "on" succeeded, re-exec into the new binary.
+    if is_hook && self_update::maybe_check_for_update(&sym, &Output::quiet()).await {
+        self_update::re_exec();
     }
 
     let cwd = std::env::current_dir().expect("failed to get current directory");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -138,7 +138,7 @@ pub async fn run(sym: &mut Symposium, cmd: Commands, cwd: &Path, out: &Output) -
 
         Commands::Sync => sync::sync(sym, cwd, out).await,
 
-        Commands::SelfUpdate => self_update::self_update(out, sym.config.update_source).await,
+        Commands::SelfUpdate => self_update::self_update(sym, out).await,
 
         Commands::CrateInfo { name, version } => {
             match crate_command::dispatch_crate(sym, &name, version.as_deref(), cwd).await {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -123,10 +123,11 @@ pub enum PluginCommand {
 /// The binary passes `std::env::current_dir()`; tests pass the fixture workspace root.
 pub async fn run(sym: &mut Symposium, cmd: Commands, cwd: &Path, out: &Output) -> Result<()> {
     // Periodic update check (skipped for self-update, which always checks).
-    // The return value signals whether a re-exec is needed (auto-update = "on"),
-    // but cli::run() can't replace the process — the binary handles that.
+    // In the binary, re-exec happens if auto-update = "on" succeeds.
+    // Here in the library we just run the warn check; the binary wraps
+    // this with re-exec logic.
     if !matches!(cmd, Commands::SelfUpdate) {
-        self_update::maybe_check_for_update(sym, out).await;
+        self_update::maybe_warn_for_update(sym, out);
     }
 
     match cmd {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,6 +13,7 @@ use crate::crate_command::{self, DispatchResult};
 use crate::hook;
 use crate::init::{self, InitOpts};
 use crate::output::Output;
+use crate::self_update;
 use crate::sync;
 
 /// Parsed CLI arguments.
@@ -72,6 +73,9 @@ pub enum Commands {
         #[command(subcommand)]
         command: PluginCommand,
     },
+
+    /// Update symposium to the latest version
+    SelfUpdate,
 
     /// Find crate sources
     #[command(hide = true)]
@@ -133,6 +137,8 @@ pub async fn run(sym: &mut Symposium, cmd: Commands, cwd: &Path, out: &Output) -
         }
 
         Commands::Sync => sync::sync(sym, cwd, out).await,
+
+        Commands::SelfUpdate => self_update::self_update(out, sym.config.update_source).await,
 
         Commands::CrateInfo { name, version } => {
             match crate_command::dispatch_crate(sym, &name, version.as_deref(), cwd).await {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -146,7 +146,7 @@ pub async fn run(sym: &mut Symposium, cmd: Commands, cwd: &Path, out: &Output) -
 
         Commands::Sync => sync::sync(sym, cwd, out).await,
 
-        Commands::SelfUpdate => self_update::self_update(sym, out).await,
+        Commands::SelfUpdate => self_update::self_update(sym, out),
 
         Commands::CrateInfo { name, version } => {
             match crate_command::dispatch_crate(sym, &name, version.as_deref(), cwd).await {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -122,6 +122,13 @@ pub enum PluginCommand {
 /// `cwd` is the working directory for commands that need it (sync, start, crate).
 /// The binary passes `std::env::current_dir()`; tests pass the fixture workspace root.
 pub async fn run(sym: &mut Symposium, cmd: Commands, cwd: &Path, out: &Output) -> Result<()> {
+    // Periodic update check (skipped for self-update, which always checks).
+    // The return value signals whether a re-exec is needed (auto-update = "on"),
+    // but cli::run() can't replace the process — the binary handles that.
+    if !matches!(cmd, Commands::SelfUpdate) {
+        self_update::maybe_check_for_update(sym, out).await;
+    }
+
     match cmd {
         Commands::Init {
             agents,

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,52 @@ use tracing::Level;
 // User configuration (~/.symposium/config.toml)
 // ---------------------------------------------------------------------------
 
+/// Auto-update behavior for the symposium binary.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, clap::ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum AutoUpdate {
+    /// Never check for or install updates.
+    Off,
+    /// Print a warning when a newer version is available.
+    #[default]
+    Warn,
+    /// Automatically download and re-exec into the new version.
+    On,
+}
+
+impl AutoUpdate {
+    fn is_default(&self) -> bool {
+        matches!(self, AutoUpdate::Warn)
+    }
+}
+
+impl std::fmt::Display for AutoUpdate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AutoUpdate::Off => write!(f, "off"),
+            AutoUpdate::Warn => write!(f, "warn"),
+            AutoUpdate::On => write!(f, "on"),
+        }
+    }
+}
+
+/// Where self-update fetches the new binary from.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, clap::ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum UpdateSource {
+    /// Download a prebuilt binary from the GitHub release.
+    #[default]
+    Binary,
+    /// Build from source via `cargo install`.
+    Source,
+}
+
+impl UpdateSource {
+    fn is_default(&self) -> bool {
+        matches!(self, UpdateSource::Binary)
+    }
+}
+
 /// Where agent hooks are installed.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, clap::ValueEnum)]
 #[serde(rename_all = "lowercase")]
@@ -45,6 +91,22 @@ pub struct Config {
         skip_serializing_if = "HookScope::is_default"
     )]
     pub hook_scope: HookScope,
+
+    /// Auto-update behavior for the symposium binary.
+    #[serde(
+        default,
+        rename = "auto-update",
+        skip_serializing_if = "AutoUpdate::is_default"
+    )]
+    pub auto_update: AutoUpdate,
+
+    /// Where self-update fetches the new binary from.
+    #[serde(
+        default,
+        rename = "self-update-source",
+        skip_serializing_if = "UpdateSource::is_default"
+    )]
+    pub update_source: UpdateSource,
 
     /// Agents configured for this user.
     #[serde(default, rename = "agent")]
@@ -89,6 +151,8 @@ impl Default for Config {
             auto_sync: true,
             agents_syncing: true,
             hook_scope: HookScope::default(),
+            auto_update: AutoUpdate::default(),
+            update_source: UpdateSource::default(),
             agents: Vec::new(),
             logging: LoggingConfig::default(),
             defaults: DefaultsConfig::default(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,15 +15,15 @@ pub enum AutoUpdate {
     /// Never check for or install updates.
     Off,
     /// Print a warning when a newer version is available.
-    #[default]
     Warn,
-    /// Automatically download and re-exec into the new version.
+    /// Automatically install updates and re-exec into the new version.
+    #[default]
     On,
 }
 
 impl AutoUpdate {
     fn is_default(&self) -> bool {
-        matches!(self, AutoUpdate::Warn)
+        matches!(self, AutoUpdate::On)
     }
 }
 
@@ -34,23 +34,6 @@ impl std::fmt::Display for AutoUpdate {
             AutoUpdate::Warn => write!(f, "warn"),
             AutoUpdate::On => write!(f, "on"),
         }
-    }
-}
-
-/// Where self-update fetches the new binary from.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, clap::ValueEnum)]
-#[serde(rename_all = "lowercase")]
-pub enum UpdateSource {
-    /// Download a prebuilt binary from the GitHub release.
-    #[default]
-    Binary,
-    /// Build from source via `cargo install`.
-    Source,
-}
-
-impl UpdateSource {
-    fn is_default(&self) -> bool {
-        matches!(self, UpdateSource::Binary)
     }
 }
 
@@ -100,14 +83,6 @@ pub struct Config {
     )]
     pub auto_update: AutoUpdate,
 
-    /// Where self-update fetches the new binary from.
-    #[serde(
-        default,
-        rename = "self-update-source",
-        skip_serializing_if = "UpdateSource::is_default"
-    )]
-    pub update_source: UpdateSource,
-
     /// Agents configured for this user.
     #[serde(default, rename = "agent")]
     pub agents: Vec<AgentEntry>,
@@ -152,7 +127,6 @@ impl Default for Config {
             agents_syncing: true,
             hook_scope: HookScope::default(),
             auto_update: AutoUpdate::default(),
-            update_source: UpdateSource::default(),
             agents: Vec::new(),
             logging: LoggingConfig::default(),
             defaults: DefaultsConfig::default(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -227,6 +227,7 @@ pub struct Symposium {
     config_dir: PathBuf,
     cache_dir: PathBuf,
     home_dir: PathBuf,
+    cargo_override: Option<PathBuf>,
 }
 
 impl Symposium {
@@ -254,6 +255,7 @@ impl Symposium {
             config_dir,
             cache_dir,
             home_dir,
+            cargo_override: None,
         }
     }
 
@@ -278,7 +280,24 @@ impl Symposium {
             config_dir,
             cache_dir,
             home_dir,
+            cargo_override: None,
         }
+    }
+
+    /// Build a `Command` for the cargo binary.
+    ///
+    /// Uses the test override if set, otherwise plain `"cargo"`.
+    pub fn cargo_command(&self) -> std::process::Command {
+        match &self.cargo_override {
+            Some(path) => std::process::Command::new(path),
+            None => std::process::Command::new("cargo"),
+        }
+    }
+
+    /// Override the cargo binary path (test-only).
+    #[doc(hidden)]
+    pub fn set_cargo_override(&mut self, path: PathBuf) {
+        self.cargo_override = Some(path);
     }
 
     /// Initialize logging. Call once at startup.

--- a/src/config.rs
+++ b/src/config.rs
@@ -250,12 +250,14 @@ impl Symposium {
         // Note: can't use tracing here — logging isn't initialized yet.
         // init_logging() is called after construction.
 
+        let cargo_override = env::var("SYMPOSIUM_CARGO").ok().map(PathBuf::from);
+
         Self {
             config,
             config_dir,
             cache_dir,
             home_dir,
-            cargo_override: None,
+            cargo_override,
         }
     }
 

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -316,12 +316,33 @@ pub async fn dispatch_builtin(
     }
 }
 
-/// Handle SessionStart: return empty (no session-start-context support).
+/// Handle SessionStart: check for updates and nudge the user via context.
 fn handle_session_start(
-    _sym: &Symposium,
+    sym: &Symposium,
     _payload: &symposium::SessionStartInput,
 ) -> symposium::OutputEvent {
-    symposium::OutputEvent::empty_for(HookEvent::SessionStart)
+    use crate::config::AutoUpdate;
+    use crate::self_update;
+    use crate::state;
+    use crate::state::CURRENT_VERSION;
+
+    if sym.config.auto_update != AutoUpdate::Warn {
+        return symposium::OutputEvent::empty_for(HookEvent::SessionStart);
+    }
+    if !state::should_check_for_update(sym.config_dir()) {
+        return symposium::OutputEvent::empty_for(HookEvent::SessionStart);
+    }
+    state::record_update_check(sym.config_dir());
+
+    if let Ok(Some(latest)) = self_update::check_upgrade(sym) {
+        let msg = format!(
+            "symposium {latest} is available (current: {CURRENT_VERSION}). \
+             Run `cargo agents self-update` to upgrade."
+        );
+        symposium::OutputEvent::with_context(HookEvent::SessionStart, msg)
+    } else {
+        symposium::OutputEvent::empty_for(HookEvent::SessionStart)
+    }
 }
 
 /// Handle PostToolUse: no-op for now.

--- a/src/init.rs
+++ b/src/init.rs
@@ -164,8 +164,9 @@ fn prompt_for_agents(existing: &[AgentEntry]) -> Result<Vec<Agent>> {
 // ---------------------------------------------------------------------------
 
 /// Find the workspace root using `cargo metadata`, run from the given directory.
-pub fn find_workspace_root(cwd: &std::path::Path) -> Result<PathBuf> {
-    let output = crate::cargo_command()
+pub fn find_workspace_root(sym: &Symposium, cwd: &std::path::Path) -> Result<PathBuf> {
+    let output = sym
+        .cargo_command()
         .args(["metadata", "--no-deps", "--format-version=1"])
         .current_dir(cwd)
         .output()

--- a/src/init.rs
+++ b/src/init.rs
@@ -82,6 +82,11 @@ pub async fn init(sym: &mut Symposium, out: &Output, opts: &InitOpts) -> Result<
     }
     tracing::debug!(scope = ?sym.config.hook_scope, "hook scope");
 
+    if !agents.is_empty() && interactive(out) {
+        sym.config.auto_update = prompt_for_auto_update(sym.config.auto_update)?;
+    }
+    tracing::debug!(auto_update = ?sym.config.auto_update, "auto-update");
+
     sym.save_config().context("failed to write user config")?;
     tracing::info!(
         agents = ?agents.iter().map(|a| a.config_name()).collect::<Vec<_>>(),
@@ -138,6 +143,33 @@ fn prompt_for_hook_scope(current: crate::config::HookScope) -> Result<crate::con
     Ok(match selection {
         0 => HookScope::Global,
         _ => HookScope::Project,
+    })
+}
+
+fn prompt_for_auto_update(current: crate::config::AutoUpdate) -> Result<crate::config::AutoUpdate> {
+    use crate::config::AutoUpdate;
+
+    let items = [
+        "Auto-update (recommended)",
+        "Warn when updates are available",
+        "Off",
+    ];
+    let default = match current {
+        AutoUpdate::On => 0,
+        AutoUpdate::Warn => 1,
+        AutoUpdate::Off => 2,
+    };
+
+    let selection = dialoguer::Select::new()
+        .with_prompt("Automatic updates")
+        .items(items)
+        .default(default)
+        .interact()?;
+
+    Ok(match selection {
+        0 => AutoUpdate::On,
+        1 => AutoUpdate::Warn,
+        _ => AutoUpdate::Off,
     })
 }
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -165,7 +165,7 @@ fn prompt_for_agents(existing: &[AgentEntry]) -> Result<Vec<Agent>> {
 
 /// Find the workspace root using `cargo metadata`, run from the given directory.
 pub fn find_workspace_root(cwd: &std::path::Path) -> Result<PathBuf> {
-    let output = std::process::Command::new("cargo")
+    let output = crate::cargo_command()
         .args(["metadata", "--no-deps", "--format-version=1"])
         .current_dir(cwd)
         .output()

--- a/src/installation.rs
+++ b/src/installation.rs
@@ -143,23 +143,26 @@ pub async fn query_crate_binaries(
 
 /// Install a crate using cargo binstall (fast) or cargo install (fallback).
 pub(crate) async fn install_cargo_crate(
+    sym: &crate::config::Symposium,
     crate_name: &str,
     version: &str,
     binary_name: Option<String>,
     cache_dir: PathBuf,
     git: Option<String>,
 ) -> Result<()> {
+    let sym = sym.clone();
     let crate_name = crate_name.to_string();
     let version = version.to_string();
 
     tokio::task::spawn_blocking(move || {
-        install_cargo_crate_sync(&crate_name, &version, binary_name, &cache_dir, git)
+        install_cargo_crate_sync(&sym, &crate_name, &version, binary_name, &cache_dir, git)
     })
     .await
     .context("Cargo install task panicked")?
 }
 
 fn install_cargo_crate_sync(
+    sym: &crate::config::Symposium,
     crate_name: &str,
     version: &str,
     binary_name: Option<String>,
@@ -192,7 +195,7 @@ fn install_cargo_crate_sync(
         binstall_args.push(git);
     }
     binstall_args.extend([cache_dir.to_str().unwrap(), &crate_spec]);
-    let binstall_result = crate::cargo_command().args(binstall_args).output();
+    let binstall_result = sym.cargo_command().args(binstall_args).output();
 
     let binary_path = binary_name
         .as_ref()
@@ -228,7 +231,8 @@ fn install_cargo_crate_sync(
         args.push(git);
     }
     args.extend([cache_dir.to_str().unwrap(), &crate_spec]);
-    let install_result = crate::cargo_command()
+    let install_result = sym
+        .cargo_command()
         .args(args)
         .output()
         .context("Failed to run cargo install")?;
@@ -286,6 +290,7 @@ async fn acquire_cargo(
         let probe = cache_dir.join("bin").join(platform_binary_exe(&resolved));
         if !probe.exists() {
             install_cargo_crate(
+                sym,
                 &cargo.crate_name,
                 cargo.version.as_deref().unwrap_or(""),
                 Some(resolved.clone()),
@@ -321,6 +326,7 @@ async fn acquire_cargo(
     let already = probe_path.as_ref().map_or(false, |p| p.exists());
     if !already {
         install_cargo_crate(
+            sym,
             &cargo.crate_name,
             &version,
             resolved.clone(),

--- a/src/installation.rs
+++ b/src/installation.rs
@@ -167,7 +167,6 @@ fn install_cargo_crate_sync(
     git: Option<String>,
 ) -> Result<()> {
     use std::fs;
-    use std::process::Command;
 
     if let Some(parent) = cache_dir.parent()
         && parent.exists()
@@ -193,7 +192,7 @@ fn install_cargo_crate_sync(
         binstall_args.push(git);
     }
     binstall_args.extend([cache_dir.to_str().unwrap(), &crate_spec]);
-    let binstall_result = Command::new("cargo").args(binstall_args).output();
+    let binstall_result = crate::cargo_command().args(binstall_args).output();
 
     let binary_path = binary_name
         .as_ref()
@@ -229,7 +228,7 @@ fn install_cargo_crate_sync(
         args.push(git);
     }
     args.extend([cache_dir.to_str().unwrap(), &crate_spec]);
-    let install_result = Command::new("cargo")
+    let install_result = crate::cargo_command()
         .args(args)
         .output()
         .context("Failed to run cargo install")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ pub mod hook_schema;
 pub mod init;
 pub mod output;
 pub mod plugins;
+pub mod self_update;
+pub mod state;
 pub mod sync;
 
 pub(crate) mod crate_sources;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-use std::process::Command;
-
 pub mod agents;
 pub mod cli;
 pub mod config;
@@ -20,8 +18,3 @@ pub(crate) mod skills;
 
 #[cfg(test)]
 pub(crate) mod test_utils;
-
-/// Build a `Command` for the cargo binary, falling back to `"cargo"`.
-pub fn cargo_command() -> Command {
-    Command::new("cargo")
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use std::process::Command;
+
 pub mod agents;
 pub mod cli;
 pub mod config;
@@ -18,3 +20,8 @@ pub(crate) mod skills;
 
 #[cfg(test)]
 pub(crate) mod test_utils;
+
+/// Build a `Command` for the cargo binary, falling back to `"cargo"`.
+pub fn cargo_command() -> Command {
+    Command::new("cargo")
+}

--- a/src/output.rs
+++ b/src/output.rs
@@ -4,80 +4,113 @@
 //! silenced with `--quiet` or when running from a hook.
 
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 /// Controls whether user-facing status messages are printed.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct Output {
     quiet: bool,
+    capture: Option<Arc<Mutex<Vec<String>>>>,
 }
 
 impl Output {
     pub fn normal() -> Self {
-        Self { quiet: false }
+        Self {
+            quiet: false,
+            capture: None,
+        }
     }
 
     pub fn quiet() -> Self {
-        Self { quiet: true }
+        Self {
+            quiet: true,
+            capture: None,
+        }
+    }
+
+    /// Create an output that captures all messages into a buffer
+    /// instead of printing them.
+    pub fn capturing() -> Self {
+        Self {
+            quiet: false,
+            capture: Some(Arc::new(Mutex::new(Vec::new()))),
+        }
+    }
+
+    /// Return all captured messages. Panics if not in capturing mode.
+    pub fn captured(&self) -> Vec<String> {
+        self.capture
+            .as_ref()
+            .expect("not in capturing mode")
+            .lock()
+            .unwrap()
+            .clone()
     }
 
     pub fn is_quiet(&self) -> bool {
         self.quiet
     }
 
+    fn emit(&self, msg: String) {
+        if self.quiet {
+            return;
+        }
+        if let Some(buf) = &self.capture {
+            buf.lock().unwrap().push(msg);
+        } else {
+            println!("{msg}");
+        }
+    }
+
+    fn emit_err(&self, msg: String) {
+        if self.quiet {
+            return;
+        }
+        if let Some(buf) = &self.capture {
+            buf.lock().unwrap().push(msg);
+        } else {
+            eprintln!("{msg}");
+        }
+    }
+
     /// Something was already in place, no action needed.
     pub fn already_ok(&self, msg: impl std::fmt::Display) {
-        if !self.quiet {
-            println!("🟢 {msg}");
-        }
+        self.emit(format!("🟢 {msg}"));
     }
 
     /// An action was taken successfully (created, added, wrote).
     pub fn done(&self, msg: impl std::fmt::Display) {
-        if !self.quiet {
-            println!("✅ {msg}");
-        }
+        self.emit(format!("✅ {msg}"));
     }
 
     /// A new item was discovered or added.
     pub fn added(&self, msg: impl std::fmt::Display) {
-        if !self.quiet {
-            println!("➕ {msg}");
-        }
+        self.emit(format!("➕ {msg}"));
     }
 
     /// An item was removed.
     pub fn removed(&self, msg: impl std::fmt::Display) {
-        if !self.quiet {
-            println!("➖ {msg}");
-        }
+        self.emit(format!("➖ {msg}"));
     }
 
     /// Informational status (not an action).
     pub fn info(&self, msg: impl std::fmt::Display) {
-        if !self.quiet {
-            println!("ℹ️  {msg}");
-        }
+        self.emit(format!("ℹ️  {msg}"));
     }
 
     /// A warning (something went wrong but not fatal).
     pub fn warn(&self, msg: impl std::fmt::Display) {
-        if !self.quiet {
-            eprintln!("⚠️  {msg}");
-        }
+        self.emit_err(format!("⚠️  {msg}"));
     }
 
     /// Print a blank line for spacing.
     pub fn blank(&self) {
-        if !self.quiet {
-            println!();
-        }
+        self.emit(String::new());
     }
 
     /// Print arbitrary text (for prompts, headers, etc.).
     pub fn println(&self, msg: impl std::fmt::Display) {
-        if !self.quiet {
-            println!("{msg}");
-        }
+        self.emit(format!("{msg}"));
     }
 }
 

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -1,24 +1,15 @@
-//! Self-update: check for newer versions and install them.
-//!
-//! Prefers downloading a prebuilt binary from the GitHub release.
-//! Falls back to `cargo install` when no prebuilt binary is available
-//! for the current platform.
+//! Self-update: check for newer versions and install them via `cargo install`.
 
-use std::io::Cursor;
-use std::path::PathBuf;
 use std::process::Command;
 
 use anyhow::{Context, Result, bail};
 
-use crate::config::{AutoUpdate, Symposium, UpdateSource};
+use crate::config::{AutoUpdate, Symposium};
 use crate::output::Output;
 use crate::state;
 use crate::state::CURRENT_VERSION;
 
 const CRATE_NAME: &str = "symposium";
-const USER_AGENT: &str = "symposium (https://github.com/symposium-dev/symposium)";
-const REPO_URL: &str = "https://github.com/symposium-dev/symposium";
-const BINARY_NAME: &str = "cargo-agents";
 
 /// Query the registry for the latest published version of symposium
 /// by running `cargo search symposium --limit 1`.
@@ -90,8 +81,8 @@ pub fn maybe_warn_for_update(sym: &Symposium, out: &Output) {
 /// Full update check for the binary startup path.
 ///
 /// Respects config and the 24-hour throttle.  For `warn`, prints a
-/// nudge.  For `on`, downloads and installs the update, then returns
-/// `true` so the caller can re-exec into the new binary.
+/// nudge.  For `on`, installs the update via `cargo install`, then
+/// returns `true` so the caller can re-exec into the new binary.
 pub async fn maybe_check_for_update(sym: &Symposium, out: &Output) -> bool {
     if sym.config.auto_update == AutoUpdate::Off {
         return false;
@@ -118,8 +109,11 @@ pub async fn maybe_check_for_update(sym: &Symposium, out: &Output) -> bool {
             out.info(format!(
                 "auto-updating symposium {CURRENT_VERSION} → {latest}..."
             ));
-            match self_update(sym, &Output::quiet()).await {
-                Ok(()) => true,
+            match cargo_install(sym) {
+                Ok(()) => {
+                    out.done(format!("updated to {latest}"));
+                    true
+                }
                 Err(e) => {
                     out.warn(format!("auto-update failed: {e}"));
                     false
@@ -130,8 +124,8 @@ pub async fn maybe_check_for_update(sym: &Symposium, out: &Output) -> bool {
     }
 }
 
-/// Run the self-update using the configured source strategy.
-pub async fn self_update(sym: &Symposium, out: &Output) -> Result<()> {
+/// Run the self-update: check for a newer version and install it.
+pub fn self_update(sym: &Symposium, out: &Output) -> Result<()> {
     let target_version = match check_upgrade(sym) {
         Ok(Some(latest)) => {
             out.info(format!("updating symposium {CURRENT_VERSION} → {latest}"));
@@ -147,177 +141,10 @@ pub async fn self_update(sym: &Symposium, out: &Output) -> Result<()> {
         }
     };
 
-    match sym.config.update_source {
-        UpdateSource::Source => {
-            cargo_install(sym)?;
-            out.done(format!("updated to {target_version} (cargo install)"));
-        }
-        UpdateSource::Binary => {
-            let install_dir = cargo_bin_dir()?;
-            match download_release(&target_version, &install_dir).await {
-                Ok(()) => {
-                    out.done(format!("updated to {target_version} (prebuilt binary)"));
-                }
-                Err(e) => {
-                    tracing::warn!("prebuilt download failed: {e:#}");
-                    out.info("prebuilt binary not available, falling back to cargo install...");
-                    cargo_install(sym)?;
-                    out.done(format!("updated to {target_version} (cargo install)"));
-                }
-            }
-        }
-    }
-
+    cargo_install(sym)?;
+    out.done(format!("updated to {target_version}"));
     Ok(())
 }
-
-// ---------------------------------------------------------------------------
-// Prebuilt binary download
-// ---------------------------------------------------------------------------
-
-fn target_triple() -> &'static str {
-    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
-    {
-        "aarch64-apple-darwin"
-    }
-    #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-    {
-        "x86_64-unknown-linux-musl"
-    }
-    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
-    {
-        "aarch64-unknown-linux-musl"
-    }
-    #[cfg(all(target_arch = "x86_64", target_os = "windows"))]
-    {
-        "x86_64-pc-windows-msvc"
-    }
-}
-
-fn release_url(version: &semver::Version) -> String {
-    let target = target_triple();
-    let ext = if cfg!(windows) { "zip" } else { "tar.gz" };
-    format!("{REPO_URL}/releases/download/{CRATE_NAME}-v{version}/{BINARY_NAME}-{target}.{ext}")
-}
-
-async fn download_release(version: &semver::Version, install_dir: &std::path::Path) -> Result<()> {
-    let url = release_url(version);
-    tracing::info!(%url, "downloading release");
-
-    let client = reqwest::Client::builder()
-        .user_agent(USER_AGENT)
-        .build()
-        .context("failed to build HTTP client")?;
-
-    let response = client
-        .get(&url)
-        .send()
-        .await
-        .context("failed to download release")?;
-
-    if !response.status().is_success() {
-        bail!("download failed: HTTP {} from {url}", response.status());
-    }
-
-    let bytes = response
-        .bytes()
-        .await
-        .context("failed to read response body")?;
-
-    let binary_bytes = if cfg!(windows) {
-        extract_zip(&bytes)?
-    } else {
-        extract_tarball(&bytes)?
-    };
-
-    install_binary(&binary_bytes, install_dir)?;
-    Ok(())
-}
-
-fn extract_tarball(archive_bytes: &[u8]) -> Result<Vec<u8>> {
-    use flate2::read::GzDecoder;
-    use std::io::Read;
-    use tar::Archive;
-
-    let gz = GzDecoder::new(Cursor::new(archive_bytes));
-    let mut archive = Archive::new(gz);
-
-    for entry in archive.entries().context("failed to read tar entries")? {
-        let mut entry = entry.context("failed to read tar entry")?;
-        let path = entry.path().context("failed to read entry path")?;
-
-        let file_name = path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or_default();
-
-        if file_name == BINARY_NAME {
-            let mut buf = Vec::new();
-            entry
-                .read_to_end(&mut buf)
-                .context("failed to read binary from archive")?;
-            return Ok(buf);
-        }
-    }
-
-    bail!("{BINARY_NAME} not found in archive");
-}
-
-#[cfg(windows)]
-fn extract_zip(archive_bytes: &[u8]) -> Result<Vec<u8>> {
-    use std::io::Read;
-
-    let reader = Cursor::new(archive_bytes);
-    let mut archive = zip::ZipArchive::new(reader).context("failed to read zip archive")?;
-
-    let exe_name = format!("{BINARY_NAME}.exe");
-    let mut file = archive
-        .by_name(&exe_name)
-        .context("binary not found in zip")?;
-
-    let mut buf = Vec::new();
-    file.read_to_end(&mut buf)
-        .context("failed to read binary from zip")?;
-    Ok(buf)
-}
-
-#[cfg(not(windows))]
-fn extract_zip(_archive_bytes: &[u8]) -> Result<Vec<u8>> {
-    bail!("zip extraction not expected on this platform");
-}
-
-fn install_binary(binary_bytes: &[u8], install_dir: &std::path::Path) -> Result<()> {
-    use std::fs;
-
-    let bin_name = if cfg!(windows) {
-        format!("{BINARY_NAME}.exe")
-    } else {
-        BINARY_NAME.to_string()
-    };
-    let dest = install_dir.join(&bin_name);
-
-    // Write to a temp file in the same directory, then atomically rename.
-    let tmp = tempfile::NamedTempFile::new_in(install_dir)
-        .context("failed to create temp file for binary")?;
-
-    fs::write(tmp.path(), binary_bytes).context("failed to write binary")?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(tmp.path(), fs::Permissions::from_mode(0o755))
-            .context("failed to set executable permissions")?;
-    }
-
-    tmp.persist(&dest).context("failed to replace binary")?;
-
-    tracing::info!(path = %dest.display(), "installed updated binary");
-    Ok(())
-}
-
-// ---------------------------------------------------------------------------
-// Fallback: cargo install
-// ---------------------------------------------------------------------------
 
 fn cargo_install(sym: &Symposium) -> Result<()> {
     let status = sym
@@ -330,18 +157,6 @@ fn cargo_install(sym: &Symposium) -> Result<()> {
         bail!("cargo install failed with exit code {:?}", status.code());
     }
     Ok(())
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-fn cargo_bin_dir() -> Result<PathBuf> {
-    if let Ok(dir) = std::env::var("CARGO_HOME") {
-        return Ok(PathBuf::from(dir).join("bin"));
-    }
-    let home = dirs::home_dir().context("could not determine home directory")?;
-    Ok(home.join(".cargo").join("bin"))
 }
 
 /// Re-execute the current process (replaces the process via exec on Unix,
@@ -407,52 +222,5 @@ mod tests {
     #[test]
     fn parse_search_output_empty() {
         assert!(parse_cargo_search_output("").is_err());
-    }
-
-    #[test]
-    fn extract_tarball_finds_binary() {
-        let tarball = build_test_tarball("cargo-agents", b"fake-binary-content");
-        let result = extract_tarball(&tarball).unwrap();
-        assert_eq!(result, b"fake-binary-content");
-    }
-
-    #[test]
-    fn extract_tarball_missing_binary() {
-        let tarball = build_test_tarball("wrong-name", b"data");
-        assert!(extract_tarball(&tarball).is_err());
-    }
-
-    #[test]
-    fn install_binary_creates_executable() {
-        let tmp = tempfile::tempdir().unwrap();
-        install_binary(b"#!/bin/sh\necho hello", tmp.path()).unwrap();
-
-        let installed = tmp.path().join(BINARY_NAME);
-        assert!(installed.exists());
-        assert_eq!(std::fs::read(&installed).unwrap(), b"#!/bin/sh\necho hello");
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mode = std::fs::metadata(&installed).unwrap().permissions().mode();
-            assert!(mode & 0o111 != 0, "binary should be executable");
-        }
-    }
-
-    fn build_test_tarball(filename: &str, content: &[u8]) -> Vec<u8> {
-        use flate2::Compression;
-        use flate2::write::GzEncoder;
-
-        let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
-        {
-            let mut builder = tar::Builder::new(&mut encoder);
-            let mut header = tar::Header::new_gnu();
-            header.set_size(content.len() as u64);
-            header.set_mode(0o755);
-            header.set_cksum();
-            builder.append_data(&mut header, filename, content).unwrap();
-            builder.finish().unwrap();
-        }
-        encoder.finish().unwrap()
     }
 }

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -10,7 +10,7 @@ use std::process::Command;
 
 use anyhow::{Context, Result, bail};
 
-use crate::config::UpdateSource;
+use crate::config::{Symposium, UpdateSource};
 use crate::output::Output;
 use crate::state::CURRENT_VERSION;
 
@@ -21,8 +21,9 @@ const BINARY_NAME: &str = "cargo-agents";
 
 /// Query the registry for the latest published version of symposium
 /// by running `cargo search symposium --limit 1`.
-pub fn latest_version() -> Result<semver::Version> {
-    let output = crate::cargo_command()
+pub fn latest_version(sym: &Symposium) -> Result<semver::Version> {
+    let output = sym
+        .cargo_command()
         .args(["search", CRATE_NAME, "--limit", "1"])
         .output()
         .context("failed to run cargo search")?;
@@ -52,10 +53,10 @@ fn parse_cargo_search_output(output: &str) -> Result<semver::Version> {
 
 /// Check whether a newer version is available.  Returns `Some(latest)`
 /// if an upgrade is available, `None` if we're current or ahead.
-pub fn check_upgrade() -> Result<Option<semver::Version>> {
+pub fn check_upgrade(sym: &Symposium) -> Result<Option<semver::Version>> {
     let current =
         semver::Version::parse(CURRENT_VERSION).context("failed to parse current version")?;
-    let latest = latest_version()?;
+    let latest = latest_version(sym)?;
     if latest > current {
         Ok(Some(latest))
     } else {
@@ -64,8 +65,8 @@ pub fn check_upgrade() -> Result<Option<semver::Version>> {
 }
 
 /// Run the self-update using the configured source strategy.
-pub async fn self_update(out: &Output, source: UpdateSource) -> Result<()> {
-    let target_version = match check_upgrade() {
+pub async fn self_update(sym: &Symposium, out: &Output) -> Result<()> {
+    let target_version = match check_upgrade(sym) {
         Ok(Some(latest)) => {
             out.info(format!("updating symposium {CURRENT_VERSION} → {latest}"));
             latest
@@ -80,9 +81,9 @@ pub async fn self_update(out: &Output, source: UpdateSource) -> Result<()> {
         }
     };
 
-    match source {
+    match sym.config.update_source {
         UpdateSource::Source => {
-            cargo_install()?;
+            cargo_install(sym)?;
             out.done(format!("updated to {target_version} (cargo install)"));
         }
         UpdateSource::Binary => {
@@ -94,7 +95,7 @@ pub async fn self_update(out: &Output, source: UpdateSource) -> Result<()> {
                 Err(e) => {
                     tracing::warn!("prebuilt download failed: {e:#}");
                     out.info("prebuilt binary not available, falling back to cargo install...");
-                    cargo_install()?;
+                    cargo_install(sym)?;
                     out.done(format!("updated to {target_version} (cargo install)"));
                 }
             }
@@ -252,8 +253,9 @@ fn install_binary(binary_bytes: &[u8], install_dir: &std::path::Path) -> Result<
 // Fallback: cargo install
 // ---------------------------------------------------------------------------
 
-fn cargo_install() -> Result<()> {
-    let status = crate::cargo_command()
+fn cargo_install(sym: &Symposium) -> Result<()> {
+    let status = sym
+        .cargo_command()
         .args(["install", CRATE_NAME, "--force"])
         .status()
         .context("failed to run cargo install")?;

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -1,0 +1,290 @@
+//! Self-update: check for newer versions and install them.
+//!
+//! Prefers downloading a prebuilt binary from the GitHub release.
+//! Falls back to `cargo install` when no prebuilt binary is available
+//! for the current platform.
+
+use std::io::Cursor;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+
+use crate::config::UpdateSource;
+use crate::output::Output;
+use crate::state::CURRENT_VERSION;
+
+const CRATE_NAME: &str = "symposium";
+const USER_AGENT: &str = "symposium (https://github.com/symposium-dev/symposium)";
+const REPO_URL: &str = "https://github.com/symposium-dev/symposium";
+const BINARY_NAME: &str = "cargo-agents";
+
+/// Query crates.io for the latest published version of symposium.
+pub async fn latest_version() -> Result<semver::Version> {
+    let client = crates_io_api::AsyncClient::new(USER_AGENT, Duration::from_millis(1000))
+        .context("failed to create crates.io client")?;
+    let krate = client
+        .get_crate(CRATE_NAME)
+        .await
+        .context("failed to query crates.io for symposium")?;
+    let max_version = &krate.crate_data.max_version;
+    semver::Version::parse(max_version).context("failed to parse latest version from crates.io")
+}
+
+/// Check whether a newer version is available.  Returns `Some(latest)`
+/// if an upgrade is available, `None` if we're current or ahead.
+pub async fn check_upgrade() -> Result<Option<semver::Version>> {
+    let current =
+        semver::Version::parse(CURRENT_VERSION).context("failed to parse current version")?;
+    let latest = latest_version().await?;
+    if latest > current {
+        Ok(Some(latest))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Run the self-update using the configured source strategy.
+pub async fn self_update(out: &Output, source: UpdateSource) -> Result<()> {
+    let target_version = match check_upgrade().await {
+        Ok(Some(latest)) => {
+            out.info(format!("updating symposium {CURRENT_VERSION} → {latest}"));
+            latest
+        }
+        Ok(None) => {
+            out.already_ok(format!("symposium {CURRENT_VERSION} is up to date"));
+            return Ok(());
+        }
+        Err(e) => {
+            out.warn(format!("could not check for updates: {e}"));
+            return Err(e);
+        }
+    };
+
+    match source {
+        UpdateSource::Source => {
+            cargo_install()?;
+            out.done(format!("updated to {target_version} (cargo install)"));
+        }
+        UpdateSource::Binary => {
+            let install_dir = cargo_bin_dir()?;
+            match download_release(&target_version, &install_dir).await {
+                Ok(()) => {
+                    out.done(format!("updated to {target_version} (prebuilt binary)"));
+                }
+                Err(e) => {
+                    tracing::warn!("prebuilt download failed: {e:#}");
+                    out.info("prebuilt binary not available, falling back to cargo install...");
+                    cargo_install()?;
+                    out.done(format!("updated to {target_version} (cargo install)"));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Prebuilt binary download
+// ---------------------------------------------------------------------------
+
+fn target_triple() -> &'static str {
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    {
+        "aarch64-apple-darwin"
+    }
+    #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+    {
+        "x86_64-unknown-linux-musl"
+    }
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    {
+        "aarch64-unknown-linux-musl"
+    }
+    #[cfg(all(target_arch = "x86_64", target_os = "windows"))]
+    {
+        "x86_64-pc-windows-msvc"
+    }
+}
+
+fn release_url(version: &semver::Version) -> String {
+    let target = target_triple();
+    let ext = if cfg!(windows) { "zip" } else { "tar.gz" };
+    format!("{REPO_URL}/releases/download/{CRATE_NAME}-v{version}/{BINARY_NAME}-{target}.{ext}")
+}
+
+async fn download_release(version: &semver::Version, install_dir: &std::path::Path) -> Result<()> {
+    let url = release_url(version);
+    tracing::info!(%url, "downloading release");
+
+    let client = reqwest::Client::builder()
+        .user_agent(USER_AGENT)
+        .build()
+        .context("failed to build HTTP client")?;
+
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .context("failed to download release")?;
+
+    if !response.status().is_success() {
+        bail!(
+            "download failed: HTTP {} from {url}",
+            response.status()
+        );
+    }
+
+    let bytes = response
+        .bytes()
+        .await
+        .context("failed to read response body")?;
+
+    let binary_bytes = if cfg!(windows) {
+        extract_zip(&bytes)?
+    } else {
+        extract_tarball(&bytes)?
+    };
+
+    install_binary(&binary_bytes, install_dir)?;
+    Ok(())
+}
+
+fn extract_tarball(archive_bytes: &[u8]) -> Result<Vec<u8>> {
+    use flate2::read::GzDecoder;
+    use std::io::Read;
+    use tar::Archive;
+
+    let gz = GzDecoder::new(Cursor::new(archive_bytes));
+    let mut archive = Archive::new(gz);
+
+    for entry in archive.entries().context("failed to read tar entries")? {
+        let mut entry = entry.context("failed to read tar entry")?;
+        let path = entry.path().context("failed to read entry path")?;
+
+        let file_name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default();
+
+        if file_name == BINARY_NAME {
+            let mut buf = Vec::new();
+            entry
+                .read_to_end(&mut buf)
+                .context("failed to read binary from archive")?;
+            return Ok(buf);
+        }
+    }
+
+    bail!("{BINARY_NAME} not found in archive");
+}
+
+#[cfg(windows)]
+fn extract_zip(archive_bytes: &[u8]) -> Result<Vec<u8>> {
+    use std::io::Read;
+
+    let reader = Cursor::new(archive_bytes);
+    let mut archive = zip::ZipArchive::new(reader).context("failed to read zip archive")?;
+
+    let exe_name = format!("{BINARY_NAME}.exe");
+    let mut file = archive
+        .by_name(&exe_name)
+        .context("binary not found in zip")?;
+
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf)
+        .context("failed to read binary from zip")?;
+    Ok(buf)
+}
+
+#[cfg(not(windows))]
+fn extract_zip(_archive_bytes: &[u8]) -> Result<Vec<u8>> {
+    bail!("zip extraction not expected on this platform");
+}
+
+fn install_binary(binary_bytes: &[u8], install_dir: &std::path::Path) -> Result<()> {
+    use std::fs;
+
+    let bin_name = if cfg!(windows) {
+        format!("{BINARY_NAME}.exe")
+    } else {
+        BINARY_NAME.to_string()
+    };
+    let dest = install_dir.join(&bin_name);
+
+    // Write to a temp file in the same directory, then atomically rename.
+    let tmp = tempfile::NamedTempFile::new_in(install_dir)
+        .context("failed to create temp file for binary")?;
+
+    fs::write(tmp.path(), binary_bytes).context("failed to write binary")?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(tmp.path(), fs::Permissions::from_mode(0o755))
+            .context("failed to set executable permissions")?;
+    }
+
+    tmp.persist(&dest)
+        .context("failed to replace binary")?;
+
+    tracing::info!(path = %dest.display(), "installed updated binary");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Fallback: cargo install
+// ---------------------------------------------------------------------------
+
+fn cargo_install() -> Result<()> {
+    let status = Command::new("cargo")
+        .args(["install", CRATE_NAME, "--force"])
+        .status()
+        .context("failed to run cargo install")?;
+
+    if !status.success() {
+        bail!("cargo install failed with exit code {:?}", status.code());
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn cargo_bin_dir() -> Result<PathBuf> {
+    if let Ok(dir) = std::env::var("CARGO_HOME") {
+        return Ok(PathBuf::from(dir).join("bin"));
+    }
+    let home = dirs::home_dir().context("could not determine home directory")?;
+    Ok(home.join(".cargo").join("bin"))
+}
+
+/// Re-execute the current process (replaces the process via exec on Unix,
+/// spawn-and-exit on Windows).
+pub fn re_exec() -> ! {
+    let args: Vec<_> = std::env::args_os().collect();
+    let program = &args[0];
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        let err = Command::new(program).args(&args[1..]).exec();
+        eprintln!("failed to re-exec: {err}");
+        std::process::exit(1);
+    }
+
+    #[cfg(not(unix))]
+    {
+        let status = Command::new(program)
+            .args(&args[1..])
+            .status()
+            .unwrap_or_else(|e| {
+                eprintln!("failed to re-exec: {e}");
+                std::process::exit(1);
+            });
+        std::process::exit(status.code().unwrap_or(1));
+    }
+}

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -7,7 +7,6 @@
 use std::io::Cursor;
 use std::path::PathBuf;
 use std::process::Command;
-use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 
@@ -20,24 +19,37 @@ const USER_AGENT: &str = "symposium (https://github.com/symposium-dev/symposium)
 const REPO_URL: &str = "https://github.com/symposium-dev/symposium";
 const BINARY_NAME: &str = "cargo-agents";
 
-/// Query crates.io for the latest published version of symposium.
-pub async fn latest_version() -> Result<semver::Version> {
-    let client = crates_io_api::AsyncClient::new(USER_AGENT, Duration::from_millis(1000))
-        .context("failed to create crates.io client")?;
-    let krate = client
-        .get_crate(CRATE_NAME)
-        .await
-        .context("failed to query crates.io for symposium")?;
-    let max_version = &krate.crate_data.max_version;
-    semver::Version::parse(max_version).context("failed to parse latest version from crates.io")
+/// Query the registry for the latest published version of symposium
+/// by running `cargo search symposium --limit 1`.
+pub fn latest_version() -> Result<semver::Version> {
+    let output = Command::new("cargo")
+        .args(["search", CRATE_NAME, "--limit", "1"])
+        .output()
+        .context("failed to run cargo search")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("cargo search failed: {stderr}");
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // First line: `symposium = "0.3.0"    # AI the Rust Way`
+    let version_str = stdout
+        .lines()
+        .next()
+        .and_then(|line| line.strip_prefix(&format!("{CRATE_NAME} = \"")))
+        .and_then(|rest| rest.split('"').next())
+        .context("unexpected cargo search output")?;
+
+    semver::Version::parse(version_str).context("failed to parse version from cargo search")
 }
 
 /// Check whether a newer version is available.  Returns `Some(latest)`
 /// if an upgrade is available, `None` if we're current or ahead.
-pub async fn check_upgrade() -> Result<Option<semver::Version>> {
+pub fn check_upgrade() -> Result<Option<semver::Version>> {
     let current =
         semver::Version::parse(CURRENT_VERSION).context("failed to parse current version")?;
-    let latest = latest_version().await?;
+    let latest = latest_version()?;
     if latest > current {
         Ok(Some(latest))
     } else {
@@ -47,7 +59,7 @@ pub async fn check_upgrade() -> Result<Option<semver::Version>> {
 
 /// Run the self-update using the configured source strategy.
 pub async fn self_update(out: &Output, source: UpdateSource) -> Result<()> {
-    let target_version = match check_upgrade().await {
+    let target_version = match check_upgrade() {
         Ok(Some(latest)) => {
             out.info(format!("updating symposium {CURRENT_VERSION} → {latest}"));
             latest
@@ -131,10 +143,7 @@ async fn download_release(version: &semver::Version, install_dir: &std::path::Pa
         .context("failed to download release")?;
 
     if !response.status().is_success() {
-        bail!(
-            "download failed: HTTP {} from {url}",
-            response.status()
-        );
+        bail!("download failed: HTTP {} from {url}", response.status());
     }
 
     let bytes = response
@@ -227,8 +236,7 @@ fn install_binary(binary_bytes: &[u8], install_dir: &std::path::Path) -> Result<
             .context("failed to set executable permissions")?;
     }
 
-    tmp.persist(&dest)
-        .context("failed to replace binary")?;
+    tmp.persist(&dest).context("failed to replace binary")?;
 
     tracing::info!(path = %dest.display(), "installed updated binary");
     Ok(())

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -65,11 +65,33 @@ pub fn check_upgrade(sym: &Symposium) -> Result<Option<semver::Version>> {
     }
 }
 
-/// Periodic update check, called before command dispatch.
+/// Warn-only update check for the library path (`cli::run`).
 ///
-/// Respects `auto-update` config and the 24-hour throttle.  For `warn`,
-/// prints a nudge.  For `on`, downloads and installs the update, then
-/// returns `true` so the caller can re-exec into the new binary.
+/// Respects config and the 24-hour throttle.  Prints a nudge when
+/// `auto-update = "warn"` and a newer version exists.  Does nothing for
+/// `off` or `on` — the binary handles `on` (which needs re-exec).
+pub fn maybe_warn_for_update(sym: &Symposium, out: &Output) {
+    if sym.config.auto_update != AutoUpdate::Warn {
+        return;
+    }
+    if !state::should_check_for_update(sym.config_dir()) {
+        return;
+    }
+    state::record_update_check(sym.config_dir());
+
+    if let Ok(Some(latest)) = check_upgrade(sym) {
+        out.warn(format!(
+            "symposium {latest} is available (current: {CURRENT_VERSION}). \
+             Run `cargo agents self-update` to upgrade.",
+        ));
+    }
+}
+
+/// Full update check for the binary startup path.
+///
+/// Respects config and the 24-hour throttle.  For `warn`, prints a
+/// nudge.  For `on`, downloads and installs the update, then returns
+/// `true` so the caller can re-exec into the new binary.
 pub async fn maybe_check_for_update(sym: &Symposium, out: &Output) -> bool {
     if sym.config.auto_update == AutoUpdate::Off {
         return false;

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -22,7 +22,7 @@ const BINARY_NAME: &str = "cargo-agents";
 /// Query the registry for the latest published version of symposium
 /// by running `cargo search symposium --limit 1`.
 pub fn latest_version() -> Result<semver::Version> {
-    let output = Command::new("cargo")
+    let output = crate::cargo_command()
         .args(["search", CRATE_NAME, "--limit", "1"])
         .output()
         .context("failed to run cargo search")?;
@@ -33,8 +33,14 @@ pub fn latest_version() -> Result<semver::Version> {
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    // First line: `symposium = "0.3.0"    # AI the Rust Way`
-    let version_str = stdout
+    parse_cargo_search_output(&stdout)
+}
+
+/// Parse the version from `cargo search` output.
+///
+/// Expected format: `symposium = "0.3.0"    # AI the Rust Way`
+fn parse_cargo_search_output(output: &str) -> Result<semver::Version> {
+    let version_str = output
         .lines()
         .next()
         .and_then(|line| line.strip_prefix(&format!("{CRATE_NAME} = \"")))
@@ -247,7 +253,7 @@ fn install_binary(binary_bytes: &[u8], install_dir: &std::path::Path) -> Result<
 // ---------------------------------------------------------------------------
 
 fn cargo_install() -> Result<()> {
-    let status = Command::new("cargo")
+    let status = crate::cargo_command()
         .args(["install", CRATE_NAME, "--force"])
         .status()
         .context("failed to run cargo install")?;
@@ -294,5 +300,91 @@ pub fn re_exec() -> ! {
                 std::process::exit(1);
             });
         std::process::exit(status.code().unwrap_or(1));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_search_output_typical() {
+        let output = r#"symposium = "1.2.3"    # AI the Rust Way
+... and 105 crates more (use --limit N to see more)
+"#;
+        let v = parse_cargo_search_output(output).unwrap();
+        assert_eq!(v, semver::Version::new(1, 2, 3));
+    }
+
+    #[test]
+    fn parse_search_output_prerelease() {
+        let output = "symposium = \"0.4.0-beta.1\"    # AI the Rust Way\n";
+        let v = parse_cargo_search_output(output).unwrap();
+        assert_eq!(v.to_string(), "0.4.0-beta.1");
+    }
+
+    #[test]
+    fn parse_search_output_no_description() {
+        let output = "symposium = \"0.3.0\"\n";
+        let v = parse_cargo_search_output(output).unwrap();
+        assert_eq!(v, semver::Version::new(0, 3, 0));
+    }
+
+    #[test]
+    fn parse_search_output_wrong_crate() {
+        let output = "something-else = \"1.0.0\"    # Not symposium\n";
+        assert!(parse_cargo_search_output(output).is_err());
+    }
+
+    #[test]
+    fn parse_search_output_empty() {
+        assert!(parse_cargo_search_output("").is_err());
+    }
+
+    #[test]
+    fn extract_tarball_finds_binary() {
+        let tarball = build_test_tarball("cargo-agents", b"fake-binary-content");
+        let result = extract_tarball(&tarball).unwrap();
+        assert_eq!(result, b"fake-binary-content");
+    }
+
+    #[test]
+    fn extract_tarball_missing_binary() {
+        let tarball = build_test_tarball("wrong-name", b"data");
+        assert!(extract_tarball(&tarball).is_err());
+    }
+
+    #[test]
+    fn install_binary_creates_executable() {
+        let tmp = tempfile::tempdir().unwrap();
+        install_binary(b"#!/bin/sh\necho hello", tmp.path()).unwrap();
+
+        let installed = tmp.path().join(BINARY_NAME);
+        assert!(installed.exists());
+        assert_eq!(std::fs::read(&installed).unwrap(), b"#!/bin/sh\necho hello");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&installed).unwrap().permissions().mode();
+            assert!(mode & 0o111 != 0, "binary should be executable");
+        }
+    }
+
+    fn build_test_tarball(filename: &str, content: &[u8]) -> Vec<u8> {
+        use flate2::Compression;
+        use flate2::write::GzEncoder;
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+        {
+            let mut builder = tar::Builder::new(&mut encoder);
+            let mut header = tar::Header::new_gnu();
+            header.set_size(content.len() as u64);
+            header.set_mode(0o755);
+            header.set_cksum();
+            builder.append_data(&mut header, filename, content).unwrap();
+            builder.finish().unwrap();
+        }
+        encoder.finish().unwrap()
     }
 }

--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -10,8 +10,9 @@ use std::process::Command;
 
 use anyhow::{Context, Result, bail};
 
-use crate::config::{Symposium, UpdateSource};
+use crate::config::{AutoUpdate, Symposium, UpdateSource};
 use crate::output::Output;
+use crate::state;
 use crate::state::CURRENT_VERSION;
 
 const CRATE_NAME: &str = "symposium";
@@ -61,6 +62,49 @@ pub fn check_upgrade(sym: &Symposium) -> Result<Option<semver::Version>> {
         Ok(Some(latest))
     } else {
         Ok(None)
+    }
+}
+
+/// Periodic update check, called before command dispatch.
+///
+/// Respects `auto-update` config and the 24-hour throttle.  For `warn`,
+/// prints a nudge.  For `on`, downloads and installs the update, then
+/// returns `true` so the caller can re-exec into the new binary.
+pub async fn maybe_check_for_update(sym: &Symposium, out: &Output) -> bool {
+    if sym.config.auto_update == AutoUpdate::Off {
+        return false;
+    }
+    if !state::should_check_for_update(sym.config_dir()) {
+        return false;
+    }
+    state::record_update_check(sym.config_dir());
+
+    let latest = match check_upgrade(sym) {
+        Ok(Some(v)) => v,
+        _ => return false,
+    };
+
+    match sym.config.auto_update {
+        AutoUpdate::Warn => {
+            out.warn(format!(
+                "symposium {latest} is available (current: {CURRENT_VERSION}). \
+                 Run `cargo agents self-update` to upgrade.",
+            ));
+            false
+        }
+        AutoUpdate::On => {
+            out.info(format!(
+                "auto-updating symposium {CURRENT_VERSION} → {latest}..."
+            ));
+            match self_update(sym, &Output::quiet()).await {
+                Ok(()) => true,
+                Err(e) => {
+                    out.warn(format!("auto-update failed: {e}"));
+                    false
+                }
+            }
+        }
+        AutoUpdate::Off => unreachable!(),
     }
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,184 @@
+//! Persistent state: `state.toml` in the config directory.
+//!
+//! Tracks the version of the binary that last touched the config/cache
+//! directories and the last time an update check was performed.
+//! Future versions can use a version mismatch to trigger migrations.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+const STATE_FILE: &str = "state.toml";
+const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Runtime version of this binary, baked in at compile time.
+pub const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct State {
+    /// Semver of the binary that last wrote this file.
+    pub version: String,
+
+    /// Last time we checked crates.io for a newer version.
+    #[serde(default, rename = "last-update-check")]
+    pub last_update_check: Option<DateTime<Utc>>,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            version: CURRENT_VERSION.to_string(),
+            last_update_check: None,
+        }
+    }
+}
+
+/// Load `state.toml` from `config_dir`, returning `None` if absent or unparseable.
+pub fn load(config_dir: &Path) -> Option<State> {
+    let path = state_path(config_dir);
+    let contents = fs::read_to_string(path).ok()?;
+    toml::from_str(&contents).ok()
+}
+
+fn save(config_dir: &Path, state: &State) {
+    if let Ok(contents) = toml::to_string_pretty(state) {
+        let _ = fs::write(state_path(config_dir), contents);
+    }
+}
+
+/// Write `state.toml` into `config_dir` with the current binary version,
+/// preserving other fields.
+pub fn stamp(config_dir: &Path) {
+    let mut state = load(config_dir).unwrap_or_default();
+    state.version = CURRENT_VERSION.to_string();
+    save(config_dir, &state);
+}
+
+/// Ensure `state.toml` exists and reflects the running binary version.
+///
+/// Returns the previously recorded version (if any) so callers can
+/// decide whether a migration is needed.
+pub fn ensure_current(config_dir: &Path) -> Option<String> {
+    let prev = load(config_dir);
+    let prev_version = prev.as_ref().map(|s| s.version.clone());
+
+    let needs_write = match &prev {
+        None => true,
+        Some(s) => s.version != CURRENT_VERSION,
+    };
+
+    if needs_write {
+        stamp(config_dir);
+    }
+
+    prev_version
+}
+
+/// Whether enough time has elapsed since the last update check.
+pub fn should_check_for_update(config_dir: &Path) -> bool {
+    let Some(state) = load(config_dir) else {
+        return true;
+    };
+    let Some(last_check) = state.last_update_check else {
+        return true;
+    };
+    let elapsed = Utc::now().signed_duration_since(last_check);
+    elapsed.to_std().unwrap_or(Duration::ZERO) >= UPDATE_CHECK_INTERVAL
+}
+
+/// Record that an update check just happened.
+pub fn record_update_check(config_dir: &Path) {
+    let mut state = load(config_dir).unwrap_or_default();
+    state.last_update_check = Some(Utc::now());
+    save(config_dir, &state);
+}
+
+fn state_path(config_dir: &Path) -> PathBuf {
+    config_dir.join(STATE_FILE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stamp_creates_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(load(tmp.path()).is_none());
+        stamp(tmp.path());
+        let state = load(tmp.path()).expect("should exist after stamp");
+        assert_eq!(state.version, CURRENT_VERSION);
+    }
+
+    #[test]
+    fn ensure_current_returns_none_on_first_run() {
+        let tmp = tempfile::tempdir().unwrap();
+        let prev = ensure_current(tmp.path());
+        assert!(prev.is_none());
+        let state = load(tmp.path()).expect("should be written");
+        assert_eq!(state.version, CURRENT_VERSION);
+    }
+
+    #[test]
+    fn ensure_current_returns_previous_version() {
+        let tmp = tempfile::tempdir().unwrap();
+        let old = State {
+            version: "0.1.0".to_string(),
+            last_update_check: None,
+        };
+        fs::write(
+            tmp.path().join(STATE_FILE),
+            toml::to_string_pretty(&old).unwrap(),
+        )
+        .unwrap();
+
+        let prev = ensure_current(tmp.path());
+        assert_eq!(prev.as_deref(), Some("0.1.0"));
+        let state = load(tmp.path()).expect("should be updated");
+        assert_eq!(state.version, CURRENT_VERSION);
+    }
+
+    #[test]
+    fn should_check_when_no_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(should_check_for_update(tmp.path()));
+    }
+
+    #[test]
+    fn should_check_when_never_checked() {
+        let tmp = tempfile::tempdir().unwrap();
+        stamp(tmp.path());
+        assert!(should_check_for_update(tmp.path()));
+    }
+
+    #[test]
+    fn should_not_check_when_recently_checked() {
+        let tmp = tempfile::tempdir().unwrap();
+        record_update_check(tmp.path());
+        assert!(!should_check_for_update(tmp.path()));
+    }
+
+    #[test]
+    fn should_check_when_interval_elapsed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = State::default();
+        state.last_update_check = Some(Utc::now() - chrono::Duration::hours(25));
+        save(tmp.path(), &state);
+        assert!(should_check_for_update(tmp.path()));
+    }
+
+    #[test]
+    fn stamp_preserves_last_update_check() {
+        let tmp = tempfile::tempdir().unwrap();
+        record_update_check(tmp.path());
+        let before = load(tmp.path()).unwrap().last_update_check;
+        assert!(before.is_some());
+
+        stamp(tmp.path());
+        let after = load(tmp.path()).unwrap().last_update_check;
+        assert_eq!(before, after);
+    }
+}

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -169,7 +169,7 @@ fn propagate_user_skill(
 /// Run the full sync: discover applicable skills, install into agent dirs,
 /// clean up stale installations.
 pub async fn sync(sym: &Symposium, cwd: &Path, out: &Output) -> Result<()> {
-    let project_root = crate::init::find_workspace_root(cwd)?;
+    let project_root = crate::init::find_workspace_root(sym, cwd)?;
     tracing::debug!(root = %project_root.display(), "resolved workspace root");
 
     // Load plugin registry and workspace deps

--- a/symposium-testlib/src/lib.rs
+++ b/symposium-testlib/src/lib.rs
@@ -227,15 +227,14 @@ impl Drop for TestContext {
 }
 
 impl TestContext {
-    /// Run a `symposium` CLI command in-process, returning captured output
-    /// with temp-dir paths normalized.
+    /// Run a `symposium` CLI command in-process, returning captured output.
     pub async fn symposium(&mut self, args: &[&str]) -> anyhow::Result<String> {
-        let mut full_args = vec!["cargo-agents", "-q"];
+        let mut full_args = vec!["cargo-agents"];
         full_args.extend_from_slice(args);
 
         let cli = Cli::try_parse_from(&full_args).map_err(|e| anyhow::anyhow!("{e}"))?;
 
-        let out = symposium::output::Output::quiet();
+        let out = symposium::output::Output::capturing();
         let cwd = self
             .workspace_root
             .clone()
@@ -245,7 +244,7 @@ impl TestContext {
             symposium::cli::run(&mut self.sym, cmd, &cwd, &out).await?;
         }
 
-        Ok(String::new())
+        Ok(out.captured().join("\n"))
     }
 
     /// Run the full hook pipeline: parse → builtin → plugins → serialize.

--- a/symposium-testlib/src/lib.rs
+++ b/symposium-testlib/src/lib.rs
@@ -431,6 +431,22 @@ impl TestContext {
         Ok(SubmitResult { hooks, response })
     }
 
+    /// Point `cargo` invocations at a mock script for the duration of this test.
+    ///
+    /// Writes the given shell script into the tempdir and configures `Symposium`
+    /// to use it instead of the real `cargo`.  No environment variables are
+    /// mutated, so tests can run in parallel without interference.
+    pub fn set_mock_cargo(&mut self, script: &str) {
+        let script_path = self.tempdir.join("mock-cargo");
+        std::fs::write(&script_path, script).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        self.sym.set_cargo_override(script_path);
+    }
+
     /// Replace temp directory paths with a stable placeholder for snapshot tests.
     pub fn normalize_paths(&self, output: &str) -> String {
         let config_dir = self.sym.config_dir().to_string_lossy().to_string();

--- a/tests/init_sync.rs
+++ b/tests/init_sync.rs
@@ -1489,15 +1489,21 @@ async fn self_update_skips_check_when_disabled() {
     .unwrap();
 }
 
-/// End-to-end auto-update test: run the real binary as a subprocess with
-/// `auto-update = "on"` and `self-update-source = "source"`.  The mock
-/// cargo's `install` handler replaces the binary with a script that prints
-/// "SURPRISE!", so after the auto-update + re-exec we should see that
-/// message in the output.
-#[tokio::test]
-async fn auto_update_on_re_execs_into_new_binary() {
+/// Set up a temp dir with auto-update = "on", a mock cargo that replaces
+/// the binary with a "SURPRISE!" script on install, and return the paths
+/// needed to run the binary as a subprocess.
+struct AutoUpdateFixture {
+    _tmp: tempfile::TempDir,
+    root: PathBuf,
+    binary: PathBuf,
+    config_dir: PathBuf,
+    mock_cargo: PathBuf,
+    bin_dir: PathBuf,
+}
+
+fn setup_auto_update_fixture() -> AutoUpdateFixture {
     let tmp = tempfile::tempdir().unwrap();
-    let root = tmp.path();
+    let root = tmp.path().to_path_buf();
 
     let config_dir = root.join("dot-symposium");
     std::fs::create_dir_all(&config_dir).unwrap();
@@ -1530,8 +1536,8 @@ async fn auto_update_on_re_execs_into_new_binary() {
     let bin_dir = root.join("bin");
     std::fs::create_dir_all(&bin_dir).unwrap();
     let real_binary = std::env::var("CARGO_BIN_EXE_cargo-agents").expect("must run via cargo test");
-    let binary_copy = bin_dir.join("cargo-agents");
-    std::fs::copy(&real_binary, &binary_copy).unwrap();
+    let binary = bin_dir.join("cargo-agents");
+    std::fs::copy(&real_binary, &binary).unwrap();
 
     let mock_cargo = root.join("mock-cargo");
     std::fs::write(
@@ -1559,7 +1565,7 @@ SCRIPT
         ;;
 esac
 "#,
-            bin = binary_copy.display(),
+            bin = binary.display(),
         ),
     )
     .unwrap();
@@ -1569,23 +1575,69 @@ esac
         std::fs::set_permissions(&mock_cargo, std::fs::Permissions::from_mode(0o755)).unwrap();
     }
 
-    let output = std::process::Command::new(&binary_copy)
-        .args(["sync"])
-        .current_dir(root)
-        .env("SYMPOSIUM_HOME", &config_dir)
-        .env("SYMPOSIUM_CARGO", &mock_cargo)
-        .env("CARGO_HOME", &bin_dir)
-        .output()
-        .expect("failed to spawn binary");
+    AutoUpdateFixture {
+        _tmp: tmp,
+        root,
+        binary,
+        config_dir,
+        mock_cargo,
+        bin_dir,
+    }
+}
 
+impl AutoUpdateFixture {
+    fn command(&self) -> std::process::Command {
+        let mut cmd = std::process::Command::new(&self.binary);
+        cmd.current_dir(&self.root)
+            .env("SYMPOSIUM_HOME", &self.config_dir)
+            .env("SYMPOSIUM_CARGO", &self.mock_cargo)
+            .env("CARGO_HOME", &self.bin_dir);
+        cmd
+    }
+}
+
+fn assert_surprise(output: &std::process::Output) {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     let combined = format!("{stdout}{stderr}");
-
     assert!(
         combined.contains("SURPRISE!"),
         "after auto-update + re-exec, the new binary should have run.\n\
          stdout: {stdout}\nstderr: {stderr}\nexit: {:?}",
         output.status,
     );
+}
+
+#[tokio::test]
+async fn auto_update_re_execs_on_sync() {
+    let fix = setup_auto_update_fixture();
+    let output = fix
+        .command()
+        .args(["sync"])
+        .output()
+        .expect("failed to spawn");
+    assert_surprise(&output);
+}
+
+#[tokio::test]
+async fn auto_update_re_execs_on_hook() {
+    let fix = setup_auto_update_fixture();
+    let output = fix
+        .command()
+        .args(["hook", "claude", "session-start"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(ref mut stdin) = child.stdin {
+                let _ = stdin.write_all(
+                    br#"{"hook_event_name":"SessionStart","session_id":"test","cwd":"/"}"#,
+                );
+            }
+            child.wait_with_output()
+        })
+        .expect("failed to spawn");
+    assert_surprise(&output);
 }

--- a/tests/init_sync.rs
+++ b/tests/init_sync.rs
@@ -2,6 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
+use symposium::state;
 use symposium_testlib::{TestMode, with_fixture};
 
 /// Read the user config file from the test context.
@@ -1288,6 +1289,90 @@ async fn agents_syncing_does_not_overwrite_user_managed_target() {
                 !target_dir.join(".symposium").exists(),
                 "no marker should be dropped onto a user-managed directory"
             );
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Self-update integration tests
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Self-update / state integration tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn self_update_command_exists() {
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["plugins0", "workspace0"],
+        async |mut ctx| {
+            // Verify self-update is a recognized CLI command by parsing it.
+            // We don't actually run the update (that would hit the network),
+            // but this confirms the command is wired through dispatch.
+            let result = ctx.symposium(&["self-update"]).await;
+            // Will fail with network error or "up to date" — both are OK,
+            // we just care it didn't fail with "unknown command".
+            match result {
+                Ok(_) => {}
+                Err(e) => {
+                    let msg = format!("{e:#}");
+                    assert!(
+                        !msg.contains("not supported") && !msg.contains("unrecognized"),
+                        "self-update should be a valid command, got: {msg}"
+                    );
+                }
+            }
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn state_toml_tracks_version() {
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["plugins0", "workspace0"],
+        async |ctx| {
+            assert!(state::load(ctx.sym.config_dir()).is_none());
+
+            state::ensure_current(ctx.sym.config_dir());
+
+            let s = state::load(ctx.sym.config_dir()).expect("state.toml should exist");
+            assert_eq!(s.version, state::CURRENT_VERSION);
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn state_toml_update_check_throttling() {
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["plugins0", "workspace0"],
+        async |ctx| {
+            let dir = ctx.sym.config_dir();
+
+            // First check: should be allowed (no state yet).
+            assert!(state::should_check_for_update(dir));
+
+            // Record a check.
+            state::record_update_check(dir);
+
+            // Immediately after: should be throttled.
+            assert!(!state::should_check_for_update(dir));
+
+            // Stamp version — should preserve the last-update-check.
+            state::stamp(dir);
+            assert!(!state::should_check_for_update(dir));
+
             Ok(())
         },
     )

--- a/tests/init_sync.rs
+++ b/tests/init_sync.rs
@@ -1641,3 +1641,46 @@ async fn auto_update_re_execs_on_hook() {
         .expect("failed to spawn");
     assert_surprise(&output);
 }
+
+#[tokio::test]
+async fn session_start_hook_warns_about_update_in_context() {
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["plugins0", "workspace0"],
+        async |mut ctx| {
+            ctx.set_mock_cargo(&mock_cargo_script("99.0.0"));
+            ctx.sym.config.auto_update = symposium::config::AutoUpdate::Warn;
+
+            ctx.symposium(&["init", "--add-agent", "claude"]).await?;
+
+            // Clear the throttle so the hook's session-start check fires.
+            let dir = ctx.sym.config_dir().to_path_buf();
+            let mut state = symposium::state::load(&dir).unwrap_or_default();
+            state.last_update_check = None;
+            let contents = toml::to_string_pretty(&state).unwrap();
+            std::fs::write(dir.join("state.toml"), contents).unwrap();
+
+            let result = ctx
+                .prompt_or_hook(
+                    "hello",
+                    &[symposium_testlib::HookStep::session_start()],
+                    symposium::hook_schema::HookAgent::Claude,
+                )
+                .await?;
+
+            assert!(
+                result.has_context_containing("99.0.0 is available"),
+                "session-start should include update nudge in additionalContext: {:#?}",
+                result.hooks,
+            );
+            assert!(
+                result.has_context_containing("cargo agents self-update"),
+                "nudge should mention self-update command: {:#?}",
+                result.hooks,
+            );
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+}

--- a/tests/init_sync.rs
+++ b/tests/init_sync.rs
@@ -1358,12 +1358,12 @@ async fn state_toml_tracks_version() {
         TestMode::SimulationOnly,
         &["plugins0", "workspace0"],
         async |ctx| {
-            let dir = ctx.sym.config_dir();
-            assert!(symposium::state::load(dir).is_none());
+            let dir = ctx.sym.config_dir().to_path_buf();
+            assert!(symposium::state::load(&dir).is_none());
 
-            symposium::state::ensure_current(dir);
+            symposium::state::ensure_current(&dir);
 
-            let s = symposium::state::load(dir).expect("state.toml should exist");
+            let s = symposium::state::load(&dir).expect("state.toml should exist");
             assert_eq!(s.version, symposium::state::CURRENT_VERSION);
             Ok(())
         },
@@ -1378,15 +1378,98 @@ async fn state_toml_update_check_throttling() {
         TestMode::SimulationOnly,
         &["plugins0", "workspace0"],
         async |ctx| {
-            let dir = ctx.sym.config_dir();
+            let dir = ctx.sym.config_dir().to_path_buf();
 
-            assert!(symposium::state::should_check_for_update(dir));
-            symposium::state::record_update_check(dir);
-            assert!(!symposium::state::should_check_for_update(dir));
+            assert!(symposium::state::should_check_for_update(&dir));
+            symposium::state::record_update_check(&dir);
+            assert!(!symposium::state::should_check_for_update(&dir));
 
-            symposium::state::stamp(dir);
-            assert!(!symposium::state::should_check_for_update(dir));
+            symposium::state::stamp(&dir);
+            assert!(!symposium::state::should_check_for_update(&dir));
 
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn sync_triggers_update_check() {
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["plugins0", "workspace0"],
+        async |mut ctx| {
+            ctx.set_mock_cargo(&mock_cargo_script("99.0.0"));
+            ctx.sym.config.auto_update = symposium::config::AutoUpdate::Warn;
+
+            let dir = ctx.sym.config_dir().to_path_buf();
+            assert!(symposium::state::load(&dir).is_none());
+
+            ctx.symposium(&["init", "--add-agent", "claude"]).await?;
+            ctx.symposium(&["sync"]).await?;
+
+            let s = symposium::state::load(&dir).expect("state.toml should exist after sync");
+            assert!(
+                s.last_update_check.is_some(),
+                "sync should have triggered an update check"
+            );
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn sync_skips_update_check_when_throttled() {
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["plugins0", "workspace0"],
+        async |mut ctx| {
+            ctx.set_mock_cargo(&mock_cargo_script("99.0.0"));
+            ctx.sym.config.auto_update = symposium::config::AutoUpdate::Warn;
+
+            let dir = ctx.sym.config_dir().to_path_buf();
+
+            // Record a recent check so the throttle kicks in.
+            symposium::state::record_update_check(&dir);
+            let before = symposium::state::load(&dir).unwrap().last_update_check;
+
+            ctx.symposium(&["init", "--add-agent", "claude"]).await?;
+            ctx.symposium(&["sync"]).await?;
+
+            let after = symposium::state::load(&dir).unwrap().last_update_check;
+            assert_eq!(
+                before, after,
+                "update check should not have re-run within the throttle window"
+            );
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn self_update_skips_check_when_disabled() {
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["plugins0", "workspace0"],
+        async |mut ctx| {
+            ctx.set_mock_cargo(&mock_cargo_script("99.0.0"));
+            ctx.sym.config.auto_update = symposium::config::AutoUpdate::Off;
+
+            let dir = ctx.sym.config_dir().to_path_buf();
+            ctx.symposium(&["init", "--add-agent", "claude"]).await?;
+            ctx.symposium(&["sync"]).await?;
+
+            let s = symposium::state::load(&dir);
+            let checked = s.as_ref().and_then(|s| s.last_update_check.as_ref());
+            assert!(
+                checked.is_none(),
+                "auto-update = off should not trigger any update check"
+            );
             Ok(())
         },
     )

--- a/tests/init_sync.rs
+++ b/tests/init_sync.rs
@@ -2,7 +2,6 @@
 
 use std::path::{Path, PathBuf};
 
-use symposium::state;
 use symposium_testlib::{TestMode, with_fixture};
 
 /// Read the user config file from the test context.
@@ -1297,35 +1296,55 @@ async fn agents_syncing_does_not_overwrite_user_managed_target() {
 }
 
 // ---------------------------------------------------------------------------
-// Self-update integration tests
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
 // Self-update / state integration tests
 // ---------------------------------------------------------------------------
 
+fn mock_cargo_script(search_version: &str) -> String {
+    format!(
+        r#"#!/bin/sh
+case "$1" in
+    search)
+        echo 'symposium = "{search_version}"    # AI the Rust Way'
+        exit 0
+        ;;
+    metadata)
+        exec cargo "$@"
+        ;;
+    install)
+        exit 0
+        ;;
+    *)
+        exec cargo "$@"
+        ;;
+esac
+"#
+    )
+}
+
 #[tokio::test]
-async fn self_update_command_exists() {
+async fn self_update_reports_up_to_date() {
     with_fixture(
         TestMode::SimulationOnly,
         &["plugins0", "workspace0"],
         async |mut ctx| {
-            // Verify self-update is a recognized CLI command by parsing it.
-            // We don't actually run the update (that would hit the network),
-            // but this confirms the command is wired through dispatch.
-            let result = ctx.symposium(&["self-update"]).await;
-            // Will fail with network error or "up to date" — both are OK,
-            // we just care it didn't fail with "unknown command".
-            match result {
-                Ok(_) => {}
-                Err(e) => {
-                    let msg = format!("{e:#}");
-                    assert!(
-                        !msg.contains("not supported") && !msg.contains("unrecognized"),
-                        "self-update should be a valid command, got: {msg}"
-                    );
-                }
-            }
+            ctx.set_mock_cargo(&mock_cargo_script(symposium::state::CURRENT_VERSION));
+            ctx.symposium(&["self-update"]).await?;
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn self_update_detects_newer_version() {
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["plugins0", "workspace0"],
+        async |mut ctx| {
+            ctx.set_mock_cargo(&mock_cargo_script("99.0.0"));
+            ctx.sym.config.update_source = symposium::config::UpdateSource::Source;
+            ctx.symposium(&["self-update"]).await?;
             Ok(())
         },
     )
@@ -1339,12 +1358,13 @@ async fn state_toml_tracks_version() {
         TestMode::SimulationOnly,
         &["plugins0", "workspace0"],
         async |ctx| {
-            assert!(state::load(ctx.sym.config_dir()).is_none());
+            let dir = ctx.sym.config_dir();
+            assert!(symposium::state::load(dir).is_none());
 
-            state::ensure_current(ctx.sym.config_dir());
+            symposium::state::ensure_current(dir);
 
-            let s = state::load(ctx.sym.config_dir()).expect("state.toml should exist");
-            assert_eq!(s.version, state::CURRENT_VERSION);
+            let s = symposium::state::load(dir).expect("state.toml should exist");
+            assert_eq!(s.version, symposium::state::CURRENT_VERSION);
             Ok(())
         },
     )
@@ -1360,18 +1380,12 @@ async fn state_toml_update_check_throttling() {
         async |ctx| {
             let dir = ctx.sym.config_dir();
 
-            // First check: should be allowed (no state yet).
-            assert!(state::should_check_for_update(dir));
+            assert!(symposium::state::should_check_for_update(dir));
+            symposium::state::record_update_check(dir);
+            assert!(!symposium::state::should_check_for_update(dir));
 
-            // Record a check.
-            state::record_update_check(dir);
-
-            // Immediately after: should be throttled.
-            assert!(!state::should_check_for_update(dir));
-
-            // Stamp version — should preserve the last-update-check.
-            state::stamp(dir);
-            assert!(!state::should_check_for_update(dir));
+            symposium::state::stamp(dir);
+            assert!(!symposium::state::should_check_for_update(dir));
 
             Ok(())
         },

--- a/tests/init_sync.rs
+++ b/tests/init_sync.rs
@@ -1488,3 +1488,104 @@ async fn self_update_skips_check_when_disabled() {
     .await
     .unwrap();
 }
+
+/// End-to-end auto-update test: run the real binary as a subprocess with
+/// `auto-update = "on"` and `self-update-source = "source"`.  The mock
+/// cargo's `install` handler replaces the binary with a script that prints
+/// "SURPRISE!", so after the auto-update + re-exec we should see that
+/// message in the output.
+#[tokio::test]
+async fn auto_update_on_re_execs_into_new_binary() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+
+    let config_dir = root.join("dot-symposium");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(
+        config_dir.join("config.toml"),
+        indoc::indoc! {r#"
+            auto-update = "on"
+            self-update-source = "source"
+            hook-scope = "project"
+
+            [[agent]]
+            name = "claude"
+        "#},
+    )
+    .unwrap();
+
+    std::fs::write(
+        root.join("Cargo.toml"),
+        indoc::indoc! {r#"
+            [package]
+            name = "test-workspace"
+            version = "0.1.0"
+            edition = "2021"
+        "#},
+    )
+    .unwrap();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    std::fs::write(root.join("src/lib.rs"), "").unwrap();
+
+    let bin_dir = root.join("bin");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+    let real_binary = std::env::var("CARGO_BIN_EXE_cargo-agents").expect("must run via cargo test");
+    let binary_copy = bin_dir.join("cargo-agents");
+    std::fs::copy(&real_binary, &binary_copy).unwrap();
+
+    let mock_cargo = root.join("mock-cargo");
+    std::fs::write(
+        &mock_cargo,
+        format!(
+            r#"#!/bin/sh
+case "$1" in
+    search)
+        echo 'symposium = "99.0.0"    # AI the Rust Way'
+        exit 0
+        ;;
+    install)
+        cat > '{bin}' <<'SCRIPT'
+#!/bin/sh
+echo "SURPRISE!"
+SCRIPT
+        chmod +x '{bin}'
+        exit 0
+        ;;
+    metadata)
+        exec cargo "$@"
+        ;;
+    *)
+        exec cargo "$@"
+        ;;
+esac
+"#,
+            bin = binary_copy.display(),
+        ),
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&mock_cargo, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    let output = std::process::Command::new(&binary_copy)
+        .args(["sync"])
+        .current_dir(root)
+        .env("SYMPOSIUM_HOME", &config_dir)
+        .env("SYMPOSIUM_CARGO", &mock_cargo)
+        .env("CARGO_HOME", &bin_dir)
+        .output()
+        .expect("failed to spawn binary");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+
+    assert!(
+        combined.contains("SURPRISE!"),
+        "after auto-update + re-exec, the new binary should have run.\n\
+         stdout: {stdout}\nstderr: {stderr}\nexit: {:?}",
+        output.status,
+    );
+}

--- a/tests/init_sync.rs
+++ b/tests/init_sync.rs
@@ -1550,11 +1550,15 @@ case "$1" in
         exit 0
         ;;
     install)
-        cat > '{bin}' <<'SCRIPT'
+        # Write to a temp file then atomic-rename to avoid "Text file busy"
+        # on Linux (can't overwrite a running executable, but rename works).
+        tmp='{bin}.new'
+        cat > "$tmp" <<'SCRIPT'
 #!/bin/sh
 echo "SURPRISE!"
 SCRIPT
-        chmod +x '{bin}'
+        chmod +x "$tmp"
+        mv -f "$tmp" '{bin}'
         exit 0
         ;;
     metadata)

--- a/tests/init_sync.rs
+++ b/tests/init_sync.rs
@@ -1409,20 +1409,18 @@ async fn sync_triggers_update_check() {
             // init is the first command through cli::run(), so it triggers
             // the update check (and consumes the 24h window).
             let output = ctx.symposium(&["init", "--add-agent", "claude"]).await?;
+            let output = ctx.normalize_paths(&output);
 
             let s = symposium::state::load(&dir).expect("state.toml should exist");
             assert!(
                 s.last_update_check.is_some(),
                 "init should have triggered an update check"
             );
-            assert!(
-                output.contains("99.0.0 is available"),
-                "should warn about the newer version, got: {output}"
-            );
-            assert!(
-                output.contains("cargo agents self-update"),
-                "warning should mention the self-update command, got: {output}"
-            );
+            expect_test::expect![[r#"
+                ⚠️  symposium 99.0.0 is available (current: 0.3.0). Run `cargo agents self-update` to upgrade.
+                Setting up symposium for your user account.
+
+                ✅ $CONFIG_DIR/config.toml: wrote user config (agents: Claude Code)"#]].assert_eq(&output);
             Ok(())
         },
     )
@@ -1470,8 +1468,8 @@ async fn self_update_skips_check_when_disabled() {
             ctx.sym.config.auto_update = symposium::config::AutoUpdate::Off;
 
             let dir = ctx.sym.config_dir().to_path_buf();
-            ctx.symposium(&["init", "--add-agent", "claude"]).await?;
-            ctx.symposium(&["sync"]).await?;
+            let output = ctx.symposium(&["init", "--add-agent", "claude"]).await?;
+            let output = ctx.normalize_paths(&output);
 
             let s = symposium::state::load(&dir);
             let checked = s.as_ref().and_then(|s| s.last_update_check.as_ref());
@@ -1479,6 +1477,11 @@ async fn self_update_skips_check_when_disabled() {
                 checked.is_none(),
                 "auto-update = off should not trigger any update check"
             );
+            expect_test::expect![[r#"
+                Setting up symposium for your user account.
+
+                ✅ $CONFIG_DIR/config.toml: wrote user config (agents: Claude Code)"#]]
+            .assert_eq(&output);
             Ok(())
         },
     )

--- a/tests/init_sync.rs
+++ b/tests/init_sync.rs
@@ -1406,13 +1406,22 @@ async fn sync_triggers_update_check() {
             let dir = ctx.sym.config_dir().to_path_buf();
             assert!(symposium::state::load(&dir).is_none());
 
-            ctx.symposium(&["init", "--add-agent", "claude"]).await?;
-            ctx.symposium(&["sync"]).await?;
+            // init is the first command through cli::run(), so it triggers
+            // the update check (and consumes the 24h window).
+            let output = ctx.symposium(&["init", "--add-agent", "claude"]).await?;
 
-            let s = symposium::state::load(&dir).expect("state.toml should exist after sync");
+            let s = symposium::state::load(&dir).expect("state.toml should exist");
             assert!(
                 s.last_update_check.is_some(),
-                "sync should have triggered an update check"
+                "init should have triggered an update check"
+            );
+            assert!(
+                output.contains("99.0.0 is available"),
+                "should warn about the newer version, got: {output}"
+            );
+            assert!(
+                output.contains("cargo agents self-update"),
+                "warning should mention the self-update command, got: {output}"
             );
             Ok(())
         },

--- a/tests/init_sync.rs
+++ b/tests/init_sync.rs
@@ -1343,7 +1343,6 @@ async fn self_update_detects_newer_version() {
         &["plugins0", "workspace0"],
         async |mut ctx| {
             ctx.set_mock_cargo(&mock_cargo_script("99.0.0"));
-            ctx.sym.config.update_source = symposium::config::UpdateSource::Source;
             ctx.symposium(&["self-update"]).await?;
             Ok(())
         },
@@ -1511,7 +1510,6 @@ fn setup_auto_update_fixture() -> AutoUpdateFixture {
         config_dir.join("config.toml"),
         indoc::indoc! {r#"
             auto-update = "on"
-            self-update-source = "source"
             hook-scope = "project"
 
             [[agent]]


### PR DESCRIPTION
## What does this PR do?

Add `cargo agents self-update` which downloads prebuilt binaries from GitHub releases (falling back to `cargo install`), and startup auto-update checks gated by a new `auto-update` config (off/warn/on, default warn). Introduce `state.toml` to track the binary version and throttle update checks to once per 24 hours.

New config keys:
- `auto-update`: off | warn | on (default warn)
- `self-update-source`: binary | source (default binary)

<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

<!-- Symposium is an AI project. We encourage the use of agentic tooling! We do however require disclosure. The disclosure helps us to calibrate our reviews. See our [PR disclosure policy](https://symposium-dev.github.io/symposium/design/governance.html#pr-disclosure-policy). -->

* The AI tool authored large parts of the code

**Questions for reviewers.**

<!-- Any specific areas of uncertainty or things you'd like reviewers to look at? -->

</details>
