### PR TITLE
Skip auto-sync when Cargo.lock is unchanged

### DIFF
--- a/src/hook.rs
+++ b/src/hook.rs
@@ -279,6 +279,10 @@ fn write_hook_trace(agent: HookAgent, event: HookEvent, input: &str, output: &[u
 }
 
 /// Run sync if we're in a workspace directory and auto-sync is enabled. Non-fatal.
+///
+/// Uses per-workspace state to skip sync when `Cargo.lock` hasn't changed
+/// since the last successful sync, avoiding expensive `cargo metadata` calls
+/// on every hook invocation.
 async fn run_auto_sync(
     sym: &Symposium,
     input: &symposium::InputEvent,
@@ -288,14 +292,40 @@ async fn run_auto_sync(
         tracing::debug!("auto-sync disabled, skipping");
         return;
     }
-    tracing::debug!("auto-sync enabled, running");
+
     let cwd = match input.cwd() {
         Some(s) => std::path::PathBuf::from(s),
         None => fallback_cwd.to_path_buf(),
     };
+
+    // Find workspace root via `cargo locate-project` (fast, no dep resolution).
+    // If we can't find one, fall through to full sync which will
+    // use cargo metadata.
+    let workspace_root = crate::workspace_state::find_workspace_root(sym, &cwd);
+
+    if let Some(ref root) = workspace_root {
+        let state = crate::workspace_state::WorkspaceState::load(sym, root);
+        if state.sync_is_fresh(root) {
+            tracing::debug!("auto-sync skipped: Cargo.lock unchanged since last sync");
+            return;
+        }
+    }
+
+    tracing::debug!("auto-sync running");
     let out = crate::output::Output::quiet();
     if let Err(e) = crate::sync::sync(sym, &cwd, &out).await {
         tracing::warn!(error = %e, "auto-sync during hook failed (continuing)");
+        return;
+    }
+
+    // Record successful sync. If we didn't find the root earlier,
+    // try again now (sync may have created Cargo.lock).
+    let root = workspace_root.or_else(|| crate::workspace_state::find_workspace_root(sym, &cwd));
+    if let Some(ref root) = root {
+        let mut state = crate::workspace_state::WorkspaceState::load(sym, root);
+        state.record_sync(root);
+        state.workspace_root = Some(root.clone());
+        state.save(sym, root);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod plugins;
 pub mod self_update;
 pub mod state;
 pub mod sync;
+pub mod workspace_state;
 
 pub(crate) mod crate_sources;
 pub(crate) mod installation;

--- a/src/workspace_state.rs
+++ b/src/workspace_state.rs
@@ -129,9 +129,12 @@ fn workspace_dir_name(workspace_root: &Path) -> String {
 }
 
 fn state_file_path(sym: &Symposium, workspace_root: &Path) -> PathBuf {
+    // Canonicalize so that symlink variants (e.g. /var vs /private/var on
+    // macOS) hash to the same cache directory.
+    let canonical = fs::canonicalize(workspace_root).unwrap_or_else(|_| workspace_root.to_path_buf());
     sym.cache_dir()
         .join("workspaces")
-        .join(workspace_dir_name(workspace_root))
+        .join(workspace_dir_name(&canonical))
         .join("state.json")
 }
 
@@ -298,7 +301,9 @@ mod tests {
 
         let sym = Symposium::from_dir(tmp.path());
         let found = find_workspace_root(&sym, &src);
-        assert_eq!(found, Some(root));
+        // Canonicalize expected path to handle macOS /var → /private/var symlink.
+        let expected = fs::canonicalize(&root).unwrap();
+        assert_eq!(found, Some(expected));
     }
 
     #[test]

--- a/src/workspace_state.rs
+++ b/src/workspace_state.rs
@@ -18,6 +18,9 @@ pub struct WorkspaceState {
     #[serde(default, rename = "last-sync-lock-mtime")]
     pub last_sync_lock_mtime: Option<u64>,
 
+    #[serde(default, rename = "last-sync-battery-pack-mtime")]
+    pub last_sync_battery_pack_mtime: Option<u64>,
+
     #[serde(default, rename = "workspace-root")]
     pub workspace_root: Option<PathBuf>,
 }
@@ -42,17 +45,29 @@ impl WorkspaceState {
     }
 
     pub fn sync_is_fresh(&self, workspace_root: &Path) -> bool {
-        let Some(cached_mtime) = self.last_sync_lock_mtime else {
+        // Cargo.lock must have been seen at least once — if we've never
+        // synced, the cache is unconditionally stale.
+        if self.last_sync_lock_mtime.is_none() {
             return false;
-        };
-        let Some(current_mtime) = cargo_lock_mtime(workspace_root) else {
+        }
+        if !mtime_matches(
+            self.last_sync_lock_mtime,
+            &workspace_root.join("Cargo.lock"),
+        ) {
             return false;
-        };
-        cached_mtime == current_mtime
+        }
+        if !mtime_matches(
+            self.last_sync_battery_pack_mtime,
+            &workspace_root.join("battery-pack.toml"),
+        ) {
+            return false;
+        }
+        true
     }
 
     pub fn record_sync(&mut self, workspace_root: &Path) {
-        self.last_sync_lock_mtime = cargo_lock_mtime(workspace_root);
+        self.last_sync_lock_mtime = file_mtime(&workspace_root.join("Cargo.lock"));
+        self.last_sync_battery_pack_mtime = file_mtime(&workspace_root.join("battery-pack.toml"));
     }
 }
 
@@ -76,9 +91,8 @@ pub fn find_workspace_root(sym: &Symposium, cwd: &Path) -> Option<PathBuf> {
     Path::new(manifest.trim()).parent().map(|p| p.to_path_buf())
 }
 
-fn cargo_lock_mtime(workspace_root: &Path) -> Option<u64> {
-    let lock_path = workspace_root.join("Cargo.lock");
-    let meta = fs::metadata(&lock_path).ok()?;
+fn file_mtime(path: &Path) -> Option<u64> {
+    let meta = fs::metadata(path).ok()?;
     let mtime = meta.modified().ok()?;
     Some(
         mtime
@@ -86,6 +100,14 @@ fn cargo_lock_mtime(workspace_root: &Path) -> Option<u64> {
             .unwrap_or_default()
             .as_secs(),
     )
+}
+
+/// Check whether the cached mtime matches the current file state.
+/// A missing file matches a `None` cached mtime (both absent = fresh).
+/// A missing file with a `Some` cached mtime means the file was deleted = stale.
+fn mtime_matches(cached: Option<u64>, path: &Path) -> bool {
+    let current = file_mtime(path);
+    cached == current
 }
 
 fn workspace_dir_name(workspace_root: &Path) -> String {
@@ -142,11 +164,13 @@ mod tests {
 
         let mut state = WorkspaceState::default();
         state.last_sync_lock_mtime = Some(1234567890);
+        state.last_sync_battery_pack_mtime = Some(9876543210);
         state.workspace_root = Some(workspace.clone());
         state.save(&sym, &workspace);
 
         let loaded = WorkspaceState::load(&sym, &workspace);
         assert_eq!(loaded.last_sync_lock_mtime, Some(1234567890));
+        assert_eq!(loaded.last_sync_battery_pack_mtime, Some(9876543210));
         assert_eq!(loaded.workspace_root, Some(workspace));
     }
 
@@ -157,16 +181,35 @@ mod tests {
         fs::create_dir_all(&workspace).unwrap();
         fs::write(workspace.join("Cargo.lock"), "# lock").unwrap();
 
-        let mtime = cargo_lock_mtime(&workspace).unwrap();
+        let lock_mtime = file_mtime(&workspace.join("Cargo.lock")).unwrap();
         let state = WorkspaceState {
-            last_sync_lock_mtime: Some(mtime),
+            last_sync_lock_mtime: Some(lock_mtime),
+            last_sync_battery_pack_mtime: None,
             workspace_root: None,
         };
         assert!(state.sync_is_fresh(&workspace));
     }
 
     #[test]
-    fn sync_is_stale_when_mtime_differs() {
+    fn sync_is_fresh_with_both_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("project");
+        fs::create_dir_all(&workspace).unwrap();
+        fs::write(workspace.join("Cargo.lock"), "# lock").unwrap();
+        fs::write(workspace.join("battery-pack.toml"), "# bp").unwrap();
+
+        let lock_mtime = file_mtime(&workspace.join("Cargo.lock")).unwrap();
+        let bp_mtime = file_mtime(&workspace.join("battery-pack.toml")).unwrap();
+        let state = WorkspaceState {
+            last_sync_lock_mtime: Some(lock_mtime),
+            last_sync_battery_pack_mtime: Some(bp_mtime),
+            workspace_root: None,
+        };
+        assert!(state.sync_is_fresh(&workspace));
+    }
+
+    #[test]
+    fn sync_is_stale_when_lock_mtime_differs() {
         let tmp = tempfile::tempdir().unwrap();
         let workspace = tmp.path().join("project");
         fs::create_dir_all(&workspace).unwrap();
@@ -174,6 +217,42 @@ mod tests {
 
         let state = WorkspaceState {
             last_sync_lock_mtime: Some(0),
+            last_sync_battery_pack_mtime: None,
+            workspace_root: None,
+        };
+        assert!(!state.sync_is_fresh(&workspace));
+    }
+
+    #[test]
+    fn sync_is_stale_when_battery_pack_added() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("project");
+        fs::create_dir_all(&workspace).unwrap();
+        fs::write(workspace.join("Cargo.lock"), "# lock").unwrap();
+        fs::write(workspace.join("battery-pack.toml"), "# bp").unwrap();
+
+        let lock_mtime = file_mtime(&workspace.join("Cargo.lock")).unwrap();
+        // Cached state doesn't know about battery-pack.toml yet
+        let state = WorkspaceState {
+            last_sync_lock_mtime: Some(lock_mtime),
+            last_sync_battery_pack_mtime: None,
+            workspace_root: None,
+        };
+        assert!(!state.sync_is_fresh(&workspace));
+    }
+
+    #[test]
+    fn sync_is_stale_when_battery_pack_mtime_differs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("project");
+        fs::create_dir_all(&workspace).unwrap();
+        fs::write(workspace.join("Cargo.lock"), "# lock").unwrap();
+        fs::write(workspace.join("battery-pack.toml"), "# bp").unwrap();
+
+        let lock_mtime = file_mtime(&workspace.join("Cargo.lock")).unwrap();
+        let state = WorkspaceState {
+            last_sync_lock_mtime: Some(lock_mtime),
+            last_sync_battery_pack_mtime: Some(0),
             workspace_root: None,
         };
         assert!(!state.sync_is_fresh(&workspace));
@@ -187,6 +266,7 @@ mod tests {
 
         let state = WorkspaceState {
             last_sync_lock_mtime: Some(1234567890),
+            last_sync_battery_pack_mtime: None,
             workspace_root: None,
         };
         assert!(!state.sync_is_fresh(&workspace));

--- a/src/workspace_state.rs
+++ b/src/workspace_state.rs
@@ -131,7 +131,8 @@ fn workspace_dir_name(workspace_root: &Path) -> String {
 fn state_file_path(sym: &Symposium, workspace_root: &Path) -> PathBuf {
     // Canonicalize so that symlink variants (e.g. /var vs /private/var on
     // macOS) hash to the same cache directory.
-    let canonical = fs::canonicalize(workspace_root).unwrap_or_else(|_| workspace_root.to_path_buf());
+    let canonical =
+        fs::canonicalize(workspace_root).unwrap_or_else(|_| workspace_root.to_path_buf());
     sym.cache_dir()
         .join("workspaces")
         .join(workspace_dir_name(&canonical))

--- a/src/workspace_state.rs
+++ b/src/workspace_state.rs
@@ -1,0 +1,234 @@
+//! Per-workspace persistent state.
+//!
+//! Stored under `~/.symposium/cache/workspaces/<name>-<hash>/state.json`.
+//! The directory name uses the workspace root's final component for
+//! readability and an 8-hex-char SHA-256 prefix of the full path for
+//! uniqueness.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::Symposium;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WorkspaceState {
+    #[serde(default, rename = "last-sync-lock-mtime")]
+    pub last_sync_lock_mtime: Option<u64>,
+
+    #[serde(default, rename = "workspace-root")]
+    pub workspace_root: Option<PathBuf>,
+}
+
+impl WorkspaceState {
+    pub fn load(sym: &Symposium, workspace_root: &Path) -> Self {
+        let path = state_file_path(sym, workspace_root);
+        let Ok(contents) = fs::read_to_string(path) else {
+            return Self::default();
+        };
+        serde_json::from_str(&contents).unwrap_or_default()
+    }
+
+    pub fn save(&self, sym: &Symposium, workspace_root: &Path) {
+        let path = state_file_path(sym, workspace_root);
+        if let Some(parent) = path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        if let Ok(contents) = serde_json::to_string_pretty(self) {
+            let _ = fs::write(path, contents);
+        }
+    }
+
+    pub fn sync_is_fresh(&self, workspace_root: &Path) -> bool {
+        let Some(cached_mtime) = self.last_sync_lock_mtime else {
+            return false;
+        };
+        let Some(current_mtime) = cargo_lock_mtime(workspace_root) else {
+            return false;
+        };
+        cached_mtime == current_mtime
+    }
+
+    pub fn record_sync(&mut self, workspace_root: &Path) {
+        self.last_sync_lock_mtime = cargo_lock_mtime(workspace_root);
+    }
+}
+
+/// Find the workspace root via `cargo locate-project --workspace`.
+/// Fast (~10-50ms) and follows cargo's actual workspace discovery logic.
+pub fn find_workspace_root(sym: &Symposium, cwd: &Path) -> Option<PathBuf> {
+    let output = sym
+        .cargo_command()
+        .args(["locate-project", "--workspace", "--message-format=plain"])
+        .current_dir(cwd)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let manifest = String::from_utf8(output.stdout).ok()?;
+    Path::new(manifest.trim()).parent().map(|p| p.to_path_buf())
+}
+
+fn cargo_lock_mtime(workspace_root: &Path) -> Option<u64> {
+    let lock_path = workspace_root.join("Cargo.lock");
+    let meta = fs::metadata(&lock_path).ok()?;
+    let mtime = meta.modified().ok()?;
+    Some(
+        mtime
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+    )
+}
+
+fn workspace_dir_name(workspace_root: &Path) -> String {
+    use sha2::{Digest, Sha256};
+    use std::fmt::Write;
+
+    let tail = workspace_root
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("workspace");
+
+    let digest = Sha256::digest(workspace_root.as_os_str().as_encoded_bytes());
+    let mut hash = String::with_capacity(8);
+    for byte in &digest[..4] {
+        write!(hash, "{byte:02x}").unwrap();
+    }
+
+    format!("{tail}-{hash}")
+}
+
+fn state_file_path(sym: &Symposium, workspace_root: &Path) -> PathBuf {
+    sym.cache_dir()
+        .join("workspaces")
+        .join(workspace_dir_name(workspace_root))
+        .join("state.json")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workspace_dir_name_uses_tail_and_hash() {
+        let name = workspace_dir_name(Path::new("/users/dev/symposium"));
+        assert!(name.starts_with("symposium-"));
+        assert_eq!(name.len(), "symposium-".len() + 8);
+    }
+
+    #[test]
+    fn different_paths_same_tail_get_different_hashes() {
+        let a = workspace_dir_name(Path::new("/home/alice/myproject"));
+        let b = workspace_dir_name(Path::new("/home/bob/myproject"));
+        assert_ne!(a, b);
+        assert!(a.starts_with("myproject-"));
+        assert!(b.starts_with("myproject-"));
+    }
+
+    #[test]
+    fn roundtrip_save_load() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sym = Symposium::from_dir(tmp.path());
+        let workspace = tmp.path().join("project");
+        fs::create_dir_all(&workspace).unwrap();
+
+        let mut state = WorkspaceState::default();
+        state.last_sync_lock_mtime = Some(1234567890);
+        state.workspace_root = Some(workspace.clone());
+        state.save(&sym, &workspace);
+
+        let loaded = WorkspaceState::load(&sym, &workspace);
+        assert_eq!(loaded.last_sync_lock_mtime, Some(1234567890));
+        assert_eq!(loaded.workspace_root, Some(workspace));
+    }
+
+    #[test]
+    fn sync_is_fresh_when_mtime_matches() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("project");
+        fs::create_dir_all(&workspace).unwrap();
+        fs::write(workspace.join("Cargo.lock"), "# lock").unwrap();
+
+        let mtime = cargo_lock_mtime(&workspace).unwrap();
+        let state = WorkspaceState {
+            last_sync_lock_mtime: Some(mtime),
+            workspace_root: None,
+        };
+        assert!(state.sync_is_fresh(&workspace));
+    }
+
+    #[test]
+    fn sync_is_stale_when_mtime_differs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("project");
+        fs::create_dir_all(&workspace).unwrap();
+        fs::write(workspace.join("Cargo.lock"), "# lock").unwrap();
+
+        let state = WorkspaceState {
+            last_sync_lock_mtime: Some(0),
+            workspace_root: None,
+        };
+        assert!(!state.sync_is_fresh(&workspace));
+    }
+
+    #[test]
+    fn sync_is_stale_when_no_lock_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("project");
+        fs::create_dir_all(&workspace).unwrap();
+
+        let state = WorkspaceState {
+            last_sync_lock_mtime: Some(1234567890),
+            workspace_root: None,
+        };
+        assert!(!state.sync_is_fresh(&workspace));
+    }
+
+    #[test]
+    fn sync_is_stale_when_no_cached_mtime() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("project");
+        fs::create_dir_all(&workspace).unwrap();
+        fs::write(workspace.join("Cargo.lock"), "# lock").unwrap();
+
+        let state = WorkspaceState::default();
+        assert!(!state.sync_is_fresh(&workspace));
+    }
+
+    #[test]
+    fn find_workspace_root_finds_workspace_from_subdir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("project");
+        let src = root.join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(
+            root.join("Cargo.toml"),
+            "[package]\nname = \"test\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .unwrap();
+        fs::write(src.join("lib.rs"), "").unwrap();
+
+        let sym = Symposium::from_dir(tmp.path());
+        let found = find_workspace_root(&sym, &src);
+        assert_eq!(found, Some(root));
+    }
+
+    #[test]
+    fn find_workspace_root_returns_none_without_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let subdir = tmp.path().join("no-rust-here");
+        fs::create_dir_all(&subdir).unwrap();
+
+        let sym = Symposium::from_dir(tmp.path());
+        let found = find_workspace_root(&sym, &subdir);
+        assert!(found.is_none());
+    }
+}

--- a/tests/init_sync.rs
+++ b/tests/init_sync.rs
@@ -1686,3 +1686,123 @@ async fn session_start_hook_warns_about_update_in_context() {
     .await
     .unwrap();
 }
+
+#[tokio::test]
+async fn auto_sync_skips_when_cargo_lock_unchanged() {
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["plugins0", "workspace0"],
+        async |mut ctx| {
+            ctx.symposium(&["init", "--add-agent", "claude"]).await?;
+
+            let workspace_root = ctx.workspace_root.clone().unwrap();
+
+            // First hook call: should trigger sync and install skills.
+            let steps = [symposium_testlib::HookStep::PreToolUse {
+                    tool_name: "Bash".to_string(),
+                    tool_input: serde_json::json!({}),
+                }];
+            ctx.prompt_or_hook(
+                "test",
+                &steps,
+                symposium::hook_schema::HookAgent::Claude,
+            )
+            .await?;
+
+            // Verify workspace state was recorded (Cargo.lock should exist
+            // after cargo metadata runs during sync).
+            let state =
+                symposium::workspace_state::WorkspaceState::load(&ctx.sym, &workspace_root);
+            assert!(
+                state.last_sync_lock_mtime.is_some(),
+                "workspace state should have recorded lock mtime after first sync"
+            );
+
+            // Record the skill directory's mtime to detect if sync runs again.
+            let skill_dir = workspace_root.join(".claude").join("skills");
+            let mtime_before = std::fs::metadata(&skill_dir)
+                .and_then(|m| m.modified())
+                .ok();
+
+            // Small sleep to ensure mtime would differ if dir were rewritten.
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+            // Second hook call: should skip sync (Cargo.lock unchanged).
+            ctx.prompt_or_hook(
+                "test",
+                &steps,
+                symposium::hook_schema::HookAgent::Claude,
+            )
+            .await?;
+
+            // The skills directory mtime should be unchanged (sync was skipped).
+            let mtime_after = std::fs::metadata(&skill_dir)
+                .and_then(|m| m.modified())
+                .ok();
+            assert_eq!(
+                mtime_before, mtime_after,
+                "skills directory should not be modified on second hook (sync should be skipped)"
+            );
+
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn auto_sync_reruns_when_cargo_lock_changes() {
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["plugins0", "workspace0"],
+        async |mut ctx| {
+            ctx.symposium(&["init", "--add-agent", "claude"]).await?;
+
+            let workspace_root = ctx.workspace_root.clone().unwrap();
+
+            // First hook call: triggers sync.
+            let steps = [symposium_testlib::HookStep::PreToolUse {
+                    tool_name: "Bash".to_string(),
+                    tool_input: serde_json::json!({}),
+                }];
+            ctx.prompt_or_hook(
+                "test",
+                &steps,
+                symposium::hook_schema::HookAgent::Claude,
+            )
+            .await?;
+
+            let state =
+                symposium::workspace_state::WorkspaceState::load(&ctx.sym, &workspace_root);
+            assert!(state.last_sync_lock_mtime.is_some());
+
+            // Simulate a dependency change by faking a stale mtime in the
+            // workspace state (avoids needing filesystem mtime granularity).
+            let mut stale_state = state.clone();
+            stale_state.last_sync_lock_mtime = Some(0);
+            stale_state.save(&ctx.sym, &workspace_root);
+
+            // Second hook call: should re-sync because Cargo.lock changed.
+            ctx.prompt_or_hook(
+                "test",
+                &steps,
+                symposium::hook_schema::HookAgent::Claude,
+            )
+            .await?;
+
+            // Workspace state should be updated with real mtime (not 0).
+            let state2 =
+                symposium::workspace_state::WorkspaceState::load(&ctx.sym, &workspace_root);
+            assert_ne!(
+                state2.last_sync_lock_mtime,
+                Some(0),
+                "workspace state mtime should be refreshed after stale cache triggers re-sync"
+            );
+
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+}

--- a/tests/init_sync.rs
+++ b/tests/init_sync.rs
@@ -1699,20 +1699,15 @@ async fn auto_sync_skips_when_cargo_lock_unchanged() {
 
             // First hook call: should trigger sync and install skills.
             let steps = [symposium_testlib::HookStep::PreToolUse {
-                    tool_name: "Bash".to_string(),
-                    tool_input: serde_json::json!({}),
-                }];
-            ctx.prompt_or_hook(
-                "test",
-                &steps,
-                symposium::hook_schema::HookAgent::Claude,
-            )
-            .await?;
+                tool_name: "Bash".to_string(),
+                tool_input: serde_json::json!({}),
+            }];
+            ctx.prompt_or_hook("test", &steps, symposium::hook_schema::HookAgent::Claude)
+                .await?;
 
             // Verify workspace state was recorded (Cargo.lock should exist
             // after cargo metadata runs during sync).
-            let state =
-                symposium::workspace_state::WorkspaceState::load(&ctx.sym, &workspace_root);
+            let state = symposium::workspace_state::WorkspaceState::load(&ctx.sym, &workspace_root);
             assert!(
                 state.last_sync_lock_mtime.is_some(),
                 "workspace state should have recorded lock mtime after first sync"
@@ -1728,12 +1723,8 @@ async fn auto_sync_skips_when_cargo_lock_unchanged() {
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
             // Second hook call: should skip sync (Cargo.lock unchanged).
-            ctx.prompt_or_hook(
-                "test",
-                &steps,
-                symposium::hook_schema::HookAgent::Claude,
-            )
-            .await?;
+            ctx.prompt_or_hook("test", &steps, symposium::hook_schema::HookAgent::Claude)
+                .await?;
 
             // The skills directory mtime should be unchanged (sync was skipped).
             let mtime_after = std::fs::metadata(&skill_dir)
@@ -1763,18 +1754,13 @@ async fn auto_sync_reruns_when_cargo_lock_changes() {
 
             // First hook call: triggers sync.
             let steps = [symposium_testlib::HookStep::PreToolUse {
-                    tool_name: "Bash".to_string(),
-                    tool_input: serde_json::json!({}),
-                }];
-            ctx.prompt_or_hook(
-                "test",
-                &steps,
-                symposium::hook_schema::HookAgent::Claude,
-            )
-            .await?;
+                tool_name: "Bash".to_string(),
+                tool_input: serde_json::json!({}),
+            }];
+            ctx.prompt_or_hook("test", &steps, symposium::hook_schema::HookAgent::Claude)
+                .await?;
 
-            let state =
-                symposium::workspace_state::WorkspaceState::load(&ctx.sym, &workspace_root);
+            let state = symposium::workspace_state::WorkspaceState::load(&ctx.sym, &workspace_root);
             assert!(state.last_sync_lock_mtime.is_some());
 
             // Simulate a dependency change by faking a stale mtime in the
@@ -1784,12 +1770,8 @@ async fn auto_sync_reruns_when_cargo_lock_changes() {
             stale_state.save(&ctx.sym, &workspace_root);
 
             // Second hook call: should re-sync because Cargo.lock changed.
-            ctx.prompt_or_hook(
-                "test",
-                &steps,
-                symposium::hook_schema::HookAgent::Claude,
-            )
-            .await?;
+            ctx.prompt_or_hook("test", &steps, symposium::hook_schema::HookAgent::Claude)
+                .await?;
 
             // Workspace state should be updated with real mtime (not 0).
             let state2 =


### PR DESCRIPTION
Add per-workspace state cache that records the Cargo.lock mtime after each successful sync. On subsequent hook invocations, if the mtime hasn't changed, skip the expensive cargo metadata + sync entirely.

This eliminates ~1.5s of latency on every tool call when auto-sync is enabled, since cargo metadata no longer runs redundantly.

## What does this PR do?

<!-- Explain the purpose, key logic, etc. -->

<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

<!-- Symposium is an AI project. We encourage the use of agentic tooling! We do however require disclosure. The disclosure helps us to calibrate our reviews. See our [PR disclosure policy](https://symposium-dev.github.io/symposium/design/governance.html#pr-disclosure-policy). -->

<!-- Remove the items that do not apply. -->

* The AI tool authored large parts of the code

**Questions for reviewers.**

<!-- Any specific areas of uncertainty or things you'd like reviewers to look at? -->

</details>
