### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,108 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/symposium-dev/symposium/compare/symposium-v0.4.0...symposium-v0.5.0) - 2026-09-05
+
+### Added
+
+- *(hook)* suggest `cargo agents --help` at session start
+- *(help)* audience-grouped --help listing plugin-vended subcommands.
+- *(plugins)* add subcommand manifest schema
+- move skill layout to [package.metadata.symposium] in crate Cargo.toml
+
+### Fixed
+
+- add `self-update` to reserved subcommand names and fix typo
+- make crate_metadata module pub(crate)
+- address review nits on source.crate
+
+### Other
+
+- Merge pull request #212 from swjng/feat/parse-copilot-tool-args
+- Merge pull request #274 from Fluzko/mcp-registration-paths
+- Merge pull request #267 from gmemuriuki/feat/windows-ci
+- RFD updates
+- *(rfd)* describe the PM interface and cargo PM as they are meant to work
+- Add user-managed plugins sub-RFD
+- Add PM interface, cargo PM, and discovery & sync sub-RFDs
+- Add plugin model sub-RFD
+- *(reference)* document use/search/status, enablement, and PM sources
+- *(design)* update module-structure, flows, and the RFD for the PM layer
+- Add the enablement commands: use, search, status
+- Introduce the package-manager layer and reshape plugin/skill resolution
+- Merge branch 'main' into symposium-mcp-design
+- Merge pull request #262 from kurasaiteja/rfd-predicate-caching
+- predicate caching RFD v4
+- predicate caching RFD v3
+- predicate caching RFD v2
+- predicate caching
+- Merge pull request #253 from nikomatsakis/register-centric-plugins-rfd
+- Merge pull request #254 from nikomatsakis/config-normalization
+- Merge pull request #247 from abusch/push-yzlulwltuttq
+- Add link in summary
+- Minor updates to the blog post
+- Add draft of next blog post
+- Add basic telemetry infra. Add Stop hook event.
+- Add RFD process with tooling and CI enforcement
+- Make WorkspaceCrate and LoadedWorkspace non-exhaustive
+- Address PR review feedback
+- Use symposium-sdk types directly instead of re-exporting
+- Require SymposiumDirs when constructing WorkspaceDeps
+- Add SymposiumDirs to symposium-sdk for shared path resolution
+- Add WorkspaceDeps with in-process and disk caching
+- Introduce symposium-sdk crate and refactor main crate to use it
+- Make sync debounce configurable; add change-detection test
+- change debounce to 5sec
+- Update tests and docs for sync_skill_dir changes
+- Unify skill installation into sync_skill_dir
+- Document that custom predicates are globally available across plugins
+- Introduce CustomPredicateRegistry newtype
+- Add integration tests for argument passing and witness-driven crate source
+- Document and test that empty/whitespace args are not passed
+- Fail predicate on any malformed witness entry
+- Fail predicate when stdout is non-empty but not valid witness JSON
+- Add integration tests for argument passing and witness-driven crate source
+- Fix CI: replace /bin/true with script-based test helpers
+- Add tests for field syntax boundary enforcement
+- Reject function-call syntax in the `crates` field
+- Consolidate predicate name validation and fix CrateList comma parsing
+- Integrate custom predicate evaluator into PredicateContext
+- Add custom predicate extensions via [[predicate]]
+- Validate skills with negated crate
+- Add crate predicate and lower crates field to it
+- Change from shell predicates to more general predicates
+- Add shell_predicates field
+- Merge pull request #234 from nikomatsakis/cargo-agents-sync-verbose
+- Add a sentence about global use case
+- Add global install option for cargo and add env vars
+- pacify the merciless fmt
+- add Plugin::get_installation, capture subcommand output, snapshot tests
+- pacify the merciless cargo fmt
+- *(help)* hoist section headings into shared constants
+- Agent help guidance:
+- add the built-in dispatch step to hook-flow.md, an "Agent
+- document the --help renderer and reclassify crate-info
+- dispatch external `cargo agents <name>` via clap catch-all
+- *(plugins)* pass empty source_name to scan_source_dir
+- *(installation)* lift hook resolver into shared module
+- Merge pull request #236 from nikomatsakis/skills-from-specific-crate
+- make init and sync modules pub(crate)
+- redesign source.crate as a nested table
+- apply fmt
+- improve docs
+- Add `source.crate` field to decouple skill fetch target from activation predicates
+- pacify the merciless fmt
+- fix macOS CI test failure (symlink canonicalization)
+- Also watch battery-pack.toml for sync staleness
+- pacify the merciless fmt
+- Skip auto-sync when Cargo.lock is unchanged
+- pacify the merciless fmt
+- Add user-facing hook documentation and SDK guide
+- Add design tenets and hook architecture docs
+- Implement per-plugin hook format selection
+- Introduce symposium-hook SDK crate
+- Change default crate skills path from `.symposium/skills` to `skills`
+
 ## [0.4.0](https://github.com/symposium-dev/symposium/compare/symposium-v0.3.0...symposium-v0.4.0) - 2026-05-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,104 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/symposium-dev/symposium/compare/symposium-v0.4.0...symposium-v0.5.0) - 2026-08-04
