### PR TITLE
fix: normalize CURRENT_VERSION in test snapshots for release compatibility

### DIFF
--- a/symposium-testlib/src/lib.rs
+++ b/symposium-testlib/src/lib.rs
@@ -446,10 +446,12 @@ impl TestContext {
         self.sym.set_cargo_override(script_path);
     }
 
-    /// Replace temp directory paths with a stable placeholder for snapshot tests.
+    /// Replace variable content with stable placeholders for snapshot tests.
     pub fn normalize_paths(&self, output: &str) -> String {
         let config_dir = self.sym.config_dir().to_string_lossy().to_string();
-        output.replace(&config_dir, "$CONFIG_DIR")
+        output
+            .replace(&config_dir, "$CONFIG_DIR")
+            .replace(symposium::state::CURRENT_VERSION, "$VERSION")
     }
 }
 

--- a/tests/init_sync.rs
+++ b/tests/init_sync.rs
@@ -1416,7 +1416,7 @@ async fn sync_triggers_update_check() {
                 "init should have triggered an update check"
             );
             expect_test::expect![[r#"
-                ⚠️  symposium 99.0.0 is available (current: 0.3.0). Run `cargo agents self-update` to upgrade.
+                ⚠️  symposium 99.0.0 is available (current: $VERSION). Run `cargo agents self-update` to upgrade.
                 Setting up symposium for your user account.
 
                 ✅ $CONFIG_DIR/config.toml: wrote user config (agents: Claude Code)"#]].assert_eq(&output);


### PR DESCRIPTION
## What does this PR do?

fix: normalize CURRENT_VERSION in test snapshots for release compatibility

The expect_test snapshots hardcoded "0.3.0" which breaks when release-plz bumps the version. normalize_paths() now also replaces CURRENT_VERSION with "$VERSION" so snapshots survive version bumps.
