### PR TITLE
Hooks 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2447,6 +2447,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "sha2",
+ "symposium-hook",
  "symposium-testlib",
  "tar",
  "tempfile",
@@ -2456,6 +2457,17 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+]
+
+[[package]]
+name = "symposium-hook"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "regex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ serde_yaml_ng = "0.10"
 sha2 = "0.10"
 tar = "0.4"
 tempfile = "3.6"
+symposium-hook = { path = "symposium-hook", features = ["clap"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 toml = "0.8"
 tracing = "0.1"
@@ -60,4 +61,4 @@ indoc = "2.0.7"
 symposium-testlib = { path = "symposium-testlib" }
 
 [workspace]
-members = [".", "symposium-testlib"]
+members = [".", "symposium-testlib", "symposium-hook"]

--- a/md/SUMMARY.md
+++ b/md/SUMMARY.md
@@ -25,6 +25,7 @@
 
 - [Supporting your crate](./crate-authors/supporting-your-crate.md)
 - [Authoring a plugin](./crate-authors/authoring-a-plugin.md)
+- [Writing a hook handler](./crate-authors/writing-a-hook-handler.md)
 
 # Appendices
 
@@ -48,9 +49,11 @@
   - [Configuration](./reference/configuration.md)
   - [Plugin sources](./reference/plugin-source.md)
   - [Plugin definition](./reference/plugin-definition.md)
+  - [Symposium hook events](./reference/hook-events.md)
   - [Skill definition](./reference/skill-definition.md)
   - [Crate predicates](./reference/crate-predicates.md)
 - [Contribution guide](./design/welcome.md)
+  - [Tenets](./design/tenets.md)
   - [Key repositories](./design/repositories.md)
   - [Key modules](./design/module-structure.md)
   - [Configuration loading](./design/configuration-loading.md)

--- a/md/crate-authors/authoring-a-plugin.md
+++ b/md/crate-authors/authoring-a-plugin.md
@@ -1,8 +1,30 @@
 # Authoring a plugin
 
-Symposium lets you ship skills, hooks, and MCP servers that are automatically loaded when a user's project depends on your crate. This page walks through the options, starting with the simplest.
+Symposium lets you ship skills, hooks, and MCP servers that are automatically loaded when a user's project depends on your crate. This page walks through how to create a plugin and configure each extension type.
 
-## Skills
+## Step 1. Create a `SYMPOSIUM.toml` manifest
+
+Every plugin starts with a `SYMPOSIUM.toml` manifest uploaded to the [central recommendations repository][rr]. The manifest declares your plugin's name, which crates it applies to, and what extensions it provides.
+
+```toml
+# `my-crate/SYMPOSIUM.toml` on the symposium-dev/recommendations repository
+name = "my-crate"
+crates = ["my-crate"]
+```
+
+The `crates` field controls when the plugin is active — it will only load for projects that depend on the listed crates. Use `["*"]` to apply to all projects.
+
+See the [plugin definition reference](../reference/plugin-definition.md) for the full manifest schema.
+
+### Why is the central repository required?
+
+We currently require an entry in our central [recommendations repository][rr] before Symposium will install a plugin. This protects against malicious plugins (e.g., from typosquatting crates) and lets us centrally yank a plugin that proves problematic. Once Symposium has reached a steady state and we have established security protocols we are comfortable with, we expect to lift this requirement.
+
+## Step 2. Add skills, hooks, and/or MCP servers
+
+With your manifest in place, you can add any combination of the extension types below.
+
+### Skills
 
 Skills are guidance documents that teach AI assistants how to use a crate. Each skill is a directory containing a `SKILL.md` file with YAML frontmatter and a markdown body:
 
@@ -18,9 +40,11 @@ Always call `.validate()` before passing widgets to the runtime.
 
 See the [Skill definition reference](../reference/skill-definition.md) for the full format and the [agentskills.io quickstart](https://agentskills.io/skill-creation/quickstart) for writing effective skills.
 
-### Embedding skills in your crate (recommended)
+#### Embedding skills in your crate (recommended)
 
-If you maintain the crate, we recommend shipping skills directly in your source tree. Place skill directories under `skills/`:
+If you maintain the crate, we recommend shipping skills directly in your source tree. This way users always get skills matching the exact version they have installed.
+
+##### 1. Put skills in your crate sources under `skills/`
 
 ```
 my-crate/
@@ -34,9 +58,10 @@ my-crate/
             SKILL.md
 ```
 
-To make Symposium aware of your skills, open a PR adding a plugin manifest to the [central recommendations repository][rr]. This is a small TOML file that tells Symposium to look inside your crate's source:
+##### 2. Add `source = "crate"` to your manifest
 
 ```toml
+# `my-crate/SYMPOSIUM.toml` on the symposium-dev/recommendations repository
 name = "my-crate"
 crates = ["my-crate"]
 
@@ -44,25 +69,40 @@ crates = ["my-crate"]
 source = "crate"
 ```
 
-Symposium fetches the crate source (from the local cargo cache or crates.io) and discovers the skills. Users always get skills matching the version they have installed.
+Symposium fetches the crate source (from the local cargo cache or crates.io) and discovers skills in the `skills/` directory.
 
-We recommend placing skills in `skills/`, but if you prefer a different directory, you can use `source.crate_path`:
+##### Prefer a directory other than `skills/`?
+
+Use `source.crate_path` to specify a custom path:
 
 ```toml
 [[skills]]
-source.crate_path = "skills"
+source.crate_path = "docs/agent-skills"
 ```
 
-### Standalone skills (for third-party crates)
+#### Standalone skills (on the recommendations repo)
 
-You can also upload skills as standalone directories — without embedding them in the crate source. This is the right approach when you're writing skills for a crate you don't maintain. We prefer crates to ship their own skills, but some crates may not want to or may not be actively maintained. We accept skills for those crates to help bootstrap the ecosystem.
+You can also upload skills directly to the [recommendations repo][rr] — without embedding them in the crate source. This is the right approach when you're writing skills for a crate you don't maintain.
 
-Standalone skills are uploaded directly to the [recommendations repo][rr] so that we can vet them. The expected directory structure is:
+Place skill directories alongside your `SYMPOSIUM.toml`:
 
 ```
-crate-name/
-    skill-name/
+my-crate/
+    SYMPOSIUM.toml
+    basics/
         SKILL.md
+    advanced-patterns/
+        SKILL.md
+```
+
+And point the manifest at the local directory:
+
+```toml
+name = "my-crate"
+crates = ["my-crate"]
+
+[[skills]]
+source.path = "."
 ```
 
 Standalone skills **must** include `crates` in their frontmatter so Symposium knows which crate they apply to:
@@ -77,76 +117,100 @@ crates: widgetlib=1.0
 Guidance body here.
 ```
 
-### Why is the central repository required?
+#### Skills from a git repository
 
-We currently require an entry in our central [recommendations repository][rr] before Symposium will install skills. This protects against malicious skills (e.g., from typosquatting crates) and lets us centrally yank a plugin that proves problematic. Once Symposium has reached a steady state and we have established security protocols we are comfortable with, we expect to lift this requirement.
-
-## Plugins
-
-If you need more than skills — hooks, MCP servers, or skills hosted in a separate git repo — you can upgrade to a full plugin by adding a `SYMPOSIUM.toml` manifest.
-
-For example, if you already have standalone skills in the recommendations repo:
-
-```
-my-crate/
-    basics/
-        SKILL.md
-    advanced-patterns/
-        SKILL.md
-```
-
-You can add a `SYMPOSIUM.toml` alongside them:
-
-```
-my-crate/
-    SYMPOSIUM.toml
-    basics/
-        SKILL.md
-    advanced-patterns/
-        SKILL.md
-```
-
-With the manifest:
+Symposium also supports fetching skills from a GitHub URL:
 
 ```toml
-name = "my-crate"
-crates = ["my-crate"]
-
 [[skills]]
-source.path = "."
+source.git = "https://github.com/org/my-crate/tree/main/symposium/skills"
 ```
 
-The `source.path = "."` tells Symposium to look for skills in the same directory as the manifest. Now that you have a plugin, you can add hooks and MCP servers.
+This is useful for hosting skills in a dedicated repository or a subdirectory of a monorepo. Note that the central recommendations repository does not currently accept `source.git` entries by policy — use `source = "crate"` or `source.path` for submissions there.
+
+### Installing auxiliary tools
+
+An **installation** tells symposium how to obtain a binary that your hooks or MCP servers will run. The recommended approach is a `cargo` installation, which installs a crate binary from crates.io:
+
+```toml
+[[installations]]
+name = "my-crate-hooks"
+source = "cargo"
+crate = "my-crate-hooks"
+executable = "my-crate-hooks"
+```
+
+Symposium caches the binary under `~/.symposium/cache/`. Binaries are updated automatically when new versions are available on [crates.io](https://crates.io/).
+
+See the [plugin definition reference](../reference/plugin-definition.md#installations) for other installation sources (GitHub repositories, local paths) and advanced options like `install_commands`.
 
 ### Hooks
 
-Hooks run when the AI performs certain actions, like invoking a tool or starting a session. Add a `[[hooks]]` entry to your manifest:
+Hooks run when the AI performs certain actions — invoking a tool, starting a session, or submitting a prompt. They receive JSON on stdin describing the event and can return guidance, inject context, or block the action.
+
+Every agent varies in the specifics of what hooks it offers and how those hooks are configured. Symposium allows you to provide agent-specific hook handlers, but we recommend instead using a *Symposium hook* handler, which is portable across all agents.
+
+#### Symposium hooks (portable across agents)
+
+To define a Symposium hook handler you add a `[[hooks]]` section. This defines the command to run as well as the events it expects and other filters. 
 
 ```toml
 [[hooks]]
 name = "check-usage"
 event = "PreToolUse"
 matcher = "Bash"
-command = "./scripts/check.sh"
+command = "my-crate-hook-command"
 ```
 
-The hook receives JSON on stdin describing the tool invocation and can return guidance or block the action. See the [plugin definition reference](../reference/plugin-definition.md#hooks) for supported events, wire formats, and semantics.
+The `command` field references the name of an installation defined in [the `[[installations]]` section](#installations) described previously. For example:
+
+```toml
+[[installations]]
+name = "my-crate-hook-command"
+source = "cargo"
+crate = "my-crate-hooks"
+executable = "my-crate-hooks"
+```
+
+The hook binary receives symposium canonical JSON on stdin and writes symposium canonical JSON to stdout. Symposium handles converting to and from each agent's wire format, so a single implementation works across all supported agents. See [Writing a hook handler](./writing-a-hook-handler.md) for how to implement the binary using the `symposium-hook` crate, and [Symposium hook events](../reference/hook-events.md) for input/output JSON schemas.
+
+#### Agent-specific hooks
+
+You can also provide hooks specialized for a particular agent by setting `format` to an agent name. The handler receives that agent's native wire format on stdin — giving you access to agent-specific features (e.g., Claude Code's `updatedInput`, Copilot's `modifiedArgs`). Symposium still intermediates; it just delivers in the declared format instead of converting to canonical. On agents without a matching hook, symposium falls back to delivering any symposium-format hook the plugin declares.
+
+```toml
+[[hooks]]
+name = "check-usage-claude"
+event = "PreToolUse"
+format = "claude"
+command = "my-crate-hooks"
+args = ["--claude"]
+```
+
+On Claude, `check-usage-claude` fires (receives Claude's native JSON). On other agents, `check-usage` fires (receives symposium canonical JSON). See the [plugin definition reference](../reference/plugin-definition.md#hooks) for the full `[[hooks]]` manifest syntax.
 
 ### MCP servers
 
-MCP servers expose tools and resources to agents via the [Model Context Protocol](https://modelcontextprotocol.io/). Symposium registers them into each agent's configuration during sync.
+MCP servers expose tools and resources to agents via the [Model Context Protocol](https://modelcontextprotocol.io/). Symposium registers them into each agent's configuration during sync — you declare the server once and it works across all agents.
+
+An MCP server typically uses the same installation as your hooks:
 
 ```toml
+[[installations]]
+name = "my-crate-mcp"
+source = "cargo"
+crate = "my-crate-mcp"
+executable = "my-crate-mcp"
+
 [[mcp_servers]]
 name = "my-crate-tools"
-command = "my-crate-mcp-server"
+command = "my-crate-mcp"
 args = ["--stdio"]
-env = []
 ```
 
 See the [plugin definition reference](../reference/plugin-definition.md#mcp_servers) for HTTP and SSE transports, crate filtering, and registration details.
 
-## Validation
+## Step 3. Validate your plugin
 
 Before submitting a PR, validate your plugin or skill directory to catch errors early — missing fields, bad crate predicates, unreachable skill paths, and crate names that don't exist on crates.io. You can run this on your local checkout of the recommendations repo once you've prepared your changes:
 

--- a/md/crate-authors/writing-a-hook-handler.md
+++ b/md/crate-authors/writing-a-hook-handler.md
@@ -1,0 +1,132 @@
+# Writing a hook handler
+
+This guide walks through writing a symposium hook handler in Rust using the `symposium-hook` crate.
+
+## Step 1. Create a new binary crate
+
+Create your new crate:
+
+```bash
+cargo new my-hook-handler
+cd my-hook-handler
+```
+
+And then add symposium-hook to your dependencies:
+
+```bash
+cargo add symposium-hook
+```
+
+## Step 2. Write the handler
+
+A hook handler is a program that reads a JSON event on stdin and writes a JSON response to stdout. The `symposium-hook` crate provides a `HookHandler` trait and a `run()` harness that handles the plumbing.
+
+Implement `HookHandler` and override the methods for the events you care about:
+
+```rust
+// src/main.rs
+use std::process::ExitCode;
+use symposium_hook::{HookHandler, PreToolUseInput, PreToolUseOutput, run};
+
+struct MyHook;
+
+impl HookHandler for MyHook {
+    fn pre_tool_use(&self, event: &PreToolUseInput) -> anyhow::Result<PreToolUseOutput> {
+        if event.tool_name == "Bash" {
+            Ok(PreToolUseOutput::context("Remember: prefer non-destructive commands"))
+        } else {
+            Ok(PreToolUseOutput::default())
+        }
+    }
+}
+
+fn main() -> ExitCode {
+    run(MyHook)
+}
+```
+
+The `run()` function:
+
+1. Reads symposium canonical JSON from stdin.
+2. Deserializes it into an `Input` event.
+3. Calls `handler.handle_event()`, which dispatches to the appropriate method.
+4. Serializes the output to stdout.
+
+You only need to override the methods you care about — unimplemented methods return the default (empty) output for their event type.
+
+## Step 3. Register it in your plugin manifest
+
+In your `SYMPOSIUM.toml`, reference the built binary as a hook command:
+
+```toml
+name = "my-crate"
+crates = ["my-crate"]
+
+[[hooks]]
+name = "check-usage"
+event = "PreToolUse"
+command = { source = "cargo", crate = "my-hook-handler", executable = "my-hook-handler" }
+```
+
+## Output types
+
+Each handler method returns its event-specific output type:
+
+| Method | Return type | Key fields |
+|--------|-------------|------------|
+| `pre_tool_use` | `PreToolUseOutput` | `additional_context`, `updated_input` |
+| `post_tool_use` | `PostToolUseOutput` | `additional_context` |
+| `user_prompt_submit` | `UserPromptSubmitOutput` | `additional_context` |
+| `session_start` | `SessionStartOutput` | `additional_context` |
+
+Each output type has convenience constructors:
+
+- `::default()` — empty output, no-op.
+- `::context("...")` — inject text into the agent's context.
+- `PreToolUseOutput::with_updated_input(value)` — replace the tool input.
+- `PreToolUseOutput::deny("reason")` — block the tool call with a reason.
+
+Return `Err(...)` from any method to report an error (exit code 1, message on stderr).
+
+## The `HookHandler` trait
+
+```rust
+pub trait HookHandler {
+    fn handle_event(&self, input: &Input) -> anyhow::Result<Output> { /* dispatches */ }
+    fn pre_tool_use(&self, event: &PreToolUseInput) -> anyhow::Result<PreToolUseOutput> { /* default */ }
+    fn post_tool_use(&self, event: &PostToolUseInput) -> anyhow::Result<PostToolUseOutput> { /* default */ }
+    fn user_prompt_submit(&self, event: &UserPromptSubmitInput) -> anyhow::Result<UserPromptSubmitOutput> { /* default */ }
+    fn session_start(&self, event: &SessionStartInput) -> anyhow::Result<SessionStartOutput> { /* default */ }
+}
+```
+
+Override `handle_event` only if you need custom dispatch logic (e.g., shared state across events). Otherwise, just override the per-event methods.
+
+## Testing locally
+
+You can test your handler by piping JSON directly:
+
+```bash
+cargo build
+echo '{"PreToolUse":{"tool_name":"Bash","tool_input":{"command":"rm -rf /"},"session_id":null,"cwd":"/tmp"}}' \
+  | ./target/debug/my-hook-handler
+```
+
+Or via the symposium CLI:
+
+```bash
+echo '{"PreToolUse":{"tool_name":"Bash","tool_input":{"command":"rm -rf /"},"session_id":null,"cwd":"/tmp"}}' \
+  | cargo agents hook symposium pre-tool-use
+```
+
+## Example: blocking destructive commands
+
+```rust
+{{#include ../../symposium-hook/examples/block_destructive.rs}}
+```
+
+## Example: injecting context on session start
+
+```rust
+{{#include ../../symposium-hook/examples/inject_context.rs}}
+```

--- a/md/design/hook-flow.md
+++ b/md/design/hook-flow.md
@@ -7,15 +7,18 @@ Entry point invoked by the agent's hook system on session events.
 1. **Auto-sync** (if enabled) — when `auto-sync = true` in the user config, runs [`cargo agents sync`](./sync-agent-flow.md) to ensure skills are current. The workspace root is resolved from the payload's `cwd` field; if the payload does not include a working directory, the process's current working directory is used as a fallback. Runs quietly and non-fatally — failures are logged but don't block hook dispatch.
 
 2. **Dispatch to plugin hooks** — for each enabled plugin that defines a hook handler for the incoming event:
-   - Ensure any `requirements` for the hook are acquired (on-demand, best-effort).
-   - Resolve the hook's `command` (a named installation reference or inline declaration) into a runnable form:
-     - If the installation declares a `source`, acquire it (install / cache / clone) and resolve the `executable` / `script` against the cached location.
-     - If no source, the `executable` / `script` is taken as a path on disk.
-     - Run the installation's `install_commands` (post-source) before invoking the runnable.
-     - Spawn `path args…` directly for `Exec`, or `sh path args…` for `Script`.
-   - Pass the event JSON on stdin to the plugin's hook.
-   - Collect output from each handler.
-   - Merge results (e.g., allow/block decisions, output text) across all handlers.
-   - Return the merged result to the agent.
+   - **Select format**: for each plugin, pick the best hook to deliver (see [Hooks](./hooks.md) for priority rules). If the plugin has a hook matching the current agent's format, deliver the input unmodified. Otherwise deliver in symposium canonical format (or convert to the declared format if only one non-symposium hook exists).
+   - **Acquire and run**:
+     - Ensure any `requirements` for the hook are acquired (on-demand, best-effort).
+     - Resolve the hook's `command` (a named installation reference or inline declaration) into a runnable form:
+       - If the installation declares a `source`, acquire it (install / cache / clone) and resolve the `executable` / `script` against the cached location.
+       - If no source, the `executable` / `script` is taken as a path on disk.
+       - Run the installation's `install_commands` (post-source) before invoking the runnable.
+       - Spawn `path args…` directly for `Exec`, or `sh path args…` for `Script`.
+     - Pass the event JSON (in the selected format) on stdin to the plugin's hook.
+     - Collect output from each handler.
+     - Convert output back to the agent's wire format.
+     - Merge results (e.g., allow/block decisions, output text) across all handlers.
+     - Return the merged result to the agent.
 
 Plugin hooks can respond to agent-specific events (e.g., `pre-tool-use`, `post-tool-use`, `user-prompt-submit` for Claude Code). The available events depend on which agent is in use.

--- a/md/design/hooks.md
+++ b/md/design/hooks.md
@@ -1,1 +1,41 @@
 # Hooks
+
+Symposium's hook system is guided by the project [tenets](./tenets.md): symposium is always the intermediary, it never dirties the user's repo, and portability is the default.
+
+## Hook formats
+
+A plugin hook declares which wire format its handler expects:
+
+- `format = "symposium"` (default) — the handler receives symposium canonical JSON. This is portable across all agents.
+- `format = "claude"` / `"copilot"` / `"gemini"` / `"codex"` / `"kiro"` — the handler receives that agent's native wire format.
+
+## Dispatch rule
+
+When symposium's global handler receives an event from agent A, it loads all plugins and finds hooks matching the event. For each plugin, it picks at most one hook to deliver:
+
+1. If the plugin declares a hook with `format` matching **agent A** → deliver the input unmodified (the handler already expects this agent's native format).
+2. Otherwise, if the plugin declares a **symposium-format** hook → convert to symposium canonical and deliver.
+3. Otherwise → nothing fires for this plugin.
+
+Symposium never converts between agent-specific formats. A `format = "claude"` hook will only fire on Claude — it won't be translated for Copilot or Gemini. If you want cross-agent coverage, provide a symposium-format hook as a fallback.
+
+### Example
+
+A plugin with hooks for `claude`, `gemini`, and `symposium`:
+- On Claude: the `format = "claude"` hook receives Claude's native JSON.
+- On Gemini: the `format = "gemini"` hook receives Gemini's native JSON.
+- On Copilot: no native handler → the `format = "symposium"` hook receives symposium canonical JSON.
+
+A plugin with only `format = "symposium"`:
+- Works on all agents. Symposium converts the agent's wire format to canonical before delivering.
+
+A plugin with only `format = "claude"`:
+- On Claude: receives Claude's native JSON directly.
+- On other agents: nothing fires (no symposium fallback declared).
+
+## Output handling
+
+Symposium converts the hook's output back to the current agent's wire format before returning it to the agent:
+
+- Native format matching the host agent → pass through directly.
+- Symposium format → convert to host agent's wire format.

--- a/md/design/hooks.md
+++ b/md/design/hooks.md
@@ -39,3 +39,25 @@ Symposium converts the hook's output back to the current agent's wire format bef
 
 - Native format matching the host agent → pass through directly.
 - Symposium format → convert to host agent's wire format.
+
+## Alternatives considered
+
+### Registering agent-specific hooks directly
+
+An earlier design had symposium write plugin hook commands directly into agent configuration files (e.g., `.claude/settings.json`, `.github/hooks/*.json`) at sync time. The agent would invoke them natively, and symposium's global handler would skip delivery for those plugins.
+
+We rejected this because it violates the [Unobtrusive](./tenets.md#unobtrusive) tenet:
+
+- Agent config files are often git-tracked. Writing plugin hooks into them creates unexpected diffs that pollute pull requests and cause merge conflicts.
+- Users would need to `.gitignore` symposium-managed entries, or accept noise in their version history.
+- It couples symposium's state to files the user considers "theirs," making it harder to adopt or remove symposium cleanly.
+
+The current design avoids these problems by keeping symposium as the sole registered hook handler. Plugin hooks are dispatched internally — the agent's config only ever contains one symposium entry, registered at init time.
+
+### Cross-agent format conversion
+
+We also considered converting between agent-specific formats (e.g., delivering a `format = "claude"` hook on Copilot by translating Copilot's input into Claude's format). We rejected this because:
+
+- The conversion is lossy — agents have different fields, semantics, and capabilities.
+- It creates surprising behavior: a hook author declares `format = "claude"` expecting Claude's schema, but receives a synthetic approximation on other agents.
+- It's simpler and more predictable to require a symposium-format fallback for cross-agent coverage.

--- a/md/design/module-structure.md
+++ b/md/design/module-structure.md
@@ -18,7 +18,7 @@ Implements `cargo agents init`. Prompts for agents (or accepts `--add-agent`/`--
 
 ### `sync.rs` — synchronization command
 
-Implements `cargo agents sync`. Scans workspace dependencies, finds applicable skills from plugin sources, installs them into each configured agent's skill directory, and drops a `.symposium` marker file into each installed skill directory. On subsequent syncs, scans every agent's skills parent directory and reaps any marker-bearing subdirectory it didn't install this time, leaving user-managed skills (which lack the marker) untouched. Writes a `.gitignore` with `*` into every directory it creates. Also provides `register_hooks()` for use by `init`.
+Implements `cargo agents sync`. Scans workspace dependencies, finds applicable skills from plugin sources, installs them into each configured agent's skill directory, and drops a `.symposium` marker file into each installed skill directory. On subsequent syncs, scans every agent's skills parent directory and reaps any marker-bearing subdirectory it didn't install this time, leaving user-managed skills (which lack the marker) untouched. Writes a `.gitignore` with `*` into every directory it creates. Also provides `register_hooks()` for use by `init`, which registers only symposium's own global hook handler — individual plugin hooks are never written into agent configs.
 
 ### `plugins.rs` — plugin registry
 
@@ -47,7 +47,7 @@ Each applicable skill carries a `SkillOrigin` describing *where its bytes live*,
 
 ### `hook.rs` — hook handling
 
-Handles the hook pipeline: parse agent wire-format input → auto-sync → builtin dispatch → plugin hook dispatch → serialize output. The dispatch path matches plugin `Hook`s against the event, builds a `ResolvedHook` per match (looking up the named installations on the plugin), then for each `ResolvedHook`: acquires its `requirements` (best-effort), runs `install_commands` after the source step, picks a `Runnable` from (hook-or-install) `executable`/`script`, and spawns it (binary directly for `Exec`, via `sh <path>` for `Script`). Format routing converts hook output between agent wire formats and the symposium canonical format.
+Handles the hook pipeline: parse agent wire-format input → auto-sync → builtin dispatch → plugin hook dispatch → serialize output. The dispatch path matches plugin `Hook`s against the event, selects the best format for each plugin (native match > symposium > single-other-agent fallback), builds a `ResolvedHook` per match (looking up the named installations on the plugin), then for each `ResolvedHook`: acquires its `requirements` (best-effort), runs `install_commands` after the source step, picks a `Runnable` from (hook-or-install) `executable`/`script`, and spawns it (binary directly for `Exec`, via `sh <path>` for `Script`). Input is delivered in the selected format; output is converted back to the agent's wire format before returning.
 
 ### `state.rs` — persistent state
 

--- a/md/design/sync-agent-flow.md
+++ b/md/design/sync-agent-flow.md
@@ -21,7 +21,7 @@ Scans workspace dependencies, installs applicable skills into agent directories,
 
 7. **Reap stale skills** — across every known agent's skills parent directory, remove any subdirectory that contains the `.symposium` marker but wasn't installed this sync. Directories without the marker (user-managed) are left untouched.
 
-8. **Register hooks** — ensure global hooks and MCP servers are registered for all configured agents. Unregister hooks for agents no longer in the config.
+8. **Register hooks** — ensure symposium's global hook handler and MCP servers are registered for all configured agents. Unregister hooks for agents no longer in the config. Only symposium's own handler is registered (e.g., `cargo-agents hook claude pre-tool-use`) — individual plugin hooks are never written into agent configs. See [Hooks](./hooks.md) for the dispatch model.
 
 ## Marker file
 

--- a/md/design/tenets.md
+++ b/md/design/tenets.md
@@ -1,0 +1,31 @@
+# Tenets
+
+Design principles that guide symposium's architecture. When in doubt, these break ties.
+
+## Unobtrusive
+
+Symposium should never be a reason to opt out. Using it should be non-disruptive to existing workflows:
+
+- Existing projects should be able to adopt symposium without restructuring.
+- Never dirty the user's repo with unexpected files or diffs or require users to manually edit `.gitignore`.
+- Avoid adding "symposium-specific" files or modifications in project repositories (when possible).
+
+## Prefer existing standards over our own
+
+When there's an existing mechanism that works, use it rather than inventing a new one. Adopt agent conventions, standard file layouts, and community norms wherever possible. Symposium's own canonical format exists only where no cross-agent standard exists.
+
+## Union, not least-common-denominator
+
+Symposium's plugins should be able to take full advantage of what agents can do. We aim for interoperability but we also let plugin authors opt into agent-specific formats or capabilities.
+
+## Vendor neutral, interoperable
+
+Plugins and repository provide functionality; users pick their agent. Symposium provides the bridge, exposing plugin functionality in whatever way is requested by an individual user.
+
+## Safety
+
+Avoid exposing users to fresh risk. Plugins run code on the user's machine — symposium should make it easy to audit, constrain, and revoke. The central repository requirement exists to prevent supply-chain attacks until we have better decentralized trust mechanisms.
+
+## Empower the ecosystem
+
+Crate authors should be able to ship agent extensions independently, without waiting for central approval or coordination beyond the initial plugin registration. Once registered, updates flow through normal crate publishing. The symposium project's role is infrastructure, not gatekeeping.

--- a/md/reference/hook-events.md
+++ b/md/reference/hook-events.md
@@ -1,0 +1,183 @@
+# Symposium hook events
+
+This page documents the JSON schemas for symposium-format hooks — the input your hook receives on stdin and the output it should write to stdout. Symposium converts to and from each agent's native wire format, so you only need to handle these canonical types.
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| `PreToolUse` | Before the agent invokes a tool. Can inject context or modify the tool input. |
+| `PostToolUse` | After a tool completes. Can inject context. |
+| `UserPromptSubmit` | When the user submits a prompt. Can inject context. |
+| `SessionStart` | When an agent session begins. Can inject context. |
+
+## Input schemas
+
+Your hook receives one of the following JSON objects on stdin, depending on which event it is registered for.
+
+### `PreToolUse`
+
+```json
+{
+  "PreToolUse": {
+    "tool_name": "Bash",
+    "tool_input": { "command": "cargo test" },
+    "session_id": "abc-123",
+    "cwd": "/home/user/project"
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tool_name` | string | Name of the tool being invoked. |
+| `tool_input` | object | Arguments the agent is passing to the tool. |
+| `session_id` | string or null | Agent session identifier, if available. |
+| `cwd` | string or null | Working directory of the agent. |
+
+### `PostToolUse`
+
+```json
+{
+  "PostToolUse": {
+    "tool_name": "Bash",
+    "tool_input": { "command": "cargo test" },
+    "tool_response": { "stdout": "test result: ok" },
+    "session_id": "abc-123",
+    "cwd": "/home/user/project"
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tool_name` | string | Name of the tool that was invoked. |
+| `tool_input` | object | Arguments passed to the tool. |
+| `tool_response` | object | The tool's response/output. |
+| `session_id` | string or null | Agent session identifier, if available. |
+| `cwd` | string or null | Working directory of the agent. |
+
+### `UserPromptSubmit`
+
+```json
+{
+  "UserPromptSubmit": {
+    "prompt": "Fix the failing test in src/lib.rs",
+    "session_id": "abc-123",
+    "cwd": "/home/user/project"
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `prompt` | string | The text the user submitted. |
+| `session_id` | string or null | Agent session identifier, if available. |
+| `cwd` | string or null | Working directory of the agent. |
+
+### `SessionStart`
+
+```json
+{
+  "SessionStart": {
+    "session_id": "abc-123",
+    "cwd": "/home/user/project"
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `session_id` | string or null | Agent session identifier, if available. |
+| `cwd` | string or null | Working directory of the agent. |
+
+## Output schemas
+
+Your hook writes a JSON object to stdout. The object is wrapped in an enum tag matching the event, just like the input.
+
+### `PreToolUse` output
+
+```json
+{
+  "PreToolUse": {
+    "additionalContext": "Remember to use --release for benchmarks",
+    "updatedInput": { "command": "cargo test --release" }
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `decision` | `"allow"` or `"deny"` | Whether to allow or block the tool call. Defaults to `"allow"` and may be omitted. |
+| `additionalContext` | string or null | Text injected into the agent's context for this tool call. |
+| `updatedInput` | object or null | Replacement tool input. If set, overrides the original `tool_input`. |
+
+### `PostToolUse` output
+
+```json
+{
+  "PostToolUse": {
+    "additionalContext": "Note: 3 tests were skipped due to missing fixtures"
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `additionalContext` | string or null | Text injected into the agent's context after the tool result. |
+
+### `UserPromptSubmit` output
+
+```json
+{
+  "UserPromptSubmit": {
+    "additionalContext": "Relevant context: this project uses tokio 1.x"
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `additionalContext` | string or null | Text injected into the agent's context for this prompt. |
+
+### `SessionStart` output
+
+```json
+{
+  "SessionStart": {
+    "additionalContext": "symposium 0.5.0 is available (current: 0.4.2). Run `cargo agents self-update` to upgrade."
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `additionalContext` | string or null | Text injected into the agent's context at session start. |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success. Stdout is parsed as JSON and merged into the hook result. |
+| `2` | Block. The action is blocked and stderr is returned to the agent as the reason. |
+| Other non-zero | Warning. The hook is considered to have succeeded for dispatch purposes; stdout is still parsed if possible. |
+
+## Matcher
+
+The `matcher` field on a hook entry is a regex matched against `tool_name` for `PreToolUse` and `PostToolUse` events. For `UserPromptSubmit` and `SessionStart`, the matcher is ignored (all hooks fire). Use `"*"` to match all tools.
+
+## Testing
+
+You can test a symposium-format hook directly from the command line:
+
+```bash
+echo '{"PreToolUse":{"tool_name":"Bash","tool_input":{"command":"rm -rf /"},"session_id":null,"cwd":"/tmp"}}' \
+  | ./scripts/check.sh
+```
+
+Or via the `cargo agents hook` CLI with the symposium format:
+
+```bash
+echo '{"PreToolUse":{"tool_name":"Bash","tool_input":{"command":"cargo test"},"session_id":null,"cwd":"/tmp"}}' \
+  | cargo agents hook symposium pre-tool-use
+```

--- a/md/reference/plugin-definition.md
+++ b/md/reference/plugin-definition.md
@@ -169,7 +169,7 @@ install_commands = [
 
 ## `[[hooks]]`
 
-Each `[[hooks]]` entry declares a hook that responds to agent events.
+Each `[[hooks]]` entry declares a hook that responds to agent events. For the JSON schemas that symposium-format hooks receive and produce, see [Symposium hook events](./hook-events.md).
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -182,7 +182,7 @@ Each `[[hooks]]` entry declares a hook that responds to agent events.
 | `args` | array (optional) | Invocation arguments. Forbidden when the installation also declares `args`. |
 | `requirements` | array (optional) | Installations to acquire before running. Same shape as `command` (string name or inline declaration). |
 | `agent` | string (optional) | Restrict the hook to a specific agent (`claude`, `copilot`, `gemini`, `kiro`, …). |
-| `format` | string | Wire format for hook input/output. One of: `symposium` (default), `claude`, `codex`, `copilot`, `gemini`, `kiro`. |
+| `format` | string | Wire format the handler expects on stdin. `symposium` (default): symposium converts the agent's event to its canonical format before delivering. Any agent name (`claude`, `codex`, `copilot`, `gemini`, `kiro`): the handler receives that agent's native wire format. Symposium always intermediates — it never registers plugin hooks directly into agent configs. See [Hooks](../crate-authors/authoring-a-plugin.md#hooks). |
 
 ### Examples
 
@@ -260,6 +260,29 @@ event = "PreToolUse"
 command = "rtk"
 args = ["rewrite"]
 ```
+
+### Agent-specific hooks
+
+An agent-specific hook expects a particular agent's native wire format on stdin. Use this when you need full access to an agent's event schema. Symposium still intermediates — it delivers the input in the declared format (passing through unmodified when the current agent matches, or converting when it doesn't).
+
+A plugin with a Claude-specific hook and a symposium fallback:
+
+```toml
+[[hooks]]
+name = "check-claude"
+event = "PreToolUse"
+format = "claude"
+command = "my-hook-binary"
+
+[[hooks]]
+name = "check-portable"
+event = "PreToolUse"
+format = "symposium"
+command = "my-hook-binary"
+args = ["--symposium"]
+```
+
+On Claude, `check-claude` fires (receives Claude's native JSON). On other agents, `check-portable` fires (receives symposium canonical JSON). Only one hook per plugin fires for a given event — symposium picks the best match by format priority.
 
 ### Requirements
 

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -313,6 +313,7 @@ pub async fn dispatch_builtin(
             handle_user_prompt_submit(sym, prompt).await
         }
         symposium::InputEvent::SessionStart(session) => handle_session_start(sym, session),
+        _ => symposium::OutputEvent::empty_for(HookEvent::PreToolUse),
     }
 }
 
@@ -384,7 +385,7 @@ pub async fn dispatch_plugin_hooks(
     prior_output: serde_json::Value,
 ) -> Result<serde_json::Value, Vec<u8>> {
     let plugins = crate::plugins::load_all_plugins(sym);
-    let hooks = dispatched_hooks_for_payload(&plugins, sym_input);
+    let hooks = dispatched_hooks_for_payload(&plugins, sym_input, host_agent);
 
     let mut output = prior_output;
 
@@ -403,24 +404,14 @@ pub async fn dispatch_plugin_hooks(
             }
         }
 
-        // Determine stdin for the plugin based on its declared format
+        // Determine stdin for the plugin based on its declared format.
+        // After format selection, the only two cases are:
+        // - native (matches host agent) → pass through original input
+        // - symposium → deliver canonical format
         let hook_agent = hook.format.as_agent();
-        let temp_input: Box<dyn AgentHookInput>;
         let hook_input: &dyn AgentHookInput = if hook_agent == Some(host_agent) {
-            // Same format as host — pass through original input
             original_input
-        } else if let Some(target) = hook_agent {
-            // Different agent format — convert symposium → target
-            let handler = target.event(event);
-            match handler {
-                Some(h) => {
-                    temp_input = h.translate_input(sym_input);
-                    &*temp_input
-                }
-                None => continue, // target agent doesn't support this event
-            }
         } else {
-            // Symposium format
             sym_input
         };
         let stdin_str = match hook_input.to_string() {
@@ -459,12 +450,13 @@ pub async fn dispatch_plugin_hooks(
                     None | Some(2) => return Err(child_out.stderr),
                     Some(0) if child_out.stdout.is_empty() => continue,
                     Some(0) => {
-                        // Parse output and convert to host agent format
+                        // Parse output and convert to host agent format.
+                        // Two cases: native (same as host) or symposium.
                         let host_handler = host_agent.event(event);
                         let Some(host_h) = host_handler else { continue };
 
                         let host_json = if hook_agent == Some(host_agent) {
-                            // Same format — parse as host agent, serialize to Value
+                            // Native format — parse as host agent output
                             match host_h.parse_output(&child_out.stdout) {
                                 Ok(o) => o.to_hook_output(),
                                 Err(e) => {
@@ -472,35 +464,17 @@ pub async fn dispatch_plugin_hooks(
                                     continue;
                                 }
                             }
-                        } else if let Some(target) = hook_agent {
-                            // Different agent — parse as hook agent → symposium → host agent
-                            let target_handler = target.event(event);
-                            let Some(target_h) = target_handler else {
-                                continue;
-                            };
-                            match target_h.parse_output(&child_out.stdout) {
-                                Ok(hook_out) => {
-                                    let sym_out = hook_out.to_symposium();
-                                    let host_out = host_h.translate_output(&sym_out);
-                                    host_out.to_hook_output()
-                                }
-                                Err(e) => {
-                                    tracing::warn!(error = %e, "failed to parse hook output");
-                                    continue;
-                                }
-                            }
                         } else {
-                            // Symposium format — parse as symposium → host agent
+                            // Symposium format — parse and convert to host agent
                             match serde_json::from_slice::<serde_json::Value>(&child_out.stdout) {
                                 Ok(v) => {
-                                    // Try to parse as symposium OutputEvent
                                     if let Ok(sym_out) =
                                         serde_json::from_value::<symposium::OutputEvent>(v.clone())
                                     {
                                         let host_out = host_h.translate_output(&sym_out);
                                         host_out.to_hook_output()
                                     } else {
-                                        v // fallback: use raw JSON
+                                        v
                                     }
                                 }
                                 Err(e) => {
@@ -548,34 +522,53 @@ pub fn merge(a: &mut serde_json::Value, b: serde_json::Value) {
     *a = b;
 }
 
-/// Match plugin hooks against the incoming event, then resolve every
-/// `InstallationRef` (named or inline) on the matched hooks into a concrete
-/// `InstallationKind`. The resulting `ResolvedHook`s are ready to dispatch
-/// without further plugin lookups.
+/// Match plugin hooks against the incoming event, selecting at most one hook
+/// per plugin based on format priority:
+/// 1. A hook whose format matches the host agent (native fidelity).
+/// 2. A symposium-format hook (portable fallback).
+/// 3. Otherwise, nothing fires for that plugin.
+///
+/// The resulting `ResolvedHook`s are ready to dispatch without further plugin
+/// lookups.
 fn dispatched_hooks_for_payload(
     plugins: &[ParsedPlugin],
     input: &symposium::InputEvent,
+    host_agent: HookAgent,
 ) -> Vec<ResolvedHook> {
     tracing::trace!(?input, "matching hooks for payload");
 
     let mut out = Vec::new();
 
     for parsed_plugin in plugins {
+        let mut native_match: Option<&crate::plugins::Hook> = None;
+        let mut symposium_match: Option<&crate::plugins::Hook> = None;
+
         for hook in &parsed_plugin.plugin.hooks {
-            tracing::trace!(?hook);
             if hook.event != input.event() {
                 continue;
             }
             if let Some(matcher) = &hook.matcher
                 && !input.matches_matcher(matcher)
             {
-                tracing::debug!(
-                    ?input,
-                    ?matcher,
-                    "skipping hook due to non-matching matcher"
-                );
                 continue;
             }
+
+            match hook.format.as_agent() {
+                Some(agent) if agent == host_agent => {
+                    native_match = Some(hook);
+                }
+                None => {
+                    // format = "symposium"
+                    symposium_match = Some(hook);
+                }
+                Some(_) => {
+                    // Different agent format — does not fire on this agent.
+                }
+            }
+        }
+
+        let selected = native_match.or(symposium_match);
+        if let Some(hook) = selected {
             match ResolvedHook::build(parsed_plugin, hook) {
                 Ok(dispatched) => out.push(dispatched),
                 Err(e) => {
@@ -601,12 +594,12 @@ mod tests {
     async fn builtin_pre_tool_use_returns_empty() {
         let tmp = tempfile::tempdir().unwrap();
         let sym = Symposium::from_dir(tmp.path());
-        let input = symposium::InputEvent::PreToolUse(symposium::PreToolUseInput {
-            tool_name: "Bash".to_string(),
-            tool_input: serde_json::Value::default(),
-            session_id: None,
-            cwd: None,
-        });
+        let input = symposium::InputEvent::PreToolUse(symposium::PreToolUseInput::new(
+            "Bash".to_string(),
+            serde_json::Value::default(),
+            None,
+            None,
+        ));
         let output = dispatch_builtin(&sym, &input).await;
         assert!(output.additional_context().is_none());
     }
@@ -615,13 +608,13 @@ mod tests {
     async fn builtin_post_tool_use_returns_empty_for_now() {
         let tmp = tempfile::tempdir().unwrap();
         let sym = Symposium::from_dir(tmp.path());
-        let input = symposium::InputEvent::PostToolUse(symposium::PostToolUseInput {
-            tool_name: "Bash".to_string(),
-            tool_input: serde_json::json!({"command": "ls"}),
-            tool_response: serde_json::json!({"stdout": "file.rs"}),
-            session_id: Some("test-session".to_string()),
-            cwd: Some("/tmp".to_string()),
-        });
+        let input = symposium::InputEvent::PostToolUse(symposium::PostToolUseInput::new(
+            "Bash".to_string(),
+            serde_json::json!({"command": "ls"}),
+            serde_json::json!({"stdout": "file.rs"}),
+            Some("test-session".to_string()),
+            Some("/tmp".to_string()),
+        ));
         let output = dispatch_builtin(&sym, &input).await;
         assert!(output.additional_context().is_none());
     }
@@ -630,11 +623,11 @@ mod tests {
     async fn builtin_user_prompt_submit_returns_empty_for_now() {
         let tmp = tempfile::tempdir().unwrap();
         let sym = Symposium::from_dir(tmp.path());
-        let input = symposium::InputEvent::UserPromptSubmit(symposium::UserPromptSubmitInput {
-            prompt: "Use tokio for async".to_string(),
-            session_id: Some("test-session".to_string()),
-            cwd: Some("/tmp".to_string()),
-        });
+        let input = symposium::InputEvent::UserPromptSubmit(symposium::UserPromptSubmitInput::new(
+            "Use tokio for async".to_string(),
+            Some("test-session".to_string()),
+            Some("/tmp".to_string()),
+        ));
         let output = dispatch_builtin(&sym, &input).await;
         assert!(output.additional_context().is_none());
     }

--- a/src/hook_schema.rs
+++ b/src/hook_schema.rs
@@ -54,25 +54,7 @@ impl HookAgent {
     }
 }
 
-/// Hook event types supported by Symposium.
-#[derive(Debug, Copy, Clone, clap::ValueEnum, Serialize, Deserialize, PartialEq, Eq)]
-pub enum HookEvent {
-    #[value(name = "pre-tool-use")]
-    #[serde(rename = "PreToolUse")]
-    PreToolUse,
-
-    #[value(name = "post-tool-use")]
-    #[serde(rename = "PostToolUse")]
-    PostToolUse,
-
-    #[value(name = "user-prompt-submit")]
-    #[serde(rename = "UserPromptSubmit")]
-    UserPromptSubmit,
-
-    #[value(name = "session-start")]
-    #[serde(rename = "SessionStart")]
-    SessionStart,
-}
+pub use symposium_hook::HookEvent;
 
 /// Represents the data sent *from* an agent *to* a hook.
 pub trait AgentHookInput: Debug {

--- a/src/hook_schema/claude.rs
+++ b/src/hook_schema/claude.rs
@@ -7,14 +7,15 @@ use crate::hook_schema::{
 pub struct ClaudeCode;
 impl Agent for ClaudeCode {
     fn event(&self, event: super::HookEvent) -> Option<Box<dyn super::ErasedAgentHookEvent>> {
-        Some(match event {
-            super::HookEvent::PreToolUse => erase_agent_hook_event(ClaudePreToolUseEvent),
-            super::HookEvent::PostToolUse => erase_agent_hook_event(ClaudePostToolUseEvent),
+        match event {
+            super::HookEvent::PreToolUse => Some(erase_agent_hook_event(ClaudePreToolUseEvent)),
+            super::HookEvent::PostToolUse => Some(erase_agent_hook_event(ClaudePostToolUseEvent)),
             super::HookEvent::UserPromptSubmit => {
-                erase_agent_hook_event(ClaudeUserPromptSubmitEvent)
+                Some(erase_agent_hook_event(ClaudeUserPromptSubmitEvent))
             }
-            super::HookEvent::SessionStart => erase_agent_hook_event(ClaudeSessionStartEvent),
-        })
+            super::HookEvent::SessionStart => Some(erase_agent_hook_event(ClaudeSessionStartEvent)),
+            _ => None,
+        }
     }
 }
 
@@ -114,20 +115,18 @@ impl AgentHookInput for ClaudePreToolUseInput {
         Ok(serde_json::from_str(payload)?)
     }
     fn to_symposium(&self) -> symposium::InputEvent {
-        symposium::InputEvent::PreToolUse(symposium::PreToolUseInput {
-            tool_name: self.tool_name.clone(),
-            tool_input: self.rest.get("tool_input").cloned().unwrap_or_default(),
-            session_id: self
-                .rest
+        symposium::InputEvent::PreToolUse(symposium::PreToolUseInput::new(
+            self.tool_name.clone(),
+            self.rest.get("tool_input").cloned().unwrap_or_default(),
+            self.rest
                 .get("session_id")
                 .and_then(|v| v.as_str())
                 .map(String::from),
-            cwd: self
-                .rest
+            self.rest
                 .get("cwd")
                 .and_then(|v| v.as_str())
                 .map(String::from),
-        })
+        ))
     }
     fn from_symposium(event: &symposium::InputEvent) -> Self {
         let symposium::InputEvent::PreToolUse(p) = event else {
@@ -170,10 +169,15 @@ impl AgentHookOutput for ClaudePreToolUseOutput {
     }
     fn to_symposium(&self) -> symposium::OutputEvent {
         let h = self.hook_specific_output.as_ref();
-        symposium::OutputEvent::PreToolUse(symposium::PreToolUseOutput {
-            additional_context: h.and_then(|h| h.additional_context.clone()),
-            updated_input: h.and_then(|h| h.updated_input.clone()),
-        })
+        let decision = match h.and_then(|h| h.permission_decision.as_deref()) {
+            Some("deny") => symposium_hook::Decision::Deny,
+            _ => symposium_hook::Decision::Allow,
+        };
+        symposium::OutputEvent::PreToolUse(symposium::PreToolUseOutput::new(
+            decision,
+            h.and_then(|h| h.additional_context.clone()),
+            h.and_then(|h| h.updated_input.clone()),
+        ))
     }
     fn to_hook_output(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap()
@@ -258,21 +262,19 @@ impl AgentHookInput for ClaudePostToolUseInput {
         Ok(serde_json::from_str(payload)?)
     }
     fn to_symposium(&self) -> symposium::InputEvent {
-        symposium::InputEvent::PostToolUse(symposium::PostToolUseInput {
-            tool_name: self.tool_name.clone(),
-            tool_input: self.tool_input.clone(),
-            tool_response: self.tool_response.clone(),
-            session_id: self
-                .rest
+        symposium::InputEvent::PostToolUse(symposium::PostToolUseInput::new(
+            self.tool_name.clone(),
+            self.tool_input.clone(),
+            self.tool_response.clone(),
+            self.rest
                 .get("session_id")
                 .and_then(|v| v.as_str())
                 .map(String::from),
-            cwd: self
-                .rest
+            self.rest
                 .get("cwd")
                 .and_then(|v| v.as_str())
                 .map(String::from),
-        })
+        ))
     }
     fn from_symposium(event: &symposium::InputEvent) -> Self {
         let symposium::InputEvent::PostToolUse(p) = event else {
@@ -315,12 +317,11 @@ impl AgentHookOutput for ClaudePostToolUseOutput {
         }
     }
     fn to_symposium(&self) -> symposium::OutputEvent {
-        symposium::OutputEvent::PostToolUse(symposium::PostToolUseOutput {
-            additional_context: self
-                .hook_specific_output
+        symposium::OutputEvent::PostToolUse(symposium::PostToolUseOutput::new(
+            self.hook_specific_output
                 .as_ref()
                 .and_then(|h| h.additional_context.clone()),
-        })
+        ))
     }
     fn to_hook_output(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap()
@@ -372,19 +373,17 @@ impl AgentHookInput for ClaudeUserPromptSubmitInput {
         Ok(serde_json::from_str(payload)?)
     }
     fn to_symposium(&self) -> symposium::InputEvent {
-        symposium::InputEvent::UserPromptSubmit(symposium::UserPromptSubmitInput {
-            prompt: self.prompt.clone(),
-            session_id: self
-                .rest
+        symposium::InputEvent::UserPromptSubmit(symposium::UserPromptSubmitInput::new(
+            self.prompt.clone(),
+            self.rest
                 .get("session_id")
                 .and_then(|v| v.as_str())
                 .map(String::from),
-            cwd: self
-                .rest
+            self.rest
                 .get("cwd")
                 .and_then(|v| v.as_str())
                 .map(String::from),
-        })
+        ))
     }
     fn from_symposium(event: &symposium::InputEvent) -> Self {
         let symposium::InputEvent::UserPromptSubmit(p) = event else {
@@ -425,12 +424,11 @@ impl AgentHookOutput for ClaudeUserPromptSubmitOutput {
         }
     }
     fn to_symposium(&self) -> symposium::OutputEvent {
-        symposium::OutputEvent::UserPromptSubmit(symposium::UserPromptSubmitOutput {
-            additional_context: self
-                .hook_specific_output
+        symposium::OutputEvent::UserPromptSubmit(symposium::UserPromptSubmitOutput::new(
+            self.hook_specific_output
                 .as_ref()
                 .and_then(|h| h.additional_context.clone()),
-        })
+        ))
     }
     fn to_hook_output(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap()
@@ -480,18 +478,16 @@ impl AgentHookInput for ClaudeSessionStartInput {
         Ok(serde_json::from_str(payload)?)
     }
     fn to_symposium(&self) -> symposium::InputEvent {
-        symposium::InputEvent::SessionStart(symposium::SessionStartInput {
-            session_id: self
-                .rest
+        symposium::InputEvent::SessionStart(symposium::SessionStartInput::new(
+            self.rest
                 .get("session_id")
                 .and_then(|v| v.as_str())
                 .map(String::from),
-            cwd: self
-                .rest
+            self.rest
                 .get("cwd")
                 .and_then(|v| v.as_str())
                 .map(String::from),
-        })
+        ))
     }
     fn from_symposium(event: &symposium::InputEvent) -> Self {
         let symposium::InputEvent::SessionStart(p) = event else {
@@ -531,12 +527,11 @@ impl AgentHookOutput for ClaudeSessionStartOutput {
         }
     }
     fn to_symposium(&self) -> symposium::OutputEvent {
-        symposium::OutputEvent::SessionStart(symposium::SessionStartOutput {
-            additional_context: self
-                .hook_specific_output
+        symposium::OutputEvent::SessionStart(symposium::SessionStartOutput::new(
+            self.hook_specific_output
                 .as_ref()
                 .and_then(|h| h.additional_context.clone()),
-        })
+        ))
     }
     fn to_hook_output(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap()

--- a/src/hook_schema/codex.rs
+++ b/src/hook_schema/codex.rs
@@ -7,14 +7,15 @@ use crate::hook_schema::{
 pub struct Codex;
 impl Agent for Codex {
     fn event(&self, event: super::HookEvent) -> Option<Box<dyn super::ErasedAgentHookEvent>> {
-        Some(match event {
-            super::HookEvent::PreToolUse => erase_agent_hook_event(CodexPreToolUseEvent),
-            super::HookEvent::PostToolUse => erase_agent_hook_event(CodexPostToolUseEvent),
+        match event {
+            super::HookEvent::PreToolUse => Some(erase_agent_hook_event(CodexPreToolUseEvent)),
+            super::HookEvent::PostToolUse => Some(erase_agent_hook_event(CodexPostToolUseEvent)),
             super::HookEvent::UserPromptSubmit => {
-                erase_agent_hook_event(CodexUserPromptSubmitEvent)
+                Some(erase_agent_hook_event(CodexUserPromptSubmitEvent))
             }
-            super::HookEvent::SessionStart => erase_agent_hook_event(CodexSessionStartEvent),
-        })
+            super::HookEvent::SessionStart => Some(erase_agent_hook_event(CodexSessionStartEvent)),
+            _ => None,
+        }
     }
 }
 
@@ -118,12 +119,12 @@ impl AgentHookInput for CodexPreToolUseInput {
         Ok(serde_json::from_str(payload)?)
     }
     fn to_symposium(&self) -> symposium::InputEvent {
-        symposium::InputEvent::PreToolUse(symposium::PreToolUseInput {
-            tool_name: self.tool_name.clone(),
-            tool_input: self.tool_input.clone(),
-            session_id: self.session_id.clone(),
-            cwd: self.cwd.clone(),
-        })
+        symposium::InputEvent::PreToolUse(symposium::PreToolUseInput::new(
+            self.tool_name.clone(),
+            self.tool_input.clone(),
+            self.session_id.clone(),
+            self.cwd.clone(),
+        ))
     }
     fn from_symposium(event: &symposium::InputEvent) -> Self {
         let symposium::InputEvent::PreToolUse(p) = event else {
@@ -162,13 +163,17 @@ impl AgentHookOutput for CodexPreToolUseOutput {
             .unwrap_or_default()
     }
     fn to_symposium(&self) -> symposium::OutputEvent {
-        symposium::OutputEvent::PreToolUse(symposium::PreToolUseOutput {
-            additional_context: self
-                .hook_specific_output
+        let decision = match self.decision.as_deref() {
+            Some("block") | Some("deny") => symposium_hook::Decision::Deny,
+            _ => symposium_hook::Decision::Allow,
+        };
+        symposium::OutputEvent::PreToolUse(symposium::PreToolUseOutput::new(
+            decision,
+            self.hook_specific_output
                 .as_ref()
                 .and_then(|h| h.additional_context.clone()),
-            updated_input: None,
-        })
+            None,
+        ))
     }
     fn to_hook_output(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap()
@@ -221,13 +226,13 @@ impl AgentHookInput for CodexPostToolUseInput {
         Ok(serde_json::from_str(payload)?)
     }
     fn to_symposium(&self) -> symposium::InputEvent {
-        symposium::InputEvent::PostToolUse(symposium::PostToolUseInput {
-            tool_name: self.tool_name.clone(),
-            tool_input: self.tool_input.clone(),
-            tool_response: self.tool_response.clone(),
-            session_id: self.session_id.clone(),
-            cwd: self.cwd.clone(),
-        })
+        symposium::InputEvent::PostToolUse(symposium::PostToolUseInput::new(
+            self.tool_name.clone(),
+            self.tool_input.clone(),
+            self.tool_response.clone(),
+            self.session_id.clone(),
+            self.cwd.clone(),
+        ))
     }
     fn from_symposium(event: &symposium::InputEvent) -> Self {
         let symposium::InputEvent::PostToolUse(p) = event else {
@@ -267,12 +272,11 @@ impl AgentHookOutput for CodexPostToolUseOutput {
             .unwrap_or_default()
     }
     fn to_symposium(&self) -> symposium::OutputEvent {
-        symposium::OutputEvent::PostToolUse(symposium::PostToolUseOutput {
-            additional_context: self
-                .hook_specific_output
+        symposium::OutputEvent::PostToolUse(symposium::PostToolUseOutput::new(
+            self.hook_specific_output
                 .as_ref()
                 .and_then(|h| h.additional_context.clone()),
-        })
+        ))
     }
     fn to_hook_output(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap()
@@ -316,11 +320,11 @@ impl AgentHookInput for CodexUserPromptSubmitInput {
         Ok(serde_json::from_str(payload)?)
     }
     fn to_symposium(&self) -> symposium::InputEvent {
-        symposium::InputEvent::UserPromptSubmit(symposium::UserPromptSubmitInput {
-            prompt: self.prompt.clone(),
-            session_id: self.session_id.clone(),
-            cwd: self.cwd.clone(),
-        })
+        symposium::InputEvent::UserPromptSubmit(symposium::UserPromptSubmitInput::new(
+            self.prompt.clone(),
+            self.session_id.clone(),
+            self.cwd.clone(),
+        ))
     }
     fn from_symposium(event: &symposium::InputEvent) -> Self {
         let symposium::InputEvent::UserPromptSubmit(p) = event else {
@@ -357,12 +361,11 @@ impl AgentHookOutput for CodexUserPromptSubmitOutput {
             .unwrap_or_default()
     }
     fn to_symposium(&self) -> symposium::OutputEvent {
-        symposium::OutputEvent::UserPromptSubmit(symposium::UserPromptSubmitOutput {
-            additional_context: self
-                .hook_specific_output
+        symposium::OutputEvent::UserPromptSubmit(symposium::UserPromptSubmitOutput::new(
+            self.hook_specific_output
                 .as_ref()
                 .and_then(|h| h.additional_context.clone()),
-        })
+        ))
     }
     fn to_hook_output(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap()
@@ -402,10 +405,10 @@ impl AgentHookInput for CodexSessionStartInput {
         Ok(serde_json::from_str(payload)?)
     }
     fn to_symposium(&self) -> symposium::InputEvent {
-        symposium::InputEvent::SessionStart(symposium::SessionStartInput {
-            session_id: self.session_id.clone(),
-            cwd: self.cwd.clone(),
-        })
+        symposium::InputEvent::SessionStart(symposium::SessionStartInput::new(
+            self.session_id.clone(),
+            self.cwd.clone(),
+        ))
     }
     fn from_symposium(event: &symposium::InputEvent) -> Self {
         let symposium::InputEvent::SessionStart(p) = event else {
@@ -440,12 +443,11 @@ impl AgentHookOutput for CodexSessionStartOutput {
             .unwrap_or_default()
     }
     fn to_symposium(&self) -> symposium::OutputEvent {
-        symposium::OutputEvent::SessionStart(symposium::SessionStartOutput {
-            additional_context: self
-                .hook_specific_output
+        symposium::OutputEvent::SessionStart(symposium::SessionStartOutput::new(
+            self.hook_specific_output
                 .as_ref()
                 .and_then(|h| h.additional_context.clone()),
-        })
+        ))
     }
     fn to_hook_output(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap()

--- a/src/hook_schema/copilot.rs
+++ b/src/hook_schema/copilot.rs
@@ -58,7 +58,9 @@ macro_rules! copilot_output_impl {
     ($ty:ident, PreToolUse, PreToolUseOutput { $($extra:tt)* }) => {
         impl AgentHookOutput for $ty {
             fn parse_output(output: &[u8]) -> anyhow::Result<Self> {
-                if output.is_empty() { return Ok(Self::default()); }
+                if output.is_empty() {
+                    return Ok(Self::default());
+                }
                 Ok(serde_json::from_slice(output)?)
             }
             fn from_symposium(event: &symposium::OutputEvent) -> Self {
@@ -77,14 +79,20 @@ macro_rules! copilot_output_impl {
                     None,
                 ))
             }
-            fn to_hook_output(&self) -> serde_json::Value { serde_json::to_value(self).unwrap() }
-            fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> { self }
+            fn to_hook_output(&self) -> serde_json::Value {
+                serde_json::to_value(self).unwrap()
+            }
+            fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+                self
+            }
         }
     };
     ($ty:ident, $variant:ident, $struct:ident { }) => {
         impl AgentHookOutput for $ty {
             fn parse_output(output: &[u8]) -> anyhow::Result<Self> {
-                if output.is_empty() { return Ok(Self::default()); }
+                if output.is_empty() {
+                    return Ok(Self::default());
+                }
                 Ok(serde_json::from_slice(output)?)
             }
             fn from_symposium(event: &symposium::OutputEvent) -> Self {
@@ -97,8 +105,12 @@ macro_rules! copilot_output_impl {
                     self.additional_context.clone(),
                 ))
             }
-            fn to_hook_output(&self) -> serde_json::Value { serde_json::to_value(self).unwrap() }
-            fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> { self }
+            fn to_hook_output(&self) -> serde_json::Value {
+                serde_json::to_value(self).unwrap()
+            }
+            fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+                self
+            }
         }
     };
 }

--- a/src/hook_schema/copilot.rs
+++ b/src/hook_schema/copilot.rs
@@ -7,14 +7,17 @@ use crate::hook_schema::{
 pub struct Copilot;
 impl Agent for Copilot {
     fn event(&self, event: super::HookEvent) -> Option<Box<dyn super::ErasedAgentHookEvent>> {
-        Some(match event {
-            super::HookEvent::PreToolUse => erase_agent_hook_event(CopilotPreToolUseEvent),
-            super::HookEvent::PostToolUse => erase_agent_hook_event(CopilotPostToolUseEvent),
+        match event {
+            super::HookEvent::PreToolUse => Some(erase_agent_hook_event(CopilotPreToolUseEvent)),
+            super::HookEvent::PostToolUse => Some(erase_agent_hook_event(CopilotPostToolUseEvent)),
             super::HookEvent::UserPromptSubmit => {
-                erase_agent_hook_event(CopilotUserPromptSubmitEvent)
+                Some(erase_agent_hook_event(CopilotUserPromptSubmitEvent))
             }
-            super::HookEvent::SessionStart => erase_agent_hook_event(CopilotSessionStartEvent),
-        })
+            super::HookEvent::SessionStart => {
+                Some(erase_agent_hook_event(CopilotSessionStartEvent))
+            }
+            _ => None,
+        }
     }
 }
 
@@ -52,7 +55,7 @@ copilot_event!(
 // Copilot output is flat (additionalContext at top level, no hookSpecificOutput).
 
 macro_rules! copilot_output_impl {
-    ($ty:ident, $variant:ident, $struct:ident { $($extra:tt)* }) => {
+    ($ty:ident, PreToolUse, PreToolUseOutput { $($extra:tt)* }) => {
         impl AgentHookOutput for $ty {
             fn parse_output(output: &[u8]) -> anyhow::Result<Self> {
                 if output.is_empty() { return Ok(Self::default()); }
@@ -64,10 +67,35 @@ macro_rules! copilot_output_impl {
                 out
             }
             fn to_symposium(&self) -> symposium::OutputEvent {
-                symposium::OutputEvent::$variant(symposium::$struct {
-                    additional_context: self.additional_context.clone(),
-                    $($extra)*
-                })
+                let decision = match self.permission_decision.as_deref() {
+                    Some("deny") => symposium_hook::Decision::Deny,
+                    _ => symposium_hook::Decision::Allow,
+                };
+                symposium::OutputEvent::PreToolUse(symposium::PreToolUseOutput::new(
+                    decision,
+                    self.additional_context.clone(),
+                    None,
+                ))
+            }
+            fn to_hook_output(&self) -> serde_json::Value { serde_json::to_value(self).unwrap() }
+            fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> { self }
+        }
+    };
+    ($ty:ident, $variant:ident, $struct:ident { }) => {
+        impl AgentHookOutput for $ty {
+            fn parse_output(output: &[u8]) -> anyhow::Result<Self> {
+                if output.is_empty() { return Ok(Self::default()); }
+                Ok(serde_json::from_slice(output)?)
+            }
+            fn from_symposium(event: &symposium::OutputEvent) -> Self {
+                let mut out = Self::default();
+                out.additional_context = event.additional_context().map(String::from);
+                out
+            }
+            fn to_symposium(&self) -> symposium::OutputEvent {
+                symposium::OutputEvent::$variant(symposium::$struct::new(
+                    self.additional_context.clone(),
+                ))
             }
             fn to_hook_output(&self) -> serde_json::Value { serde_json::to_value(self).unwrap() }
             fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> { self }
@@ -115,12 +143,12 @@ impl AgentHookInput for CopilotPreToolUseInput {
         Ok(serde_json::from_str(payload)?)
     }
     fn to_symposium(&self) -> symposium::InputEvent {
-        symposium::InputEvent::PreToolUse(symposium::PreToolUseInput {
-            tool_name: self.tool_name.clone(),
-            tool_input: self.tool_args.clone(),
-            session_id: None,
-            cwd: self.cwd.clone(),
-        })
+        symposium::InputEvent::PreToolUse(symposium::PreToolUseInput::new(
+            self.tool_name.clone(),
+            self.tool_args.clone(),
+            None,
+            self.cwd.clone(),
+        ))
     }
     fn from_symposium(event: &symposium::InputEvent) -> Self {
         let symposium::InputEvent::PreToolUse(p) = event else {
@@ -181,13 +209,13 @@ impl AgentHookInput for CopilotPostToolUseInput {
         Ok(serde_json::from_str(payload)?)
     }
     fn to_symposium(&self) -> symposium::InputEvent {
-        symposium::InputEvent::PostToolUse(symposium::PostToolUseInput {
-            tool_name: self.tool_name.clone(),
-            tool_input: self.tool_args.clone(),
-            tool_response: self.tool_response.clone(),
-            session_id: None,
-            cwd: self.cwd.clone(),
-        })
+        symposium::InputEvent::PostToolUse(symposium::PostToolUseInput::new(
+            self.tool_name.clone(),
+            self.tool_args.clone(),
+            self.tool_response.clone(),
+            None,
+            self.cwd.clone(),
+        ))
     }
     fn from_symposium(event: &symposium::InputEvent) -> Self {
         let symposium::InputEvent::PostToolUse(p) = event else {
@@ -239,11 +267,11 @@ impl AgentHookInput for CopilotUserPromptSubmitInput {
         Ok(serde_json::from_str(payload)?)
     }
     fn to_symposium(&self) -> symposium::InputEvent {
-        symposium::InputEvent::UserPromptSubmit(symposium::UserPromptSubmitInput {
-            prompt: self.prompt.clone(),
-            session_id: None,
-            cwd: self.cwd.clone(),
-        })
+        symposium::InputEvent::UserPromptSubmit(symposium::UserPromptSubmitInput::new(
+            self.prompt.clone(),
+            None,
+            self.cwd.clone(),
+        ))
     }
     fn from_symposium(event: &symposium::InputEvent) -> Self {
         let symposium::InputEvent::UserPromptSubmit(p) = event else {
@@ -295,10 +323,10 @@ impl AgentHookInput for CopilotSessionStartInput {
         Ok(serde_json::from_str(payload)?)
     }
     fn to_symposium(&self) -> symposium::InputEvent {
-        symposium::InputEvent::SessionStart(symposium::SessionStartInput {
-            session_id: None,
-            cwd: self.cwd.clone(),
-        })
+        symposium::InputEvent::SessionStart(symposium::SessionStartInput::new(
+            None,
+            self.cwd.clone(),
+        ))
     }
     fn from_symposium(event: &symposium::InputEvent) -> Self {
         let symposium::InputEvent::SessionStart(p) = event else {

--- a/src/hook_schema/gemini.rs
+++ b/src/hook_schema/gemini.rs
@@ -7,14 +7,15 @@ use crate::hook_schema::{
 pub struct Gemini;
 impl Agent for Gemini {
     fn event(&self, event: super::HookEvent) -> Option<Box<dyn super::ErasedAgentHookEvent>> {
-        Some(match event {
-            super::HookEvent::PreToolUse => erase_agent_hook_event(GeminiPreToolUseEvent),
-            super::HookEvent::PostToolUse => erase_agent_hook_event(GeminiPostToolUseEvent),
+        match event {
+            super::HookEvent::PreToolUse => Some(erase_agent_hook_event(GeminiPreToolUseEvent)),
+            super::HookEvent::PostToolUse => Some(erase_agent_hook_event(GeminiPostToolUseEvent)),
             super::HookEvent::UserPromptSubmit => {
-                erase_agent_hook_event(GeminiUserPromptSubmitEvent)
+                Some(erase_agent_hook_event(GeminiUserPromptSubmitEvent))
             }
-            super::HookEvent::SessionStart => erase_agent_hook_event(GeminiSessionStartEvent),
-        })
+            super::HookEvent::SessionStart => Some(erase_agent_hook_event(GeminiSessionStartEvent)),
+            _ => None,
+        }
     }
 }
 
@@ -123,12 +124,12 @@ impl AgentHookInput for GeminiPreToolUseInput {
         Ok(serde_json::from_str(payload)?)
     }
     fn to_symposium(&self) -> symposium::InputEvent {
-        symposium::InputEvent::PreToolUse(symposium::PreToolUseInput {
-            tool_name: self.tool_name.clone(),
-            tool_input: self.tool_input.clone(),
-            session_id: self.session_id.clone(),
-            cwd: self.cwd.clone(),
-        })
+        symposium::InputEvent::PreToolUse(symposium::PreToolUseInput::new(
+            self.tool_name.clone(),
+            self.tool_input.clone(),
+            self.session_id.clone(),
+            self.cwd.clone(),
+        ))
     }
     fn from_symposium(event: &symposium::InputEvent) -> Self {
         let symposium::InputEvent::PreToolUse(p) = event else {
@@ -170,10 +171,15 @@ impl AgentHookOutput for GeminiPreToolUseOutput {
     }
     fn to_symposium(&self) -> symposium::OutputEvent {
         let h = self.hook_specific_output.as_ref();
-        symposium::OutputEvent::PreToolUse(symposium::PreToolUseOutput {
-            additional_context: h.and_then(|h| h.additional_context.clone()),
-            updated_input: h.and_then(|h| h.tool_input.clone()),
-        })
+        let decision = match self.decision.as_deref() {
+            Some("deny") | Some("block") => symposium_hook::Decision::Deny,
+            _ => symposium_hook::Decision::Allow,
+        };
+        symposium::OutputEvent::PreToolUse(symposium::PreToolUseOutput::new(
+            decision,
+            h.and_then(|h| h.additional_context.clone()),
+            h.and_then(|h| h.tool_input.clone()),
+        ))
     }
     fn to_hook_output(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap()
@@ -232,13 +238,13 @@ impl AgentHookInput for GeminiPostToolUseInput {
         Ok(serde_json::from_str(payload)?)
     }
     fn to_symposium(&self) -> symposium::InputEvent {
-        symposium::InputEvent::PostToolUse(symposium::PostToolUseInput {
-            tool_name: self.tool_name.clone(),
-            tool_input: self.tool_input.clone(),
-            tool_response: self.tool_response.clone(),
-            session_id: self.session_id.clone(),
-            cwd: self.cwd.clone(),
-        })
+        symposium::InputEvent::PostToolUse(symposium::PostToolUseInput::new(
+            self.tool_name.clone(),
+            self.tool_input.clone(),
+            self.tool_response.clone(),
+            self.session_id.clone(),
+            self.cwd.clone(),
+        ))
     }
     fn from_symposium(event: &symposium::InputEvent) -> Self {
         let symposium::InputEvent::PostToolUse(p) = event else {
@@ -278,12 +284,11 @@ impl AgentHookOutput for GeminiPostToolUseOutput {
         }
     }
     fn to_symposium(&self) -> symposium::OutputEvent {
-        symposium::OutputEvent::PostToolUse(symposium::PostToolUseOutput {
-            additional_context: self
-                .hook_specific_output
+        symposium::OutputEvent::PostToolUse(symposium::PostToolUseOutput::new(
+            self.hook_specific_output
                 .as_ref()
                 .and_then(|h| h.additional_context.clone()),
-        })
+        ))
     }
     fn to_hook_output(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap()
@@ -331,11 +336,11 @@ impl AgentHookInput for GeminiUserPromptSubmitInput {
         Ok(serde_json::from_str(payload)?)
     }
     fn to_symposium(&self) -> symposium::InputEvent {
-        symposium::InputEvent::UserPromptSubmit(symposium::UserPromptSubmitInput {
-            prompt: self.prompt.clone(),
-            session_id: self.session_id.clone(),
-            cwd: self.cwd.clone(),
-        })
+        symposium::InputEvent::UserPromptSubmit(symposium::UserPromptSubmitInput::new(
+            self.prompt.clone(),
+            self.session_id.clone(),
+            self.cwd.clone(),
+        ))
     }
     fn from_symposium(event: &symposium::InputEvent) -> Self {
         let symposium::InputEvent::UserPromptSubmit(p) = event else {
@@ -371,12 +376,11 @@ impl AgentHookOutput for GeminiUserPromptSubmitOutput {
         }
     }
     fn to_symposium(&self) -> symposium::OutputEvent {
-        symposium::OutputEvent::UserPromptSubmit(symposium::UserPromptSubmitOutput {
-            additional_context: self
-                .hook_specific_output
+        symposium::OutputEvent::UserPromptSubmit(symposium::UserPromptSubmitOutput::new(
+            self.hook_specific_output
                 .as_ref()
                 .and_then(|h| h.additional_context.clone()),
-        })
+        ))
     }
     fn to_hook_output(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap()
@@ -422,10 +426,10 @@ impl AgentHookInput for GeminiSessionStartInput {
         Ok(serde_json::from_str(payload)?)
     }
     fn to_symposium(&self) -> symposium::InputEvent {
-        symposium::InputEvent::SessionStart(symposium::SessionStartInput {
-            session_id: self.session_id.clone(),
-            cwd: self.cwd.clone(),
-        })
+        symposium::InputEvent::SessionStart(symposium::SessionStartInput::new(
+            self.session_id.clone(),
+            self.cwd.clone(),
+        ))
     }
     fn from_symposium(event: &symposium::InputEvent) -> Self {
         let symposium::InputEvent::SessionStart(p) = event else {
@@ -460,12 +464,11 @@ impl AgentHookOutput for GeminiSessionStartOutput {
         }
     }
     fn to_symposium(&self) -> symposium::OutputEvent {
-        symposium::OutputEvent::SessionStart(symposium::SessionStartOutput {
-            additional_context: self
-                .hook_specific_output
+        symposium::OutputEvent::SessionStart(symposium::SessionStartOutput::new(
+            self.hook_specific_output
                 .as_ref()
                 .and_then(|h| h.additional_context.clone()),
-        })
+        ))
     }
     fn to_hook_output(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap()

--- a/src/hook_schema/kiro.rs
+++ b/src/hook_schema/kiro.rs
@@ -7,12 +7,15 @@ use crate::hook_schema::{
 pub struct Kiro;
 impl Agent for Kiro {
     fn event(&self, event: super::HookEvent) -> Option<Box<dyn super::ErasedAgentHookEvent>> {
-        Some(match event {
-            super::HookEvent::PreToolUse => erase_agent_hook_event(KiroPreToolUseEvent),
-            super::HookEvent::PostToolUse => erase_agent_hook_event(KiroPostToolUseEvent),
-            super::HookEvent::UserPromptSubmit => erase_agent_hook_event(KiroUserPromptSubmitEvent),
-            super::HookEvent::SessionStart => erase_agent_hook_event(KiroSessionStartEvent),
-        })
+        match event {
+            super::HookEvent::PreToolUse => Some(erase_agent_hook_event(KiroPreToolUseEvent)),
+            super::HookEvent::PostToolUse => Some(erase_agent_hook_event(KiroPostToolUseEvent)),
+            super::HookEvent::UserPromptSubmit => {
+                Some(erase_agent_hook_event(KiroUserPromptSubmitEvent))
+            }
+            super::HookEvent::SessionStart => Some(erase_agent_hook_event(KiroSessionStartEvent)),
+            _ => None,
+        }
     }
 }
 
@@ -57,7 +60,7 @@ kiro_event!(
 
 // Kiro output: plain text stdout → additionalContext
 macro_rules! kiro_output_impl {
-    ($ty:ident, $variant:ident, $struct:ident { $($extra:tt)* }) => {
+    ($ty:ident, PreToolUse, PreToolUseOutput { $($extra:tt)* }) => {
         impl AgentHookOutput for $ty {
             fn parse_output(output: &[u8]) -> anyhow::Result<Self> {
                 if output.is_empty() { return Ok(Self::default()); }
@@ -68,10 +71,30 @@ macro_rules! kiro_output_impl {
                 Self { additional_context: event.additional_context().map(String::from), rest: serde_json::Map::new() }
             }
             fn to_symposium(&self) -> symposium::OutputEvent {
-                symposium::OutputEvent::$variant(symposium::$struct {
-                    additional_context: self.additional_context.clone(),
-                    $($extra)*
-                })
+                symposium::OutputEvent::PreToolUse(symposium::PreToolUseOutput::new(
+                    Default::default(),
+                    self.additional_context.clone(),
+                    None,
+                ))
+            }
+            fn to_hook_output(&self) -> serde_json::Value { serde_json::to_value(self).unwrap() }
+            fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> { self }
+        }
+    };
+    ($ty:ident, $variant:ident, $struct:ident { }) => {
+        impl AgentHookOutput for $ty {
+            fn parse_output(output: &[u8]) -> anyhow::Result<Self> {
+                if output.is_empty() { return Ok(Self::default()); }
+                let text = String::from_utf8_lossy(output);
+                Ok(Self { additional_context: Some(text.into_owned()), rest: serde_json::Map::new() })
+            }
+            fn from_symposium(event: &symposium::OutputEvent) -> Self {
+                Self { additional_context: event.additional_context().map(String::from), rest: serde_json::Map::new() }
+            }
+            fn to_symposium(&self) -> symposium::OutputEvent {
+                symposium::OutputEvent::$variant(symposium::$struct::new(
+                    self.additional_context.clone(),
+                ))
             }
             fn to_hook_output(&self) -> serde_json::Value { serde_json::to_value(self).unwrap() }
             fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> { self }
@@ -108,12 +131,12 @@ impl AgentHookInput for KiroPreToolUseInput {
         Ok(serde_json::from_str(payload)?)
     }
     fn to_symposium(&self) -> symposium::InputEvent {
-        symposium::InputEvent::PreToolUse(symposium::PreToolUseInput {
-            tool_name: self.tool_name.clone(),
-            tool_input: self.tool_input.clone(),
-            session_id: self.session_id.clone(),
-            cwd: self.cwd.clone(),
-        })
+        symposium::InputEvent::PreToolUse(symposium::PreToolUseInput::new(
+            self.tool_name.clone(),
+            self.tool_input.clone(),
+            self.session_id.clone(),
+            self.cwd.clone(),
+        ))
     }
     fn from_symposium(event: &symposium::InputEvent) -> Self {
         let symposium::InputEvent::PreToolUse(p) = event else {
@@ -175,13 +198,13 @@ impl AgentHookInput for KiroPostToolUseInput {
         Ok(serde_json::from_str(payload)?)
     }
     fn to_symposium(&self) -> symposium::InputEvent {
-        symposium::InputEvent::PostToolUse(symposium::PostToolUseInput {
-            tool_name: self.tool_name.clone(),
-            tool_input: self.tool_input.clone(),
-            tool_response: self.tool_response.clone(),
-            session_id: self.session_id.clone(),
-            cwd: self.cwd.clone(),
-        })
+        symposium::InputEvent::PostToolUse(symposium::PostToolUseInput::new(
+            self.tool_name.clone(),
+            self.tool_input.clone(),
+            self.tool_response.clone(),
+            self.session_id.clone(),
+            self.cwd.clone(),
+        ))
     }
     fn from_symposium(event: &symposium::InputEvent) -> Self {
         let symposium::InputEvent::PostToolUse(p) = event else {
@@ -235,11 +258,11 @@ impl AgentHookInput for KiroUserPromptSubmitInput {
         Ok(serde_json::from_str(payload)?)
     }
     fn to_symposium(&self) -> symposium::InputEvent {
-        symposium::InputEvent::UserPromptSubmit(symposium::UserPromptSubmitInput {
-            prompt: self.prompt.clone(),
-            session_id: self.session_id.clone(),
-            cwd: self.cwd.clone(),
-        })
+        symposium::InputEvent::UserPromptSubmit(symposium::UserPromptSubmitInput::new(
+            self.prompt.clone(),
+            self.session_id.clone(),
+            self.cwd.clone(),
+        ))
     }
     fn from_symposium(event: &symposium::InputEvent) -> Self {
         let symposium::InputEvent::UserPromptSubmit(p) = event else {
@@ -293,10 +316,10 @@ impl AgentHookInput for KiroSessionStartInput {
         Ok(serde_json::from_str(payload)?)
     }
     fn to_symposium(&self) -> symposium::InputEvent {
-        symposium::InputEvent::SessionStart(symposium::SessionStartInput {
-            session_id: self.session_id.clone(),
-            cwd: self.cwd.clone(),
-        })
+        symposium::InputEvent::SessionStart(symposium::SessionStartInput::new(
+            self.session_id.clone(),
+            self.cwd.clone(),
+        ))
     }
     fn from_symposium(event: &symposium::InputEvent) -> Self {
         let symposium::InputEvent::SessionStart(p) = event else {

--- a/src/hook_schema/kiro.rs
+++ b/src/hook_schema/kiro.rs
@@ -63,12 +63,20 @@ macro_rules! kiro_output_impl {
     ($ty:ident, PreToolUse, PreToolUseOutput { $($extra:tt)* }) => {
         impl AgentHookOutput for $ty {
             fn parse_output(output: &[u8]) -> anyhow::Result<Self> {
-                if output.is_empty() { return Ok(Self::default()); }
+                if output.is_empty() {
+                    return Ok(Self::default());
+                }
                 let text = String::from_utf8_lossy(output);
-                Ok(Self { additional_context: Some(text.into_owned()), rest: serde_json::Map::new() })
+                Ok(Self {
+                    additional_context: Some(text.into_owned()),
+                    rest: serde_json::Map::new(),
+                })
             }
             fn from_symposium(event: &symposium::OutputEvent) -> Self {
-                Self { additional_context: event.additional_context().map(String::from), rest: serde_json::Map::new() }
+                Self {
+                    additional_context: event.additional_context().map(String::from),
+                    rest: serde_json::Map::new(),
+                }
             }
             fn to_symposium(&self) -> symposium::OutputEvent {
                 symposium::OutputEvent::PreToolUse(symposium::PreToolUseOutput::new(
@@ -77,27 +85,43 @@ macro_rules! kiro_output_impl {
                     None,
                 ))
             }
-            fn to_hook_output(&self) -> serde_json::Value { serde_json::to_value(self).unwrap() }
-            fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> { self }
+            fn to_hook_output(&self) -> serde_json::Value {
+                serde_json::to_value(self).unwrap()
+            }
+            fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+                self
+            }
         }
     };
     ($ty:ident, $variant:ident, $struct:ident { }) => {
         impl AgentHookOutput for $ty {
             fn parse_output(output: &[u8]) -> anyhow::Result<Self> {
-                if output.is_empty() { return Ok(Self::default()); }
+                if output.is_empty() {
+                    return Ok(Self::default());
+                }
                 let text = String::from_utf8_lossy(output);
-                Ok(Self { additional_context: Some(text.into_owned()), rest: serde_json::Map::new() })
+                Ok(Self {
+                    additional_context: Some(text.into_owned()),
+                    rest: serde_json::Map::new(),
+                })
             }
             fn from_symposium(event: &symposium::OutputEvent) -> Self {
-                Self { additional_context: event.additional_context().map(String::from), rest: serde_json::Map::new() }
+                Self {
+                    additional_context: event.additional_context().map(String::from),
+                    rest: serde_json::Map::new(),
+                }
             }
             fn to_symposium(&self) -> symposium::OutputEvent {
                 symposium::OutputEvent::$variant(symposium::$struct::new(
                     self.additional_context.clone(),
                 ))
             }
-            fn to_hook_output(&self) -> serde_json::Value { serde_json::to_value(self).unwrap() }
-            fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> { self }
+            fn to_hook_output(&self) -> serde_json::Value {
+                serde_json::to_value(self).unwrap()
+            }
+            fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+                self
+            }
         }
     };
 }

--- a/src/hook_schema/symposium.rs
+++ b/src/hook_schema/symposium.rs
@@ -69,10 +69,7 @@ mod tests {
 
     #[test]
     fn wildcard_matches_everything() {
-        let input = InputEvent::SessionStart(SessionStartInput::new(
-            None,
-            None,
-        ));
+        let input = InputEvent::SessionStart(SessionStartInput::new(None, None));
 
         assert!(input.matches_matcher("*"));
     }

--- a/src/hook_schema/symposium.rs
+++ b/src/hook_schema/symposium.rs
@@ -2,208 +2,19 @@
 //!
 //! Each agent module converts to/from these types. Builtin dispatch
 //! operates entirely on these types.
+//!
+//! Type definitions are owned by the `symposium-hook` crate so that hook
+//! authors can depend on them without pulling in the full symposium binary.
+//! This module re-exports those types.
 
-use regex::Regex;
-use serde::{Deserialize, Serialize};
+// Re-export wire types from the SDK crate.
+pub use symposium_hook::{
+    Input as InputEvent, Output as OutputEvent, PostToolUseInput, PostToolUseOutput,
+    PreToolUseInput, PreToolUseOutput, SessionStartInput, SessionStartOutput,
+    UserPromptSubmitInput, UserPromptSubmitOutput,
+};
 
-use super::HookEvent;
-
-// ── Input types ───────────────────────────────────────────────────────
-
-/// Canonical PreToolUse input.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PreToolUseInput {
-    pub tool_name: String,
-    #[serde(default)]
-    pub tool_input: serde_json::Value,
-    #[serde(default)]
-    pub session_id: Option<String>,
-    #[serde(default)]
-    pub cwd: Option<String>,
-}
-
-/// Canonical PostToolUse input.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PostToolUseInput {
-    pub tool_name: String,
-    #[serde(default)]
-    pub tool_input: serde_json::Value,
-    #[serde(default)]
-    pub tool_response: serde_json::Value,
-    #[serde(default)]
-    pub session_id: Option<String>,
-    #[serde(default)]
-    pub cwd: Option<String>,
-}
-
-/// Canonical UserPromptSubmit input.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UserPromptSubmitInput {
-    #[serde(default)]
-    pub prompt: String,
-    #[serde(default)]
-    pub session_id: Option<String>,
-    #[serde(default)]
-    pub cwd: Option<String>,
-}
-
-/// Canonical SessionStart input.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SessionStartInput {
-    #[serde(default)]
-    pub session_id: Option<String>,
-    #[serde(default)]
-    pub cwd: Option<String>,
-}
-
-/// Enum over all canonical input types.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum InputEvent {
-    PreToolUse(PreToolUseInput),
-    PostToolUse(PostToolUseInput),
-    UserPromptSubmit(UserPromptSubmitInput),
-    SessionStart(SessionStartInput),
-}
-
-impl InputEvent {
-    pub fn event(&self) -> HookEvent {
-        match self {
-            InputEvent::PreToolUse(_) => HookEvent::PreToolUse,
-            InputEvent::PostToolUse(_) => HookEvent::PostToolUse,
-            InputEvent::UserPromptSubmit(_) => HookEvent::UserPromptSubmit,
-            InputEvent::SessionStart(_) => HookEvent::SessionStart,
-        }
-    }
-
-    pub fn cwd(&self) -> Option<&str> {
-        match self {
-            InputEvent::PreToolUse(p) => p.cwd.as_deref(),
-            InputEvent::PostToolUse(p) => p.cwd.as_deref(),
-            InputEvent::UserPromptSubmit(p) => p.cwd.as_deref(),
-            InputEvent::SessionStart(p) => p.cwd.as_deref(),
-        }
-    }
-
-    pub fn matches_matcher(&self, matcher: &str) -> bool {
-        if matcher == "*" {
-            return true;
-        }
-
-        let tool_name = match self {
-            InputEvent::PreToolUse(p) => &p.tool_name,
-            InputEvent::PostToolUse(p) => &p.tool_name,
-            InputEvent::UserPromptSubmit(_) | InputEvent::SessionStart(_) => return true,
-        };
-
-        Regex::new(matcher).map_or(false, |re| re.is_match(tool_name))
-    }
-}
-
-// ── Output types ──────────────────────────────────────────────────────
-
-/// Canonical PreToolUse output — can inject context or modify input.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct PreToolUseOutput {
-    #[serde(
-        rename = "additionalContext",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub additional_context: Option<String>,
-    #[serde(
-        rename = "updatedInput",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub updated_input: Option<serde_json::Value>,
-}
-
-/// Canonical PostToolUse output — can inject context.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct PostToolUseOutput {
-    #[serde(
-        rename = "additionalContext",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub additional_context: Option<String>,
-}
-
-/// Canonical UserPromptSubmit output — can inject context.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct UserPromptSubmitOutput {
-    #[serde(
-        rename = "additionalContext",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub additional_context: Option<String>,
-}
-
-/// Canonical SessionStart output — can inject context.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct SessionStartOutput {
-    #[serde(
-        rename = "additionalContext",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub additional_context: Option<String>,
-}
-
-/// Enum over all canonical output types.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum OutputEvent {
-    PreToolUse(PreToolUseOutput),
-    PostToolUse(PostToolUseOutput),
-    UserPromptSubmit(UserPromptSubmitOutput),
-    SessionStart(SessionStartOutput),
-}
-
-impl OutputEvent {
-    /// Create an empty output for the given event.
-    pub fn empty_for(event: HookEvent) -> Self {
-        match event {
-            HookEvent::PreToolUse => OutputEvent::PreToolUse(PreToolUseOutput::default()),
-            HookEvent::PostToolUse => OutputEvent::PostToolUse(PostToolUseOutput::default()),
-            HookEvent::UserPromptSubmit => {
-                OutputEvent::UserPromptSubmit(UserPromptSubmitOutput::default())
-            }
-            HookEvent::SessionStart => OutputEvent::SessionStart(SessionStartOutput::default()),
-        }
-    }
-
-    /// Create an output with additional context for the given event.
-    pub fn with_context(event: HookEvent, context: String) -> Self {
-        match event {
-            HookEvent::PreToolUse => OutputEvent::PreToolUse(PreToolUseOutput {
-                additional_context: Some(context),
-                updated_input: None,
-            }),
-            HookEvent::PostToolUse => OutputEvent::PostToolUse(PostToolUseOutput {
-                additional_context: Some(context),
-            }),
-            HookEvent::UserPromptSubmit => OutputEvent::UserPromptSubmit(UserPromptSubmitOutput {
-                additional_context: Some(context),
-            }),
-            HookEvent::SessionStart => OutputEvent::SessionStart(SessionStartOutput {
-                additional_context: Some(context),
-            }),
-        }
-    }
-
-    /// Extract additional_context from any variant.
-    pub fn additional_context(&self) -> Option<&str> {
-        match self {
-            OutputEvent::PreToolUse(o) => o.additional_context.as_deref(),
-            OutputEvent::PostToolUse(o) => o.additional_context.as_deref(),
-            OutputEvent::UserPromptSubmit(o) => o.additional_context.as_deref(),
-            OutputEvent::SessionStart(o) => o.additional_context.as_deref(),
-        }
-    }
-}
-
-// ── AgentHookInput for InputEvent ────────────────────────────────────
+// ── AgentHookInput for InputEvent ────────────────────────────────────────
 // Allows symposium-format plugins to receive canonical InputEvent JSON.
 
 impl super::AgentHookInput for InputEvent {
@@ -230,12 +41,12 @@ mod tests {
 
     #[test]
     fn tool_matchers_use_regex_against_tool_name() {
-        let input = InputEvent::PreToolUse(PreToolUseInput {
-            tool_name: "mcp__filesystem__read".to_string(),
-            tool_input: serde_json::Value::Null,
-            session_id: None,
-            cwd: None,
-        });
+        let input = InputEvent::PreToolUse(PreToolUseInput::new(
+            "mcp__filesystem__read".to_string(),
+            serde_json::Value::Null,
+            None,
+            None,
+        ));
 
         assert!(input.matches_matcher("mcp__.*"));
         assert!(input.matches_matcher("^mcp__filesystem__read$"));
@@ -245,23 +56,23 @@ mod tests {
 
     #[test]
     fn invalid_regex_matchers_do_not_match() {
-        let input = InputEvent::PostToolUse(PostToolUseInput {
-            tool_name: "Bash".to_string(),
-            tool_input: serde_json::Value::Null,
-            tool_response: serde_json::Value::Null,
-            session_id: None,
-            cwd: None,
-        });
+        let input = InputEvent::PostToolUse(PostToolUseInput::new(
+            "Bash".to_string(),
+            serde_json::Value::Null,
+            serde_json::Value::Null,
+            None,
+            None,
+        ));
 
         assert!(!input.matches_matcher("("));
     }
 
     #[test]
     fn wildcard_matches_everything() {
-        let input = InputEvent::SessionStart(SessionStartInput {
-            session_id: None,
-            cwd: None,
-        });
+        let input = InputEvent::SessionStart(SessionStartInput::new(
+            None,
+            None,
+        ));
 
         assert!(input.matches_matcher("*"));
     }

--- a/symposium-hook/Cargo.toml
+++ b/symposium-hook/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "symposium-hook"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "SDK for writing symposium hook handlers in Rust"
+repository = "https://github.com/symposium-dev/symposium"
+
+[features]
+clap = ["dep:clap"]
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive"], optional = true }
+regex = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/symposium-hook/examples/block_destructive.rs
+++ b/symposium-hook/examples/block_destructive.rs
@@ -1,0 +1,23 @@
+use std::process::ExitCode;
+use symposium_hook::{HookHandler, PreToolUseInput, PreToolUseOutput, run};
+
+struct BlockDestructive;
+
+impl HookHandler for BlockDestructive {
+    fn pre_tool_use(&self, event: &PreToolUseInput) -> anyhow::Result<PreToolUseOutput> {
+        if event.tool_name == "Bash" {
+            if let Some(cmd) = event.tool_input.get("command").and_then(|v| v.as_str()) {
+                if cmd.contains("rm -rf") {
+                    return Ok(PreToolUseOutput::deny(
+                        "Destructive rm -rf commands are not allowed",
+                    ));
+                }
+            }
+        }
+        Ok(PreToolUseOutput::default())
+    }
+}
+
+fn main() -> ExitCode {
+    run(BlockDestructive)
+}

--- a/symposium-hook/examples/inject_context.rs
+++ b/symposium-hook/examples/inject_context.rs
@@ -1,0 +1,16 @@
+use std::process::ExitCode;
+use symposium_hook::{HookHandler, SessionStartInput, SessionStartOutput, run};
+
+struct InjectContext;
+
+impl HookHandler for InjectContext {
+    fn session_start(&self, _event: &SessionStartInput) -> anyhow::Result<SessionStartOutput> {
+        Ok(SessionStartOutput::context(
+            "This project uses tokio 1.x for async. Prefer spawn over block_on.",
+        ))
+    }
+}
+
+fn main() -> ExitCode {
+    run(InjectContext)
+}

--- a/symposium-hook/src/lib.rs
+++ b/symposium-hook/src/lib.rs
@@ -1,0 +1,505 @@
+//! SDK for writing symposium hook handlers in Rust.
+//!
+//! A symposium hook is a program that reads a JSON event on stdin and writes a
+//! JSON response to stdout. This crate provides the types and a `run()` harness
+//! so you can focus on the logic.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use std::process::ExitCode;
+//! use symposium_hook::{HookHandler, PreToolUseInput, PreToolUseOutput, run};
+//!
+//! struct MyHook;
+//!
+//! impl HookHandler for MyHook {
+//!     fn pre_tool_use(&self, event: &PreToolUseInput) -> anyhow::Result<PreToolUseOutput> {
+//!         if event.tool_name == "Bash" {
+//!             Ok(PreToolUseOutput::context("Remember: prefer non-destructive commands"))
+//!         } else {
+//!             Ok(PreToolUseOutput::default())
+//!         }
+//!     }
+//! }
+//!
+//! fn main() -> ExitCode {
+//!     run(MyHook)
+//! }
+//! ```
+
+pub use anyhow;
+
+use serde::{Deserialize, Serialize};
+use std::io::Read as _;
+use std::process::ExitCode;
+
+// ── Event types ─────────────────────────────────────────────────────────
+
+/// Hook event types supported by Symposium.
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+pub enum HookEvent {
+    #[cfg_attr(feature = "clap", value(name = "pre-tool-use"))]
+    #[serde(rename = "PreToolUse")]
+    PreToolUse,
+
+    #[cfg_attr(feature = "clap", value(name = "post-tool-use"))]
+    #[serde(rename = "PostToolUse")]
+    PostToolUse,
+
+    #[cfg_attr(feature = "clap", value(name = "user-prompt-submit"))]
+    #[serde(rename = "UserPromptSubmit")]
+    UserPromptSubmit,
+
+    #[cfg_attr(feature = "clap", value(name = "session-start"))]
+    #[serde(rename = "SessionStart")]
+    SessionStart,
+}
+
+// ── Input types ─────────────────────────────────────────────────────────
+
+/// Input event received on stdin.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum Input {
+    PreToolUse(PreToolUseInput),
+    PostToolUse(PostToolUseInput),
+    UserPromptSubmit(UserPromptSubmitInput),
+    SessionStart(SessionStartInput),
+}
+
+impl Input {
+    /// Returns the event type for this input.
+    pub fn event(&self) -> HookEvent {
+        match self {
+            Input::PreToolUse(_) => HookEvent::PreToolUse,
+            Input::PostToolUse(_) => HookEvent::PostToolUse,
+            Input::UserPromptSubmit(_) => HookEvent::UserPromptSubmit,
+            Input::SessionStart(_) => HookEvent::SessionStart,
+        }
+    }
+
+    /// Extract the working directory from any event variant.
+    pub fn cwd(&self) -> Option<&str> {
+        match self {
+            Input::PreToolUse(p) => p.cwd.as_deref(),
+            Input::PostToolUse(p) => p.cwd.as_deref(),
+            Input::UserPromptSubmit(p) => p.cwd.as_deref(),
+            Input::SessionStart(p) => p.cwd.as_deref(),
+        }
+    }
+
+    /// Check whether this event matches the given matcher string.
+    ///
+    /// For tool events (`PreToolUse`, `PostToolUse`), the matcher is a regex
+    /// tested against the tool name. For other events, all matchers match.
+    /// The wildcard `"*"` matches everything.
+    pub fn matches_matcher(&self, matcher: &str) -> bool {
+        if matcher == "*" {
+            return true;
+        }
+
+        let tool_name = match self {
+            Input::PreToolUse(p) => &p.tool_name,
+            Input::PostToolUse(p) => &p.tool_name,
+            Input::UserPromptSubmit(_) | Input::SessionStart(_) => return true,
+        };
+
+        regex::Regex::new(matcher).map_or(false, |re| re.is_match(tool_name))
+    }
+}
+
+/// Input for a `PreToolUse` event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct PreToolUseInput {
+    pub tool_name: String,
+    #[serde(default)]
+    pub tool_input: serde_json::Value,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub cwd: Option<String>,
+}
+
+impl PreToolUseInput {
+    pub fn new(
+        tool_name: String,
+        tool_input: serde_json::Value,
+        session_id: Option<String>,
+        cwd: Option<String>,
+    ) -> Self {
+        Self { tool_name, tool_input, session_id, cwd }
+    }
+}
+
+/// Input for a `PostToolUse` event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct PostToolUseInput {
+    pub tool_name: String,
+    #[serde(default)]
+    pub tool_input: serde_json::Value,
+    #[serde(default)]
+    pub tool_response: serde_json::Value,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub cwd: Option<String>,
+}
+
+impl PostToolUseInput {
+    pub fn new(
+        tool_name: String,
+        tool_input: serde_json::Value,
+        tool_response: serde_json::Value,
+        session_id: Option<String>,
+        cwd: Option<String>,
+    ) -> Self {
+        Self { tool_name, tool_input, tool_response, session_id, cwd }
+    }
+}
+
+/// Input for a `UserPromptSubmit` event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct UserPromptSubmitInput {
+    #[serde(default)]
+    pub prompt: String,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub cwd: Option<String>,
+}
+
+impl UserPromptSubmitInput {
+    pub fn new(prompt: String, session_id: Option<String>, cwd: Option<String>) -> Self {
+        Self { prompt, session_id, cwd }
+    }
+}
+
+/// Input for a `SessionStart` event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct SessionStartInput {
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub cwd: Option<String>,
+}
+
+impl SessionStartInput {
+    pub fn new(session_id: Option<String>, cwd: Option<String>) -> Self {
+        Self { session_id, cwd }
+    }
+}
+
+// ── Output types ────────────────────────────────────────────────────────
+
+/// Output event written to stdout.
+#[non_exhaustive]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Output {
+    PreToolUse(PreToolUseOutput),
+    PostToolUse(PostToolUseOutput),
+    UserPromptSubmit(UserPromptSubmitOutput),
+    SessionStart(SessionStartOutput),
+}
+
+impl Output {
+    /// Create an empty output for the given event type.
+    pub fn empty_for(event: HookEvent) -> Self {
+        match event {
+            HookEvent::PreToolUse => Output::PreToolUse(PreToolUseOutput::default()),
+            HookEvent::PostToolUse => Output::PostToolUse(PostToolUseOutput::default()),
+            HookEvent::UserPromptSubmit => {
+                Output::UserPromptSubmit(UserPromptSubmitOutput::default())
+            }
+            HookEvent::SessionStart => Output::SessionStart(SessionStartOutput::default()),
+        }
+    }
+
+    /// Create an output with additional context for the given event type.
+    pub fn with_context(event: HookEvent, context: String) -> Self {
+        match event {
+            HookEvent::PreToolUse => Output::PreToolUse(PreToolUseOutput::context(context)),
+            HookEvent::PostToolUse => Output::PostToolUse(PostToolUseOutput::context(context)),
+            HookEvent::UserPromptSubmit => {
+                Output::UserPromptSubmit(UserPromptSubmitOutput::context(context))
+            }
+            HookEvent::SessionStart => Output::SessionStart(SessionStartOutput::context(context)),
+        }
+    }
+
+    /// Extract additional context from any variant.
+    pub fn additional_context(&self) -> Option<&str> {
+        match self {
+            Output::PreToolUse(o) => o.additional_context.as_deref(),
+            Output::PostToolUse(o) => o.additional_context.as_deref(),
+            Output::UserPromptSubmit(o) => o.additional_context.as_deref(),
+            Output::SessionStart(o) => o.additional_context.as_deref(),
+        }
+    }
+}
+
+/// Output for a `PreToolUse` event.
+/// Decision for a `PreToolUse` hook.
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Decision {
+    /// Allow the tool call to proceed (default).
+    #[default]
+    Allow,
+    /// Block the tool call.
+    Deny,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PreToolUseOutput {
+    #[serde(default, skip_serializing_if = "Decision::is_allow")]
+    pub decision: Decision,
+    #[serde(
+        rename = "additionalContext",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub additional_context: Option<String>,
+    #[serde(
+        rename = "updatedInput",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub updated_input: Option<serde_json::Value>,
+}
+
+impl Decision {
+    fn is_allow(&self) -> bool {
+        *self == Decision::Allow
+    }
+}
+
+impl PreToolUseOutput {
+    /// Create an output with all fields specified.
+    pub fn new(
+        decision: Decision,
+        additional_context: Option<String>,
+        updated_input: Option<serde_json::Value>,
+    ) -> Self {
+        Self {
+            decision,
+            additional_context,
+            updated_input,
+        }
+    }
+
+    /// Create an output that injects additional context.
+    pub fn context(text: impl Into<String>) -> Self {
+        Self {
+            additional_context: Some(text.into()),
+            ..Default::default()
+        }
+    }
+
+    /// Create an output that replaces the tool input.
+    pub fn with_updated_input(input: serde_json::Value) -> Self {
+        Self {
+            updated_input: Some(input),
+            ..Default::default()
+        }
+    }
+
+    /// Deny the tool call with a reason.
+    pub fn deny(reason: impl Into<String>) -> Self {
+        Self {
+            decision: Decision::Deny,
+            additional_context: Some(reason.into()),
+            ..Default::default()
+        }
+    }
+}
+
+/// Output for a `PostToolUse` event.
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PostToolUseOutput {
+    #[serde(
+        rename = "additionalContext",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub additional_context: Option<String>,
+}
+
+impl PostToolUseOutput {
+    /// Create an output with all fields specified.
+    pub fn new(additional_context: Option<String>) -> Self {
+        Self { additional_context }
+    }
+
+    /// Create an output that injects additional context.
+    pub fn context(text: impl Into<String>) -> Self {
+        Self::new(Some(text.into()))
+    }
+}
+
+/// Output for a `UserPromptSubmit` event.
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct UserPromptSubmitOutput {
+    #[serde(
+        rename = "additionalContext",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub additional_context: Option<String>,
+}
+
+impl UserPromptSubmitOutput {
+    /// Create an output with all fields specified.
+    pub fn new(additional_context: Option<String>) -> Self {
+        Self { additional_context }
+    }
+
+    /// Create an output that injects additional context.
+    pub fn context(text: impl Into<String>) -> Self {
+        Self::new(Some(text.into()))
+    }
+}
+
+/// Output for a `SessionStart` event.
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SessionStartOutput {
+    #[serde(
+        rename = "additionalContext",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub additional_context: Option<String>,
+}
+
+impl SessionStartOutput {
+    /// Create an output with all fields specified.
+    pub fn new(additional_context: Option<String>) -> Self {
+        Self { additional_context }
+    }
+
+    /// Create an output that injects additional context.
+    pub fn context(text: impl Into<String>) -> Self {
+        Self::new(Some(text.into()))
+    }
+}
+
+// ── Handler trait ───────────────────────────────────────────────────────
+
+/// Default dispatch logic: matches on the event variant and calls the
+/// corresponding method on the handler, wrapping the result in the appropriate
+/// `Output` variant.
+pub fn default_handle_event(
+    handler: &(impl HookHandler + ?Sized),
+    input: &Input,
+) -> anyhow::Result<Output> {
+    match input {
+        Input::PreToolUse(event) => Ok(Output::PreToolUse(handler.pre_tool_use(event)?)),
+        Input::PostToolUse(event) => Ok(Output::PostToolUse(handler.post_tool_use(event)?)),
+        Input::UserPromptSubmit(event) => {
+            Ok(Output::UserPromptSubmit(handler.user_prompt_submit(event)?))
+        }
+        Input::SessionStart(event) => Ok(Output::SessionStart(handler.session_start(event)?)),
+    }
+}
+
+/// Trait for implementing a symposium hook handler.
+///
+/// Override the methods for the events you care about. The defaults return
+/// the default (empty) output for each event type.
+pub trait HookHandler {
+    /// Dispatch an input event to the appropriate handler method.
+    ///
+    /// The default implementation calls [`default_handle_event`], which matches
+    /// on the event variant, calls the corresponding method, and wraps the
+    /// result in the appropriate `Output` variant.
+    fn handle_event(&self, input: &Input) -> anyhow::Result<Output> {
+        default_handle_event(self, input)
+    }
+
+    /// Called before the agent invokes a tool.
+    fn pre_tool_use(&self, _event: &PreToolUseInput) -> anyhow::Result<PreToolUseOutput> {
+        Ok(PreToolUseOutput::default())
+    }
+
+    /// Called after a tool completes.
+    fn post_tool_use(&self, _event: &PostToolUseInput) -> anyhow::Result<PostToolUseOutput> {
+        Ok(PostToolUseOutput::default())
+    }
+
+    /// Called when the user submits a prompt.
+    fn user_prompt_submit(
+        &self,
+        _event: &UserPromptSubmitInput,
+    ) -> anyhow::Result<UserPromptSubmitOutput> {
+        Ok(UserPromptSubmitOutput::default())
+    }
+
+    /// Called when an agent session begins.
+    fn session_start(&self, _event: &SessionStartInput) -> anyhow::Result<SessionStartOutput> {
+        Ok(SessionStartOutput::default())
+    }
+}
+
+// ── Harness ─────────────────────────────────────────────────────────────
+
+/// Run a hook handler. Reads the input event from stdin, dispatches to the
+/// handler, and writes the output to stdout with the correct exit code.
+///
+/// - Empty output (all fields `None`) → exit 0, no stdout.
+/// - Non-empty output → exit 0, JSON on stdout.
+/// - `Err(...)` → exit 1, error message on stderr.
+pub fn run(handler: impl HookHandler) -> ExitCode {
+    let mut input_str = String::new();
+    if std::io::stdin().read_to_string(&mut input_str).is_err() {
+        return ExitCode::FAILURE;
+    }
+
+    let input: Input = match serde_json::from_str(&input_str) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("symposium-hook: failed to parse input: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let output = match handler.handle_event(&input) {
+        Ok(o) => o,
+        Err(e) => {
+            eprintln!("symposium-hook: handler error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if is_empty_output(&output) {
+        return ExitCode::SUCCESS;
+    }
+
+    match serde_json::to_string(&output) {
+        Ok(json) => println!("{json}"),
+        Err(e) => {
+            eprintln!("symposium-hook: failed to serialize output: {e}");
+            return ExitCode::FAILURE;
+        }
+    }
+
+    ExitCode::SUCCESS
+}
+
+fn is_empty_output(output: &Output) -> bool {
+    match output {
+        Output::PreToolUse(o) => o.additional_context.is_none() && o.updated_input.is_none(),
+        Output::PostToolUse(o) => o.additional_context.is_none(),
+        Output::UserPromptSubmit(o) => o.additional_context.is_none(),
+        Output::SessionStart(o) => o.additional_context.is_none(),
+    }
+}

--- a/symposium-hook/src/lib.rs
+++ b/symposium-hook/src/lib.rs
@@ -130,7 +130,12 @@ impl PreToolUseInput {
         session_id: Option<String>,
         cwd: Option<String>,
     ) -> Self {
-        Self { tool_name, tool_input, session_id, cwd }
+        Self {
+            tool_name,
+            tool_input,
+            session_id,
+            cwd,
+        }
     }
 }
 
@@ -157,7 +162,13 @@ impl PostToolUseInput {
         session_id: Option<String>,
         cwd: Option<String>,
     ) -> Self {
-        Self { tool_name, tool_input, tool_response, session_id, cwd }
+        Self {
+            tool_name,
+            tool_input,
+            tool_response,
+            session_id,
+            cwd,
+        }
     }
 }
 
@@ -175,7 +186,11 @@ pub struct UserPromptSubmitInput {
 
 impl UserPromptSubmitInput {
     pub fn new(prompt: String, session_id: Option<String>, cwd: Option<String>) -> Self {
-        Self { prompt, session_id, cwd }
+        Self {
+            prompt,
+            session_id,
+            cwd,
+        }
     }
 }
 

--- a/symposium-testlib/src/lib.rs
+++ b/symposium-testlib/src/lib.rs
@@ -119,38 +119,38 @@ impl HookStep {
         let cwd = Some(cwd.to_string());
         match self {
             Self::SessionStart => {
-                sym_types::InputEvent::SessionStart(sym_types::SessionStartInput {
+                sym_types::InputEvent::SessionStart(sym_types::SessionStartInput::new(
                     session_id,
                     cwd,
-                })
+                ))
             }
             Self::UserPromptSubmit { prompt } => {
-                sym_types::InputEvent::UserPromptSubmit(sym_types::UserPromptSubmitInput {
-                    prompt: prompt.clone(),
+                sym_types::InputEvent::UserPromptSubmit(sym_types::UserPromptSubmitInput::new(
+                    prompt.clone(),
                     session_id,
                     cwd,
-                })
+                ))
             }
             Self::PreToolUse {
                 tool_name,
                 tool_input,
-            } => sym_types::InputEvent::PreToolUse(sym_types::PreToolUseInput {
-                tool_name: tool_name.clone(),
-                tool_input: tool_input.clone(),
+            } => sym_types::InputEvent::PreToolUse(sym_types::PreToolUseInput::new(
+                tool_name.clone(),
+                tool_input.clone(),
                 session_id,
                 cwd,
-            }),
+            )),
             Self::PostToolUse {
                 tool_name,
                 tool_input,
                 tool_response,
-            } => sym_types::InputEvent::PostToolUse(sym_types::PostToolUseInput {
-                tool_name: tool_name.clone(),
-                tool_input: tool_input.clone(),
-                tool_response: tool_response.clone(),
+            } => sym_types::InputEvent::PostToolUse(sym_types::PostToolUseInput::new(
+                tool_name.clone(),
+                tool_input.clone(),
+                tool_response.clone(),
                 session_id,
                 cwd,
-            }),
+            )),
         }
     }
 }

--- a/symposium-testlib/src/lib.rs
+++ b/symposium-testlib/src/lib.rs
@@ -118,19 +118,12 @@ impl HookStep {
         let session_id = Some("test-session-id".to_string());
         let cwd = Some(cwd.to_string());
         match self {
-            Self::SessionStart => {
-                sym_types::InputEvent::SessionStart(sym_types::SessionStartInput::new(
-                    session_id,
-                    cwd,
-                ))
-            }
-            Self::UserPromptSubmit { prompt } => {
-                sym_types::InputEvent::UserPromptSubmit(sym_types::UserPromptSubmitInput::new(
-                    prompt.clone(),
-                    session_id,
-                    cwd,
-                ))
-            }
+            Self::SessionStart => sym_types::InputEvent::SessionStart(
+                sym_types::SessionStartInput::new(session_id, cwd),
+            ),
+            Self::UserPromptSubmit { prompt } => sym_types::InputEvent::UserPromptSubmit(
+                sym_types::UserPromptSubmitInput::new(prompt.clone(), session_id, cwd),
+            ),
             Self::PreToolUse {
                 tool_name,
                 tool_input,

--- a/tests/fixtures/plugin-hooks-format/dot-symposium/config.toml
+++ b/tests/fixtures/plugin-hooks-format/dot-symposium/config.toml
@@ -1,0 +1,6 @@
+hook-scope = "project"
+auto-sync = false
+
+[defaults]
+symposium-recommendations = false
+user-plugins = true

--- a/tests/fixtures/plugin-hooks-format/dot-symposium/plugins/claude-only-plugin/SYMPOSIUM.toml
+++ b/tests/fixtures/plugin-hooks-format/dot-symposium/plugins/claude-only-plugin/SYMPOSIUM.toml
@@ -1,0 +1,12 @@
+name = "claude-only-plugin"
+crates = ["*"]
+
+# Only a Claude hook — no symposium fallback.
+# Should fire on Claude, should NOT fire on other agents.
+# Uses matcher "Read" to avoid conflict with format-plugin's "Bash" hooks.
+[[hooks]]
+name = "claude-only"
+event = "PreToolUse"
+matcher = "Read"
+format = "claude"
+command = { script = "$TEST_DIR/dot-symposium/plugins/claude-only-plugin/scripts/claude-only.sh" }

--- a/tests/fixtures/plugin-hooks-format/dot-symposium/plugins/claude-only-plugin/scripts/claude-only.sh
+++ b/tests/fixtures/plugin-hooks-format/dot-symposium/plugins/claude-only-plugin/scripts/claude-only.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"claude-only-fired"}}'

--- a/tests/fixtures/plugin-hooks-format/dot-symposium/plugins/format-plugin/SYMPOSIUM.toml
+++ b/tests/fixtures/plugin-hooks-format/dot-symposium/plugins/format-plugin/SYMPOSIUM.toml
@@ -1,0 +1,18 @@
+name = "format-plugin"
+crates = ["*"]
+
+# Claude-specific hook — should fire on Claude, be skipped on other agents.
+[[hooks]]
+name = "claude-specific"
+event = "PreToolUse"
+matcher = "Bash"
+format = "claude"
+command = { script = "$TEST_DIR/dot-symposium/plugins/format-plugin/scripts/claude-hook.sh" }
+
+# Symposium fallback — should fire on non-Claude agents.
+[[hooks]]
+name = "symposium-fallback"
+event = "PreToolUse"
+matcher = "Bash"
+format = "symposium"
+command = { script = "$TEST_DIR/dot-symposium/plugins/format-plugin/scripts/symposium-hook.sh" }

--- a/tests/fixtures/plugin-hooks-format/dot-symposium/plugins/format-plugin/scripts/claude-hook.sh
+++ b/tests/fixtures/plugin-hooks-format/dot-symposium/plugins/format-plugin/scripts/claude-hook.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Claude native format — outputs Claude-style JSON
+echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"claude-hook-fired"}}'

--- a/tests/fixtures/plugin-hooks-format/dot-symposium/plugins/format-plugin/scripts/symposium-hook.sh
+++ b/tests/fixtures/plugin-hooks-format/dot-symposium/plugins/format-plugin/scripts/symposium-hook.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo '{"PreToolUse":{"additionalContext":"symposium-hook-fired"}}'

--- a/tests/hook_events_doc.rs
+++ b/tests/hook_events_doc.rs
@@ -1,0 +1,118 @@
+//! Verifies that JSON examples in `md/reference/hook-events.md` deserialize
+//! as valid symposium hook events and round-trip cleanly through serde.
+
+use symposium::hook_schema::symposium::{InputEvent, OutputEvent};
+
+fn extract_json_blocks(markdown: &str) -> Vec<(usize, String)> {
+    let mut blocks = Vec::new();
+    let mut in_block = false;
+    let mut current = String::new();
+    let mut block_start_line = 0;
+
+    for (line_no, line) in markdown.lines().enumerate() {
+        if !in_block {
+            if line.trim_start().starts_with("```json") {
+                in_block = true;
+                current.clear();
+                block_start_line = line_no + 1;
+            }
+        } else if line.trim_start().starts_with("```") {
+            blocks.push((block_start_line, current.clone()));
+            in_block = false;
+        } else {
+            current.push_str(line);
+            current.push('\n');
+        }
+    }
+
+    blocks
+}
+
+/// Determine if a JSON block is under an "Input" or "Output" top-level section
+/// by scanning backwards from the block's line number for the nearest `## `
+/// (level-2) heading.
+fn parent_section_for_line(markdown: &str, target_line: usize) -> String {
+    let lines: Vec<&str> = markdown.lines().collect();
+    for i in (0..target_line).rev() {
+        let trimmed = lines[i].trim();
+        if trimmed.starts_with("## ") && !trimmed.starts_with("### ") {
+            return trimmed.to_lowercase();
+        }
+    }
+    String::new()
+}
+
+fn is_input_section(section: &str) -> bool {
+    section.contains("input")
+}
+
+fn is_output_section(section: &str) -> bool {
+    section.contains("output")
+}
+
+#[test]
+fn doc_json_examples_roundtrip() {
+    let doc = include_str!("../md/reference/hook-events.md");
+    let blocks = extract_json_blocks(doc);
+
+    assert!(
+        blocks.len() >= 8,
+        "expected at least 8 JSON blocks (4 input + 4 output), found {}",
+        blocks.len()
+    );
+
+    let mut input_count = 0;
+    let mut output_count = 0;
+
+    for (line_no, json_str) in &blocks {
+        let section = parent_section_for_line(doc, *line_no);
+
+        // Skip blocks in the "Testing" section — those are CLI examples
+        if section.contains("testing") {
+            continue;
+        }
+
+        if is_input_section(&section) {
+            let parsed: InputEvent = serde_json::from_str(json_str).unwrap_or_else(|e| {
+                panic!(
+                    "Failed to parse InputEvent from doc (line {}): {e}\nJSON: {json_str}",
+                    line_no
+                )
+            });
+            let reserialized = serde_json::to_value(&parsed).unwrap();
+            let original: serde_json::Value = serde_json::from_str(json_str).unwrap();
+            assert_eq!(
+                reserialized, original,
+                "InputEvent round-trip mismatch at line {line_no}"
+            );
+            input_count += 1;
+        } else if is_output_section(&section) {
+            let parsed: OutputEvent = serde_json::from_str(json_str).unwrap_or_else(|e| {
+                panic!(
+                    "Failed to parse OutputEvent from doc (line {}): {e}\nJSON: {json_str}",
+                    line_no
+                )
+            });
+            let reserialized = serde_json::to_value(&parsed).unwrap();
+            let original: serde_json::Value = serde_json::from_str(json_str).unwrap();
+            assert_eq!(
+                reserialized, original,
+                "OutputEvent round-trip mismatch at line {line_no}"
+            );
+            output_count += 1;
+        } else {
+            panic!(
+                "JSON block at line {line_no} is not under a recognized input/output section: {section:?}"
+            );
+        }
+    }
+
+    assert!(
+        input_count >= 4,
+        "expected at least 4 input examples, found {input_count}"
+    );
+    assert!(
+        output_count >= 4,
+        "expected at least 4 output examples, found {output_count}"
+    );
+}

--- a/tests/hook_format_priority.rs
+++ b/tests/hook_format_priority.rs
@@ -1,0 +1,142 @@
+//! Tests for per-plugin format selection in hook dispatch.
+//!
+//! Verifies that:
+//! - A native hook (matching the host agent) takes priority over a symposium hook.
+//! - A symposium hook fires when no native hook matches.
+//! - A hook for a different agent does not fire when there's no symposium fallback.
+
+use serde_json::json;
+use symposium::hook_schema::{HookAgent, HookEvent};
+use symposium_testlib::{HookStep, TestMode, with_fixture};
+
+/// When running on Claude and the plugin has both `format = "claude"` and
+/// `format = "symposium"` hooks, the claude hook fires (native priority).
+#[tokio::test(flavor = "multi_thread")]
+async fn native_hook_takes_priority_over_symposium() {
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["plugin-hooks-format"],
+        async |mut ctx| {
+            let result = ctx
+                .prompt_or_hook(
+                    "ignored",
+                    &[HookStep::PreToolUse {
+                        tool_name: "Bash".to_string(),
+                        tool_input: json!({"command": "ls"}),
+                    }],
+                    HookAgent::Claude,
+                )
+                .await?;
+
+            assert!(
+                result.has_context_containing("claude-hook-fired"),
+                "expected claude native hook to fire on Claude, got: {:#?}",
+                result.outputs_for(HookEvent::PreToolUse),
+            );
+            assert!(
+                !result.has_context_containing("symposium-hook-fired"),
+                "symposium hook should NOT fire when native hook matches",
+            );
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+}
+
+/// When running on Copilot and the plugin has both `format = "claude"` and
+/// `format = "symposium"` hooks, the symposium hook fires (no native match).
+#[tokio::test(flavor = "multi_thread")]
+async fn symposium_hook_fires_when_no_native_match() {
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["plugin-hooks-format"],
+        async |mut ctx| {
+            let result = ctx
+                .prompt_or_hook(
+                    "ignored",
+                    &[HookStep::PreToolUse {
+                        tool_name: "Bash".to_string(),
+                        tool_input: json!({"command": "ls"}),
+                    }],
+                    HookAgent::Copilot,
+                )
+                .await?;
+
+            assert!(
+                result.has_context_containing("symposium-hook-fired"),
+                "expected symposium hook to fire on Copilot, got: {:#?}",
+                result.outputs_for(HookEvent::PreToolUse),
+            );
+            assert!(
+                !result.has_context_containing("claude-hook-fired"),
+                "claude hook should NOT fire on Copilot",
+            );
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+}
+
+/// When running on Claude and the plugin only has `format = "claude"` (no
+/// symposium fallback), the hook fires.
+#[tokio::test(flavor = "multi_thread")]
+async fn claude_only_hook_fires_on_claude() {
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["plugin-hooks-format"],
+        async |mut ctx| {
+            let result = ctx
+                .prompt_or_hook(
+                    "ignored",
+                    &[HookStep::PreToolUse {
+                        tool_name: "Read".to_string(),
+                        tool_input: json!({"file_path": "/tmp/x"}),
+                    }],
+                    HookAgent::Claude,
+                )
+                .await?;
+
+            assert!(
+                result.has_context_containing("claude-only-fired"),
+                "expected claude-only hook to fire on Claude, got: {:#?}",
+                result.outputs_for(HookEvent::PreToolUse),
+            );
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+}
+
+/// When running on Copilot and the plugin only has `format = "claude"` (no
+/// symposium fallback), nothing fires — the hook is silently skipped.
+#[tokio::test(flavor = "multi_thread")]
+async fn claude_only_hook_does_not_fire_on_other_agents() {
+    with_fixture(
+        TestMode::SimulationOnly,
+        &["plugin-hooks-format"],
+        async |mut ctx| {
+            let result = ctx
+                .prompt_or_hook(
+                    "ignored",
+                    &[HookStep::PreToolUse {
+                        tool_name: "Read".to_string(),
+                        tool_input: json!({"file_path": "/tmp/x"}),
+                    }],
+                    HookAgent::Copilot,
+                )
+                .await?;
+
+            assert!(
+                !result.has_context_containing("claude-only-fired"),
+                "claude-only hook should NOT fire on Copilot, got: {:#?}",
+                result.outputs_for(HookEvent::PreToolUse),
+            );
+            Ok(())
+        },
+    )
+    .await
+    .unwrap();
+}


### PR DESCRIPTION
## What does this PR do?

Rework symposium's hook architecture:

* We now have "symposium" as the "interoperable" hook and the ability to provide "native" hook handlers as specialized alternatives. We never convert *into* a native input. We prefer a native handler and fallback to a symposium handler if it exists, otherwise we do nothing.
* Create a `symposium-hook` library for authoring symposium handlers.
* Improve the user-facing docs in general 
* Document overall design tenets and alternatives considered

In particular, I originally wanted to install native hooks into the agent-specific config, but I realized that this would lead to files that have to be added into git, so I opted against that route.

<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

* The AI tool authored large parts of the code

**Questions for reviewers.**

<!-- Any specific areas of uncertainty or things you'd like reviewers to look at? -->

</details>