+
+### Added
+
+- use disk cache in evaluate_custom and sync
+- add per-workspace on-disk PredicateCache
+- add WatchSet and Fingerprints types for predicate-caching
+- *(predicate)* parse CustomPredicateEvent JSONL stream
+- *(hook)* suggest `cargo agents --help` at session start
+- *(help)* audience-grouped --help listing plugin-vended subcommands.
+- *(plugins)* add subcommand manifest schema
+- move skill layout to [package.metadata.symposium] in crate Cargo.toml
+
+### Fixed
+
+- add `self-update` to reserved subcommand names and fix typo
+- make crate_metadata module pub(crate)
+- address review nits on source.crate
+
+### Other
+
+- *(reference)* document use/search/status, enablement, and PM sources
+- *(design)* update module-structure, flows, and the RFD for the PM layer
+- Add the enablement commands: use, search, status
+- Introduce the package-manager layer and reshape plugin/skill resolution
+- Merge branch 'main' into symposium-mcp-design
+- Merge pull request #262 from kurasaiteja/rfd-predicate-caching
+- predicate caching RFD v4
+- predicate caching RFD v3
+- predicate caching RFD v2
+- predicate caching
+- Merge pull request #253 from nikomatsakis/register-centric-plugins-rfd
+- Merge pull request #254 from nikomatsakis/config-normalization
+- Merge pull request #247 from abusch/push-yzlulwltuttq
+- Add link in summary
+- Minor updates to the blog post
+- Add draft of next blog post
+- Add basic telemetry infra. Add Stop hook event.
+- Add RFD process with tooling and CI enforcement
+- Make WorkspaceCrate and LoadedWorkspace non-exhaustive
+- Address PR review feedback
+- Use symposium-sdk types directly instead of re-exporting
+- Require SymposiumDirs when constructing WorkspaceDeps
+- Add SymposiumDirs to symposium-sdk for shared path resolution
+- Add WorkspaceDeps with in-process and disk caching
+- Introduce symposium-sdk crate and refactor main crate to use it
+- Make sync debounce configurable; add change-detection test
+- change debounce to 5sec
+- Update tests and docs for sync_skill_dir changes
+- Unify skill installation into sync_skill_dir
+- Document that custom predicates are globally available across plugins
+- Introduce CustomPredicateRegistry newtype
+- Add integration tests for argument passing and witness-driven crate source
+- Document and test that empty/whitespace args are not passed
+- Fail predicate on any malformed witness entry
+- Fail predicate when stdout is non-empty but not valid witness JSON
+- Add integration tests for argument passing and witness-driven crate source
+- Fix CI: replace /bin/true with script-based test helpers
+- Add tests for field syntax boundary enforcement
+- Reject function-call syntax in the `crates` field
+- Consolidate predicate name validation and fix CrateList comma parsing
+- Integrate custom predicate evaluator into PredicateContext
+- Add custom predicate extensions via [[predicate]]
+- Validate skills with negated crate
+- Add crate predicate and lower crates field to it
+- Change from shell predicates to more general predicates
+- Add shell_predicates field
+- Merge pull request #234 from nikomatsakis/cargo-agents-sync-verbose
+- Add a sentence about global use case
+- Add global install option for cargo and add env vars
+- pacify the merciless fmt
+- add Plugin::get_installation, capture subcommand output, snapshot tests
+- pacify the merciless cargo fmt
+- *(help)* hoist section headings into shared constants
+- Agent help guidance:
+- add the built-in dispatch step to hook-flow.md, an "Agent
+- document the --help renderer and reclassify crate-info
+- dispatch external `cargo agents <name>` via clap catch-all
+- *(plugins)* pass empty source_name to scan_source_dir
+- *(installation)* lift hook resolver into shared module
+- Merge pull request #236 from nikomatsakis/skills-from-specific-crate
+- make init and sync modules pub(crate)
+- redesign source.crate as a nested table
+- apply fmt
+- improve docs
+- Add `source.crate` field to decouple skill fetch target from activation predicates
+- pacify the merciless fmt
+- fix macOS CI test failure (symlink canonicalization)
+- Also watch battery-pack.toml for sync staleness
+- pacify the merciless fmt
+- Skip auto-sync when Cargo.lock is unchanged
+- pacify the merciless fmt
+- Add user-facing hook documentation and SDK guide
+- Add design tenets and hook architecture docs
+- Implement per-plugin hook format selection
+- Introduce symposium-hook SDK crate
+- Change default crate skills path from `.symposium/skills` to `skills`
+
 ## [0.4.0](https://github.com/symposium-dev/symposium/compare/symposium-v0.3.0...symposium-v0.4.0) - 2026-05-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symposium"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symposium"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "AI the Rust Way"

--- a/symposium-install/CHANGELOG.md
+++ b/symposium-install/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/symposium-dev/symposium/releases/tag/symposium-install-v0.1.0) - 2026-09-05
+
+### Other
+
+- Add auto-update logic for installations
+- Add custom predicate extensions via [[predicate]]
+- Add global install option for cargo and add env vars
+- introduce GitSource enum and reduce git API surface
+- extract symposium-install crate and make symposium-hook async

--- a/symposium-install/CHANGELOG.md
+++ b/symposium-install/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/symposium-dev/symposium/releases/tag/symposium-install-v0.1.0) - 2026-08-04
+
+### Other
+
+- Add auto-update logic for installations
+- Add custom predicate extensions via [[predicate]]
+- Add global install option for cargo and add env vars
+- introduce GitSource enum and reduce git API surface
+- extract symposium-install crate and make symposium-hook async

--- a/symposium-sdk/CHANGELOG.md
+++ b/symposium-sdk/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/symposium-dev/symposium/releases/tag/symposium-sdk-v0.1.0) - 2026-09-05
+
+### Added
+
+- *(sdk)* env::var and fs::read_to_string helpers
+- *(predicate)* parse CustomPredicateEvent JSONL stream
+
+### Other
+
+- Introduce the package-manager layer and reshape plugin/skill resolution
+- Load crates as plugins via [[plugins]] chained references
+- Workspace plugins: the workspace's own dirs define plugins
+- Merge pull request #252 from kurasaiteja/tejakura-custom-predicate-jsonl
+- switch custom predicate stdout to JSONL
+- Make WorkspaceCrate and LoadedWorkspace non-exhaustive
+- Address PR review feedback
+- Use symposium-sdk types directly instead of re-exporting
+- Require SymposiumDirs when constructing WorkspaceDeps
+- Replace ad-hoc WorkspaceDeps fields with SymposiumDirs
+- Add SymposiumDirs to symposium-sdk for shared path resolution
+- Add WorkspaceDeps with in-process and disk caching
+- Introduce symposium-sdk crate and refactor main crate to use it

--- a/symposium-sdk/CHANGELOG.md
+++ b/symposium-sdk/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/symposium-dev/symposium/releases/tag/symposium-sdk-v0.1.0) - 2026-08-04
+
+### Added
+
+- *(sdk)* env::var and fs::read_to_string helpers
+- *(predicate)* parse CustomPredicateEvent JSONL stream
+
+### Other
+
+- Introduce the package-manager layer and reshape plugin/skill resolution
+- Load crates as plugins via [[plugins]] chained references
+- Workspace plugins: the workspace's own dirs define plugins
+- Merge pull request #252 from kurasaiteja/tejakura-custom-predicate-jsonl
+- switch custom predicate stdout to JSONL
+- Make WorkspaceCrate and LoadedWorkspace non-exhaustive
+- Address PR review feedback
+- Use symposium-sdk types directly instead of re-exporting
+- Require SymposiumDirs when constructing WorkspaceDeps
+- Replace ad-hoc WorkspaceDeps fields with SymposiumDirs
+- Add SymposiumDirs to symposium-sdk for shared path resolution
+- Add WorkspaceDeps with in-process and disk caching
+- Introduce symposium-sdk crate and refactor main crate to use it


### PR DESCRIPTION



## 🤖 New release

* `symposium-install`: 0.1.0
* `symposium-sdk`: 0.1.0
* `symposium`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `symposium` breaking changes

```text
--- failure constructible_struct_adds_field: struct exhaustively constructible through public API adds field ---

Description:
A pub struct that could be exhaustively constructed with a literal using only public API has a new pub field, breaking existing exhaustive literals.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SkillGroup.predicates in /tmp/.tmp1VC1Kh/symposium/src/plugins.rs:174
  field SkillGroup.source_label in /tmp/.tmp1VC1Kh/symposium/src/plugins.rs:183
  field SkillGroup.workspace_member in /tmp/.tmp1VC1Kh/symposium/src/plugins.rs:189
  field PluginRegistry.custom_predicates in /tmp/.tmp1VC1Kh/symposium/src/plugins.rs:928
  field Config.sync_debounce_secs in /tmp/.tmp1VC1Kh/symposium/src/config.rs:74
  field Config.telemetry in /tmp/.tmp1VC1Kh/symposium/src/config.rs:94
  field Config.plugins in /tmp/.tmp1VC1Kh/symposium/src/config.rs:98
  field Config.registries in /tmp/.tmp1VC1Kh/symposium/src/config.rs:114
  field PluginMcpServer.predicates in /tmp/.tmp1VC1Kh/symposium/src/plugins.rs:29
  field ParsedPlugin.workspace_member in /tmp/.tmp1VC1Kh/symposium/src/plugins.rs:416
  field ParsedPlugin.canonical in /tmp/.tmp1VC1Kh/symposium/src/plugins.rs:430
  field ValidationResult.id in /tmp/.tmp1VC1Kh/symposium/src/plugins.rs:1663
  field Plugin.predicates in /tmp/.tmp1VC1Kh/symposium/src/plugins.rs:458
  field Plugin.subcommands in /tmp/.tmp1VC1Kh/symposium/src/plugins.rs:469
  field Plugin.custom_predicates in /tmp/.tmp1VC1Kh/symposium/src/plugins.rs:472
  field Plugin.chained in /tmp/.tmp1VC1Kh/symposium/src/plugins.rs:477
  field Plugin.requires_use in /tmp/.tmp1VC1Kh/symposium/src/plugins.rs:489
  field Cli.verbose in /tmp/.tmp1VC1Kh/symposium/src/cli.rs:48
  field Cli.json in /tmp/.tmp1VC1Kh/symposium/src/cli.rs:52
  field Cli.help in /tmp/.tmp1VC1Kh/symposium/src/cli.rs:56
  field Hook.predicates in /tmp/.tmp1VC1Kh/symposium/src/plugins.rs:612

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_missing.ron

Failed in:
  enum symposium::hook_schema::symposium::OutputEvent, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/symposium.rs:156
  enum symposium::plugins::UpdateLevel, previously in file /tmp/.tmpGEYsyb/symposium/src/plugins.rs:31
  enum symposium::hook_schema::symposium::InputEvent, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/symposium.rs:61
  enum symposium::hook::HookEvent, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema.rs:59
  enum symposium::hook_schema::HookEvent, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema.rs:59

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant HookAgent::Claude 0 -> 1 in /tmp/.tmp1VC1Kh/symposium/src/hook_schema.rs:25
  variant HookAgent::Codex 1 -> 2 in /tmp/.tmp1VC1Kh/symposium/src/hook_schema.rs:28
  variant HookAgent::Copilot 2 -> 3 in /tmp/.tmp1VC1Kh/symposium/src/hook_schema.rs:31
  variant HookAgent::Claude 0 -> 1 in /tmp/.tmp1VC1Kh/symposium/src/hook_schema.rs:25
  variant HookAgent::Codex 1 -> 2 in /tmp/.tmp1VC1Kh/symposium/src/hook_schema.rs:28
  variant HookAgent::Copilot 2 -> 3 in /tmp/.tmp1VC1Kh/symposium/src/hook_schema.rs:31
  variant HookFormat::Claude 1 -> 2 in /tmp/.tmp1VC1Kh/symposium/src/plugins.rs:836
  variant HookFormat::Codex 2 -> 3 in /tmp/.tmp1VC1Kh/symposium/src/plugins.rs:837
  variant HookFormat::Copilot 3 -> 4 in /tmp/.tmp1VC1Kh/symposium/src/plugins.rs:838
  variant Agent::Claude 0 -> 1 in /tmp/.tmp1VC1Kh/symposium/src/agents/mod.rs:35
  variant Agent::Codex 1 -> 2 in /tmp/.tmp1VC1Kh/symposium/src/agents/mod.rs:36
  variant Agent::Copilot 2 -> 3 in /tmp/.tmp1VC1Kh/symposium/src/agents/mod.rs:37

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_variant_added.ron

Failed in:
  variant Agent:Antigravity in /tmp/.tmp1VC1Kh/symposium/src/agents/mod.rs:34
  variant HookAgent:Antigravity in /tmp/.tmp1VC1Kh/symposium/src/hook_schema.rs:22
  variant HookAgent:Antigravity in /tmp/.tmp1VC1Kh/symposium/src/hook_schema.rs:22
  variant Commands:Search in /tmp/.tmp1VC1Kh/symposium/src/cli.rs:84
  variant Commands:Use in /tmp/.tmp1VC1Kh/symposium/src/cli.rs:90
  variant Commands:Status in /tmp/.tmp1VC1Kh/symposium/src/cli.rs:104
  variant Commands:Telemetry in /tmp/.tmp1VC1Kh/symposium/src/cli.rs:136
  variant Commands:External in /tmp/.tmp1VC1Kh/symposium/src/cli.rs:143
  variant HookFormat:Antigravity in /tmp/.tmp1VC1Kh/symposium/src/plugins.rs:835

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_variant_missing.ron

Failed in:
  variant HookAgent::Gemini, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema.rs:31
  variant HookAgent::Gemini, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema.rs:31
  variant HookFormat::Gemini, previously in file /tmp/.tmpGEYsyb/symposium/src/plugins.rs:594
  variant Agent::Gemini, previously in file /tmp/.tmpGEYsyb/symposium/src/agents/mod.rs:24
  variant PluginSource::None, previously in file /tmp/.tmpGEYsyb/symposium/src/plugins.rs:56
  variant PluginSource::CratePath, previously in file /tmp/.tmpGEYsyb/symposium/src/plugins.rs:62

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/function_missing.ron

Failed in:
  function symposium::init::init, previously in file /tmp/.tmpGEYsyb/symposium/src/init.rs:64
  function symposium::plugins::ensure_plugin_sources, previously in file /tmp/.tmpGEYsyb/symposium/src/plugins.rs:735
  function symposium::init::find_workspace_root, previously in file /tmp/.tmpGEYsyb/symposium/src/init.rs:199
  function symposium::plugins::load_all_plugins, previously in file /tmp/.tmpGEYsyb/symposium/src/plugins.rs:767
  function symposium::plugins::sync_plugin_source, previously in file /tmp/.tmpGEYsyb/symposium/src/plugins.rs:775

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/function_parameter_count_changed.ron

Failed in:
  symposium::cli::run now takes 5 parameters instead of 4, in /tmp/.tmp1VC1Kh/symposium/src/cli.rs:214
  symposium::hook::dispatch_builtin now takes 3 parameters instead of 2, in /tmp/.tmp1VC1Kh/symposium/src/hook.rs:508
  symposium::hook::dispatch_plugin_hooks now takes 7 parameters instead of 6, in /tmp/.tmp1VC1Kh/symposium/src/hook.rs:654

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/inherent_method_missing.ron

Failed in:
  Symposium::plugin_sources, previously in file /tmp/.tmpGEYsyb/symposium/src/config.rs:328
  Plugin::applies_to_crates, previously in file /tmp/.tmpGEYsyb/symposium/src/plugins.rs:327
  Agent::register_project_mcp_servers, previously in file /tmp/.tmpGEYsyb/symposium/src/agents/mod.rs:195
  Agent::register_global_mcp_servers, previously in file /tmp/.tmpGEYsyb/symposium/src/agents/mod.rs:241
  Agent::unregister_project_mcp_servers, previously in file /tmp/.tmpGEYsyb/symposium/src/agents/mod.rs:288
  Agent::unregister_global_mcp_servers, previously in file /tmp/.tmpGEYsyb/symposium/src/agents/mod.rs:334
  Agent::install_skill, previously in file /tmp/.tmpGEYsyb/symposium/src/agents/mod.rs:420

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/method_parameter_count_changed.ron

Failed in:
  symposium::config::Symposium::init_logging takes 0 parameters in /tmp/.tmpGEYsyb/symposium/src/config.rs:280, but now takes 1 parameters in /tmp/.tmp1VC1Kh/symposium/src/config.rs:547

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/module_missing.ron

Failed in:
  mod symposium::init, previously in file /tmp/.tmpGEYsyb/symposium/src/init.rs:1
  mod symposium::hook_schema::gemini, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/gemini.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/struct_missing.ron

Failed in:
  struct symposium::hook_schema::gemini::GeminiUserPromptSubmitOutput, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/gemini.rs:312
  struct symposium::hook_schema::gemini::GeminiSessionStartInput, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/gemini.rs:392
  struct symposium::hook_schema::symposium::PreToolUseOutput, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/symposium.rs:106
  struct symposium::hook_schema::gemini::GeminiPostToolUseEvent, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/gemini.rs:36
  struct symposium::hook_schema::symposium::SessionStartInput, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/symposium.rs:52
  struct symposium::hook_schema::gemini::GeminiSessionStartHookOutput, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/gemini.rs:411
  struct symposium::hook_schema::gemini::GeminiPostToolUseOutput, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/gemini.rs:209
  struct symposium::hook_schema::gemini::Gemini, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/gemini.rs:7
  struct symposium::plugins::CratePathSource, previously in file /tmp/.tmpGEYsyb/symposium/src/plugins.rs:73
  struct symposium::hook_schema::symposium::PreToolUseInput, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/symposium.rs:15
  struct symposium::hook_schema::symposium::PostToolUseOutput, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/symposium.rs:123
  struct symposium::hook_schema::gemini::GeminiUserPromptSubmitInput, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/gemini.rs:299
  struct symposium::hook_schema::gemini::GeminiPreToolUseEvent, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/gemini.rs:31
  struct symposium::hook_schema::gemini::GeminiPostToolUseHookOutput, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/gemini.rs:221
  struct symposium::config::ResolvedPluginSource, previously in file /tmp/.tmpGEYsyb/symposium/src/config.rs:185
  struct symposium::hook_schema::gemini::GeminiUserPromptSubmitHookOutput, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/gemini.rs:320
  struct symposium::hook_schema::gemini::GeminiPreToolUseOutput, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/gemini.rs:90
  struct symposium::plugins::StandaloneSkill, previously in file /tmp/.tmpGEYsyb/symposium/src/plugins.rs:633
  struct symposium::hook_schema::symposium::UserPromptSubmitInput, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/symposium.rs:41
  struct symposium::hook_schema::symposium::UserPromptSubmitOutput, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/symposium.rs:134
  struct symposium::hook_schema::gemini::GeminiPostToolUseInput, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/gemini.rs:189
  struct symposium::init::InitOpts, previously in file /tmp/.tmpGEYsyb/symposium/src/init.rs:15
  struct symposium::hook_schema::gemini::GeminiSessionStartEvent, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/gemini.rs:46
  struct symposium::hook_schema::symposium::SessionStartOutput, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/symposium.rs:145
  struct symposium::hook_schema::gemini::GeminiPreToolUseInput, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/gemini.rs:68
  struct symposium::hook_schema::gemini::GeminiSessionStartOutput, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/gemini.rs:403
  struct symposium::hook_schema::symposium::PostToolUseInput, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/symposium.rs:27
  struct symposium::hook_schema::gemini::GeminiPreToolUseHookOutput, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/gemini.rs:110
  struct symposium::hook_schema::gemini::GeminiUserPromptSubmitEvent, previously in file /tmp/.tmpGEYsyb/symposium/src/hook_schema/gemini.rs:41
  struct symposium::config::PluginSourceConfig, previously in file /tmp/.tmpGEYsyb/symposium/src/config.rs:162

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field crates of struct Plugin, previously in file /tmp/.tmpGEYsyb/symposium/src/plugins.rs:314
  field standalone_skills of struct PluginRegistry, previously in file /tmp/.tmpGEYsyb/symposium/src/plugins.rs:646
  field plugin_source of struct Config, previously in file /tmp/.tmpGEYsyb/symposium/src/config.rs:99
  field path of struct ParsedPlugin, previously in file /tmp/.tmpGEYsyb/symposium/src/plugins.rs:288
  field source_name of struct ParsedPlugin, previously in file /tmp/.tmpGEYsyb/symposium/src/plugins.rs:298
  field source_dir of struct ParsedPlugin, previously in file /tmp/.tmpGEYsyb/symposium/src/plugins.rs:302
  field crates of struct SkillGroup, previously in file /tmp/.tmpGEYsyb/symposium/src/plugins.rs:210
  field crates of struct PluginMcpServer, previously in file /tmp/.tmpGEYsyb/symposium/src/plugins.rs:24
  field path of struct ValidationResult, previously in file /tmp/.tmpGEYsyb/symposium/src/plugins.rs:1153
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `symposium-install`

<blockquote>

## [0.1.0](https://github.com/symposium-dev/symposium/releases/tag/symposium-install-v0.1.0) - 2026-09-21

### Other

- Add auto-update logic for installations
- Add custom predicate extensions via [[predicate]]
- Add global install option for cargo and add env vars
- introduce GitSource enum and reduce git API surface
- extract symposium-install crate and make symposium-hook async
</blockquote>

## `symposium-sdk`

<blockquote>

## [0.1.0](https://github.com/symposium-dev/symposium/releases/tag/symposium-sdk-v0.1.0) - 2026-09-21

### Added

- *(sdk)* env::var and fs::read_to_string helpers
- *(predicate)* parse CustomPredicateEvent JSONL stream

### Other

- Introduce the package-manager layer and reshape plugin/skill resolution
- Load crates as plugins via [[plugins]] chained references
- Workspace plugins: the workspace's own dirs define plugins
- Merge pull request #252 from kurasaiteja/tejakura-custom-predicate-jsonl
- switch custom predicate stdout to JSONL
- Make WorkspaceCrate and LoadedWorkspace non-exhaustive
- Address PR review feedback
- Use symposium-sdk types directly instead of re-exporting
- Require SymposiumDirs when constructing WorkspaceDeps
- Replace ad-hoc WorkspaceDeps fields with SymposiumDirs
- Add SymposiumDirs to symposium-sdk for shared path resolution
- Add WorkspaceDeps with in-process and disk caching
- Introduce symposium-sdk crate and refactor main crate to use it
</blockquote>

## `symposium`

<blockquote>

## [0.5.0](https://github.com/symposium-dev/symposium/compare/symposium-v0.4.0...symposium-v0.5.0) - 2026-09-21

### Added

- [**breaking**] replace Gemini CLI with Antigravity CLI
- *(hook)* suggest `cargo agents --help` at session start
- *(help)* audience-grouped --help listing plugin-vended subcommands.
- *(plugins)* add subcommand manifest schema
- move skill layout to [package.metadata.symposium] in crate Cargo.toml

### Fixed

- *(sync)* register hooks at the configured scope
- add `self-update` to reserved subcommand names and fix typo
- make crate_metadata module pub(crate)
- address review nits on source.crate

### Other

- document Antigravity CLI and drop Gemini CLI
- Fix CI issues
- Format
- *(rfd)* address agent-plugins review feedback
- *(rfd)* record agent-plugins findings from probing real agents
- *(rfd)* add implementation details to agent-plugins RFD
- *(rfd)* clarify agent-plugins RFD
- *(rfd)* propose Agent Plugins interoperability
- Merge pull request #212 from swjng/feat/parse-copilot-tool-args
- Merge pull request #274 from Fluzko/mcp-registration-paths
- Merge pull request #267 from gmemuriuki/feat/windows-ci
- RFD updates
- *(rfd)* describe the PM interface and cargo PM as they are meant to work
- Add user-managed plugins sub-RFD
- Add PM interface, cargo PM, and discovery & sync sub-RFDs
- Add plugin model sub-RFD
- *(reference)* document use/search/status, enablement, and PM sources
- *(design)* update module-structure, flows, and the RFD for the PM layer
- Add the enablement commands: use, search, status
- Introduce the package-manager layer and reshape plugin/skill resolution
- Merge branch 'main' into symposium-mcp-design
- Merge pull request #262 from kurasaiteja/rfd-predicate-caching
- predicate caching RFD v4
- predicate caching RFD v3
- predicate caching RFD v2
- predicate caching
- Merge pull request #253 from nikomatsakis/register-centric-plugins-rfd
- Merge pull request #254 from nikomatsakis/config-normalization
- Merge pull request #247 from abusch/push-yzlulwltuttq
- Add link in summary
- Minor updates to the blog post
- Add draft of next blog post
- Add basic telemetry infra. Add Stop hook event.
- Add RFD process with tooling and CI enforcement
- Make WorkspaceCrate and LoadedWorkspace non-exhaustive
- Address PR review feedback
- Use symposium-sdk types directly instead of re-exporting
- Require SymposiumDirs when constructing WorkspaceDeps
- Add SymposiumDirs to symposium-sdk for shared path resolution
- Add WorkspaceDeps with in-process and disk caching
- Introduce symposium-sdk crate and refactor main crate to use it
- Make sync debounce configurable; add change-detection test
- change debounce to 5sec
- Update tests and docs for sync_skill_dir changes
- Unify skill installation into sync_skill_dir
- Document that custom predicates are globally available across plugins
- Introduce CustomPredicateRegistry newtype
- Add integration tests for argument passing and witness-driven crate source
- Document and test that empty/whitespace args are not passed
- Fail predicate on any malformed witness entry
- Fail predicate when stdout is non-empty but not valid witness JSON
- Add integration tests for argument passing and witness-driven crate source
- Fix CI: replace /bin/true with script-based test helpers
- Add tests for field syntax boundary enforcement
- Reject function-call syntax in the `crates` field
- Consolidate predicate name validation and fix CrateList comma parsing
- Integrate custom predicate evaluator into PredicateContext
- Add custom predicate extensions via [[predicate]]
- Validate skills with negated crate
- Add crate predicate and lower crates field to it
- Change from shell predicates to more general predicates
- Add shell_predicates field
- Merge pull request #234 from nikomatsakis/cargo-agents-sync-verbose
- Add a sentence about global use case
- Add global install option for cargo and add env vars
- pacify the merciless fmt
- add Plugin::get_installation, capture subcommand output, snapshot tests
- pacify the merciless cargo fmt
- *(help)* hoist section headings into shared constants
- Agent help guidance:
- add the built-in dispatch step to hook-flow.md, an "Agent
- document the --help renderer and reclassify crate-info
- dispatch external `cargo agents <name>` via clap catch-all
- *(plugins)* pass empty source_name to scan_source_dir
- *(installation)* lift hook resolver into shared module
- Merge pull request #236 from nikomatsakis/skills-from-specific-crate
- make init and sync modules pub(crate)
- redesign source.crate as a nested table
- apply fmt
- improve docs
- Add `source.crate` field to decouple skill fetch target from activation predicates
- pacify the merciless fmt
- fix macOS CI test failure (symlink canonicalization)
- Also watch battery-pack.toml for sync staleness
- pacify the merciless fmt
- Skip auto-sync when Cargo.lock is unchanged
- pacify the merciless fmt
- Add user-facing hook documentation and SDK guide
- Add design tenets and hook architecture docs
- Implement per-plugin hook format selection
- Introduce symposium-hook SDK crate
- Change default crate skills path from `.symposium/skills` to `skills`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).