### PR TITLE
extract symposium-install crate and make symposium-hook async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2448,6 +2448,7 @@ dependencies = [
  "serde_yaml_ng",
  "sha2",
  "symposium-hook",
+ "symposium-install",
  "symposium-testlib",
  "tar",
  "tempfile",
@@ -2465,9 +2466,30 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "dirs",
  "regex",
  "serde",
  "serde_json",
+ "symposium-install",
+ "tokio",
+]
+
+[[package]]
+name = "symposium-install"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "chrono",
+ "clap",
+ "flate2",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tar",
+ "tempfile",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2659,9 +2681,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ bytes = "1.11.1"
 dialoguer = "0.12.0"
 toml_edit = "0.25.11"
 url = "2.5.8"
+symposium-install = { version = "0.1.0", path = "symposium-install", features = ["clap"] }
 
 
 [dev-dependencies]
@@ -61,4 +62,4 @@ indoc = "2.0.7"
 symposium-testlib = { path = "symposium-testlib" }
 
 [workspace]
-members = [".", "symposium-testlib", "symposium-hook"]
+members = [".", "symposium-testlib", "symposium-hook", "symposium-install"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,7 +27,7 @@ use crate::sync;
 pub struct Cli {
     /// Control plugin source update behavior (none, check, fetch)
     #[arg(long, global = true, default_value = "none")]
-    pub update: crate::plugins::UpdateLevel,
+    pub update: symposium_install::UpdateLevel,
 
     /// Suppress status output
     #[arg(short, long, global = true)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -270,6 +270,15 @@ impl Symposium {
         }
     }
 
+    /// Create an [`InstallContext`] for use with `symposium-install` functions.
+    pub fn install_context(&self) -> symposium_install::InstallContext {
+        let ctx = symposium_install::InstallContext::new(self.cache_dir.clone());
+        match &self.cargo_override {
+            Some(path) => ctx.with_cargo_bin(path.clone()),
+            None => ctx,
+        }
+    }
+
     /// Override the cargo binary path (test-only).
     #[doc(hidden)]
     pub fn set_cargo_override(&mut self, path: PathBuf) {

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -4,13 +4,13 @@ use std::{
     process::{Command, ExitCode, Stdio},
 };
 
-use crate::installation::{Runnable, acquire_source, make_executable};
 use crate::plugins::{HookFormat, Installation};
 use crate::{
     config::Symposium,
     hook_schema::{AgentHookInput, symposium},
     plugins::ParsedPlugin,
 };
+use symposium_install::{Runnable, acquire_source, make_executable};
 
 /// A hook prepared for dispatch — installation names looked up to concrete
 /// `Installation` entries, so the dispatch loop never has to scan the plugin's
@@ -65,7 +65,12 @@ impl ResolvedHook {
 /// a runnable — requirements are only ever "ensure on disk".
 async fn install(sym: &Symposium, install: &Installation) -> anyhow::Result<()> {
     if let Some(source) = &install.source {
-        acquire_source(sym, source, install.executable.as_deref()).await?;
+        acquire_source(
+            &sym.install_context(),
+            source,
+            install.executable.as_deref(),
+        )
+        .await?;
     }
     run_install_commands(&install.install_commands).await
 }
@@ -105,7 +110,7 @@ async fn build_spawn_spec(sym: &Symposium, hook: &ResolvedHook) -> anyhow::Resul
 
     // Acquire the source if any.
     let acquired = match &installation.source {
-        Some(source) => Some(acquire_source(sym, source, exec_choice).await?),
+        Some(source) => Some(acquire_source(&sym.install_context(), source, exec_choice).await?),
         None => None,
     };
 
@@ -113,13 +118,13 @@ async fn build_spawn_spec(sym: &Symposium, hook: &ResolvedHook) -> anyhow::Resul
     run_install_commands(&installation.install_commands).await?;
 
     let runnable = match (acquired, exec_choice, script_choice) {
-        (Some(a), Some(name), None) => Runnable::Exec(a.resolve_executable(name)),
-        (Some(a), None, Some(name)) => Runnable::Script(a.resolve_script(name)),
+        (Some(a), Some(name), None) => Runnable::Exec(a.executable_named(name)),
+        (Some(a), None, Some(name)) => Runnable::Script(a.script_named(name)),
         (Some(a), None, None) => {
             // Cargo single-binary fallback: use the binary name resolved at
             // acquisition time (from crates.io or the explicit hint).
             if let Some(name) = a.resolved_executable.as_deref() {
-                Runnable::Exec(a.resolve_executable(name))
+                Runnable::Exec(a.executable_named(name))
             } else {
                 anyhow::bail!(
                     "hook `{}`: command resolved to no executable or script",
@@ -149,6 +154,7 @@ async fn build_spawn_spec(sym: &Symposium, hook: &ResolvedHook) -> anyhow::Resul
             path,
             args: hook.args.clone(),
         }),
+        _ => anyhow::bail!("hook `{}`: unsupported runnable kind", hook.hook_name),
     }
 }
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -28,9 +28,13 @@ fn interactive(out: &Output) -> bool {
 
 /// Resolve which agents to configure. Priority:
 /// 1. Explicit `--add-agent` / `--remove-agent` flags (applied to existing set)
-/// 2. Interactive multi-select (if terminal), pre-selecting existing agents
+/// 2. Interactive multi-select (if `should_prompt`), pre-selecting existing agents
 /// 3. Default to first agent (Claude) in non-interactive mode
-fn resolve_agents(opts: &InitOpts, existing: &[AgentEntry], out: &Output) -> Result<Vec<Agent>> {
+fn resolve_agents(
+    opts: &InitOpts,
+    existing: &[AgentEntry],
+    should_prompt: bool,
+) -> Result<Vec<Agent>> {
     if !opts.agents.is_empty() || !opts.remove_agents.is_empty() {
         let mut names: Vec<String> = existing.iter().map(|e| e.name.clone()).collect();
         for name in &opts.agents {
@@ -45,7 +49,7 @@ fn resolve_agents(opts: &InitOpts, existing: &[AgentEntry], out: &Output) -> Res
         }
         return names.iter().map(|n| Agent::from_config_name(n)).collect();
     }
-    if interactive(out) {
+    if should_prompt {
         return prompt_for_agents(existing);
     }
     if !existing.is_empty() {
@@ -65,8 +69,12 @@ pub async fn init(sym: &mut Symposium, out: &Output, opts: &InitOpts) -> Result<
     tracing::info!("init started");
     out.println("Setting up symposium for your user account.\n");
 
-    let agents = resolve_agents(opts, &sym.config.agents, out)?;
-    tracing::debug!(agents = ?agents.iter().map(|a| a.config_name()).collect::<Vec<_>>(), "resolved agents");
+    // CLI flags signal non-interactive intent — skip all prompts.
+    let cli_driven = !opts.agents.is_empty() || !opts.remove_agents.is_empty();
+    let should_prompt = !cli_driven && interactive(out);
+
+    // Resolve each setting: CLI flag > interactive prompt > keep existing.
+    let agents = resolve_agents(opts, &sym.config.agents, should_prompt)?;
 
     sym.config.agents = agents
         .iter()
@@ -75,29 +83,31 @@ pub async fn init(sym: &mut Symposium, out: &Output, opts: &InitOpts) -> Result<
         })
         .collect();
 
-    if let Some(scope) = opts.hook_scope {
-        sym.config.hook_scope = scope;
-    } else if !agents.is_empty() && interactive(out) {
-        sym.config.hook_scope = prompt_for_hook_scope(sym.config.hook_scope)?;
-    }
-    tracing::debug!(scope = ?sym.config.hook_scope, "hook scope");
+    sym.config.hook_scope = match opts.hook_scope {
+        Some(scope) => scope,
+        None if should_prompt && !agents.is_empty() => {
+            prompt_for_hook_scope(sym.config.hook_scope)?
+        }
+        None => sym.config.hook_scope,
+    };
 
-    if !agents.is_empty() && interactive(out) {
+    if should_prompt && !agents.is_empty() {
         sym.config.auto_update = prompt_for_auto_update(sym.config.auto_update)?;
     }
-    tracing::debug!(auto_update = ?sym.config.auto_update, "auto-update");
 
-    sym.save_config().context("failed to write user config")?;
-    tracing::info!(
+    tracing::debug!(
         agents = ?agents.iter().map(|a| a.config_name()).collect::<Vec<_>>(),
         scope = ?sym.config.hook_scope,
-        "config written"
+        auto_update = ?sym.config.auto_update,
+        "resolved config"
     );
+
+    // Persist and apply.
+    sym.save_config().context("failed to write user config")?;
 
     let config_path = sym.config_dir().join("config.toml");
 
     if agents.is_empty() {
-        // Uninstall: unregister all hooks and MCP servers for every agent.
         crate::sync::register_hooks(sym, out).context("failed to unregister hooks")?;
         out.done(format!(
             "{}: wrote user config (no agents — symposium uninstalled)",
@@ -113,7 +123,6 @@ pub async fn init(sym: &mut Symposium, out: &Output, opts: &InitOpts) -> Result<
         agent_names.join(", ")
     ));
 
-    // Register global hooks (project-scope hooks are installed by `sync`).
     if sym.config.hook_scope == crate::config::HookScope::Global {
         crate::sync::register_hooks(sym, out).context("failed to register global hooks")?;
     }

--- a/src/init.rs
+++ b/src/init.rs
@@ -108,6 +108,7 @@ pub async fn init(sym: &mut Symposium, out: &Output, opts: &InitOpts) -> Result<
     let config_path = sym.config_dir().join("config.toml");
 
     if agents.is_empty() {
+        // Uninstall: unregister all hooks and MCP servers for every agent.
         crate::sync::register_hooks(sym, out).context("failed to unregister hooks")?;
         out.done(format!(
             "{}: wrote user config (no agents — symposium uninstalled)",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@ pub mod sync;
 pub mod workspace_state;
 
 pub(crate) mod crate_sources;
-pub(crate) mod installation;
 pub(crate) mod predicate;
 pub(crate) mod skills;
 

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::config::Symposium;
 use crate::hook::HookEvent;
 use crate::hook_schema::HookAgent;
-use crate::installation::Source;
+use symposium_install::Source;
 
 use sacp::schema::McpServer;
 
@@ -26,16 +26,7 @@ pub struct PluginMcpServer {
     pub server: McpServerEntry,
 }
 
-/// Controls how aggressively plugin sources are updated.
-#[derive(Debug, Clone, Copy, clap::ValueEnum)]
-pub enum UpdateLevel {
-    /// Debounced: skip the API check if fetched recently.
-    None,
-    /// Always check freshness via API, but only download if stale.
-    Check,
-    /// Always re-download regardless of staleness.
-    Fetch,
-}
+pub use symposium_install::UpdateLevel;
 
 /// Source declaration for a skill group.
 ///
@@ -902,7 +893,7 @@ fn resolve_one_source(
             return Some(base_dir.join(p));
         }
     } else if let Some(ref git_url) = source.git {
-        match crate::installation::git::parse_github_url(git_url) {
+        match symposium_install::git::parse_github_url(git_url) {
             Ok(gh) => return Some(cache_base.join(gh.cache_key())),
             Err(e) => {
                 tracing::warn!(source = %source.name, error = %e, "bad plugin source URL");
@@ -950,11 +941,9 @@ async fn fetch_plugin_source(
     git_url: &str,
     update: UpdateLevel,
 ) -> Result<PathBuf> {
-    use crate::installation::git;
-
-    let source = git::parse_github_url(git_url)?;
-    let cache_mgr = git::GitCacheManager::new(sym, "plugin-sources");
-    cache_mgr.get_or_fetch(&source, git_url, update).await
+    let cache_mgr =
+        symposium_install::git::GitCacheManager::new(&sym.install_context(), "plugin-sources");
+    cache_mgr.fetch_url(git_url, update).await
 }
 
 /// Scan all configured plugin source directories and load the registry.

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -26,7 +26,7 @@ pub struct PluginMcpServer {
     pub server: McpServerEntry,
 }
 
-pub use symposium_install::UpdateLevel;
+use symposium_install::UpdateLevel;
 
 /// Source declaration for a skill group.
 ///
@@ -893,10 +893,11 @@ fn resolve_one_source(
             return Some(base_dir.join(p));
         }
     } else if let Some(ref git_url) = source.git {
-        match symposium_install::git::parse_github_url(git_url) {
-            Ok(gh) => return Some(cache_base.join(gh.cache_key())),
-            Err(e) => {
-                tracing::warn!(source = %source.name, error = %e, "bad plugin source URL");
+        let cache_mgr = symposium_install::git::GitCacheManager::from_cache_dir(cache_base);
+        match cache_mgr.cache_path_for_url(git_url) {
+            Some(path) => return Some(path),
+            None => {
+                tracing::warn!(source = %source.name, url = %git_url, "bad plugin source URL");
             }
         }
     }

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -51,15 +51,14 @@ impl Skill {
 ///   Identity is `(name, version)` only: two plugins targeting the same
 ///   crate version produce the same logical skills regardless of which
 ///   plugin pointed at them.
-/// - `Git { repo, commit_sha, skill_path }` — the skill came from a
-///   `source.git` group. Identity is the triple `(repo, commit_sha,
-///   skill_path)`: the repo is in `<owner>/<repo>` form (no `tree/<ref>`
-///   prefix), the commit SHA is the resolved hash that was actually
-///   fetched, and `skill_path` is the SKILL.md's path within the repo
-///   tree. Two plugins that pointed at the same repo via different URL
-///   forms (root URL vs. a `tree/<ref>/<subpath>` URL) collapse to one
-///   install if they end up loading the same SKILL.md from the same
-///   commit; different SKILL.md files within one repo stay distinct.
+/// - `Git { source, commit_sha, skill_path }` — the skill came from a
+///   `source.git` group. Identity is `(source, commit_sha, skill_path)`:
+///   `source` is the parsed [`GitSource`](symposium_install::git::GitSource)
+///   which normalizes equivalent URLs to the same value, the commit SHA
+///   is the resolved hash that was actually fetched, and `skill_path` is
+///   the SKILL.md's path within the repo tree. Two URLs that refer to
+///   the same repository normalize to the same `GitSource` and therefore
+///   deduplicate. Different SKILL.md files within one repo stay distinct.
 /// - `Source { source_name, skill_path }` — the skill came from a
 ///   plugin's `source.path` group, or from a standalone `SKILL.md` in
 ///   a registry source. `source_name` is the registry source's
@@ -74,9 +73,8 @@ pub enum SkillOrigin {
         version: semver::Version,
     },
     Git {
-        /// `<owner>/<repo>` — the repository identity, stripped of any
-        /// branch / subpath URL components.
-        repo: String,
+        /// The parsed git source (carries normalized repo identity).
+        source: symposium_install::git::GitSource,
         /// Commit SHA actually fetched (from the cache meta).
         commit_sha: String,
         /// SKILL.md's path within the repo tree, normalized to forward
@@ -215,7 +213,7 @@ pub async fn skills_applicable_to(
 ///
 /// - `CratePath` → `SkillOrigin::Crate { name, version }`, one per
 ///   matched crate (canonical name/version from the fetch result).
-/// - `Git` → `SkillOrigin::Git { repo, commit_sha, skill_path }`, one
+/// - `Git` → `SkillOrigin::Git { source, commit_sha, skill_path }`, one
 ///   per discovered SKILL.md (path varies per skill within the group).
 /// - `Path` → `SkillOrigin::Source { source_name, skill_path }`, with
 ///   `skill_path` computed per discovered SKILL.md relative to the
@@ -342,16 +340,16 @@ async fn load_git_skills(
     group: &SkillGroup,
     url: &str,
 ) -> Vec<(Skill, SkillOrigin)> {
-    let Some((gh, cache_dir, commit_sha)) = fetch_git_skill_source(sym, url).await else {
+    let Some((cache_dir, source, commit_sha)) = fetch_git_skill_source(sym, url).await else {
         return Vec::new();
     };
     let mut skills = Vec::new();
     for result in discover_skills(&cache_dir, group) {
         match result {
             Ok(skill) => {
-                let skill_path = skill_path_within_repo(&cache_dir, &skill.path, &gh.path);
+                let skill_path = skill_path_within_repo(&cache_dir, &skill.path, source.subpath());
                 let origin = SkillOrigin::Git {
-                    repo: format!("{}/{}", gh.owner, gh.repo),
+                    source: source.clone(),
                     commit_sha: commit_sha.clone(),
                     skill_path,
                 };
@@ -436,24 +434,18 @@ fn skill_path_within_repo(cache_dir: &Path, skill_md: &Path, source_subpath: &st
 }
 
 /// Fetch a `source.git` group's tarball and look up the resolved commit
-/// SHA from the cache meta. Returns `None` (with a warning) on failure.
+/// SHA from the cache meta. Returns `(cache_dir, parsed_source, commit_sha)`
+/// or `None` (with a warning) on failure.
 async fn fetch_git_skill_source(
     sym: &Symposium,
     git_url: &str,
-) -> Option<(symposium_install::git::GitHubSource, PathBuf, String)> {
-    let gh = match symposium_install::git::parse_github_url(git_url) {
-        Ok(gh) => gh,
-        Err(e) => {
-            tracing::warn!(git = %git_url, error = %e, "failed to parse git URL");
-            return None;
-        }
-    };
+) -> Option<(PathBuf, symposium_install::git::GitSource, String)> {
     let cache_mgr = symposium_install::git::GitCacheManager::new(&sym.install_context(), "plugins");
-    let cache_dir = match cache_mgr
-        .get_or_fetch(&gh, git_url, symposium_install::UpdateLevel::None)
+    let (cache_dir, source) = match cache_mgr
+        .fetch_url_parsed(git_url, symposium_install::UpdateLevel::None)
         .await
     {
-        Ok(p) => p,
+        Ok(r) => r,
         Err(e) => {
             tracing::warn!(git = %git_url, error = %e, "failed to fetch skill source");
             return None;
@@ -467,7 +459,7 @@ async fn fetch_git_skill_source(
         );
         return None;
     };
-    Some((gh, cache_dir, meta.commit_sha))
+    Some((cache_dir, source, meta.commit_sha))
 }
 
 /// Discover all skills found in a given directory.
@@ -735,12 +727,22 @@ mod tests {
         // *same* skill regardless of which URL form (or which plugin)
         // brought us there.
         let a = SkillOrigin::Git {
-            repo: "foo/bar".into(),
+            source: symposium_install::git::GitSource::GitHub {
+                owner: "foo".into(),
+                repo: "bar".into(),
+                git_ref: String::new(),
+                subpath: String::new(),
+            },
             commit_sha: "deadbeef".into(),
             skill_path: "skills/code-review".into(),
         };
         let b = SkillOrigin::Git {
-            repo: "foo/bar".into(),
+            source: symposium_install::git::GitSource::GitHub {
+                owner: "foo".into(),
+                repo: "bar".into(),
+                git_ref: String::new(),
+                subpath: String::new(),
+            },
             commit_sha: "deadbeef".into(),
             skill_path: "skills/code-review".into(),
         };
@@ -751,12 +753,22 @@ mod tests {
     #[test]
     fn skill_origin_git_distinct_paths_stay_distinct() {
         let a = SkillOrigin::Git {
-            repo: "foo/bar".into(),
+            source: symposium_install::git::GitSource::GitHub {
+                owner: "foo".into(),
+                repo: "bar".into(),
+                git_ref: String::new(),
+                subpath: String::new(),
+            },
             commit_sha: "deadbeef".into(),
             skill_path: "skills/a".into(),
         };
         let b = SkillOrigin::Git {
-            repo: "foo/bar".into(),
+            source: symposium_install::git::GitSource::GitHub {
+                owner: "foo".into(),
+                repo: "bar".into(),
+                git_ref: String::new(),
+                subpath: String::new(),
+            },
             commit_sha: "deadbeef".into(),
             skill_path: "skills/b".into(),
         };
@@ -775,7 +787,12 @@ mod tests {
             skill_path: "1.0.0".into(),
         };
         let g = SkillOrigin::Git {
-            repo: "foo/bar".into(),
+            source: symposium_install::git::GitSource::GitHub {
+                owner: "foo".into(),
+                repo: "bar".into(),
+                git_ref: String::new(),
+                subpath: String::new(),
+            },
             commit_sha: "deadbeef".into(),
             skill_path: "1.0.0".into(),
         };

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -440,17 +440,17 @@ fn skill_path_within_repo(cache_dir: &Path, skill_md: &Path, source_subpath: &st
 async fn fetch_git_skill_source(
     sym: &Symposium,
     git_url: &str,
-) -> Option<(crate::installation::git::GitHubSource, PathBuf, String)> {
-    let gh = match crate::installation::git::parse_github_url(git_url) {
+) -> Option<(symposium_install::git::GitHubSource, PathBuf, String)> {
+    let gh = match symposium_install::git::parse_github_url(git_url) {
         Ok(gh) => gh,
         Err(e) => {
             tracing::warn!(git = %git_url, error = %e, "failed to parse git URL");
             return None;
         }
     };
-    let cache_mgr = crate::installation::git::GitCacheManager::new(sym, "plugins");
+    let cache_mgr = symposium_install::git::GitCacheManager::new(&sym.install_context(), "plugins");
     let cache_dir = match cache_mgr
-        .get_or_fetch(&gh, git_url, crate::plugins::UpdateLevel::None)
+        .get_or_fetch(&gh, git_url, symposium_install::UpdateLevel::None)
         .await
     {
         Ok(p) => p,

--- a/symposium-hook/Cargo.toml
+++ b/symposium-hook/Cargo.toml
@@ -15,3 +15,9 @@ clap = { version = "4", features = ["derive"], optional = true }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1.52.3", features = ["macros", "rt"] }
+
+[dev-dependencies]
+dirs = "6"
+symposium-install = { path = "../symposium-install" }
+tokio = { version = "1.52.3", features = ["process"] }

--- a/symposium-hook/examples/acquire_helper.rs
+++ b/symposium-hook/examples/acquire_helper.rs
@@ -1,0 +1,55 @@
+//! Example: acquire a helper binary (`cargo-bp`) and invoke it at session start.
+//!
+//! Demonstrates how a hook handler can use `symposium-install` to lazily
+//! install a cargo binary and run it to produce dynamic context.
+
+use std::process::ExitCode;
+
+use symposium_hook::{HookHandler, SessionStartInput, SessionStartOutput, run};
+use symposium_install::{CargoSource, InstallContext, Source, acquire_source};
+
+struct BpContextHook {
+    install_ctx: InstallContext,
+}
+
+impl BpContextHook {
+    fn new() -> Self {
+        let cache_dir = dirs::cache_dir()
+            .unwrap_or_else(|| std::path::PathBuf::from(".cache"))
+            .join("symposium");
+        Self {
+            install_ctx: InstallContext::new(cache_dir),
+        }
+    }
+}
+
+impl HookHandler for BpContextHook {
+    async fn session_start(
+        &self,
+        _event: &SessionStartInput,
+    ) -> anyhow::Result<SessionStartOutput> {
+        let source = Source::Cargo(CargoSource::new("cargo-bp"));
+
+        let acquired = acquire_source(&self.install_ctx, &source, None).await?;
+        let binary_path = acquired
+            .executable()
+            .ok_or_else(|| anyhow::anyhow!("could not determine binary name for cargo-bp"))?;
+
+        let output = tokio::process::Command::new(&binary_path)
+            .args(["bp", "list", "-N"])
+            .output()
+            .await?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("cargo-bp failed: {stderr}");
+        }
+
+        let context = String::from_utf8(output.stdout)?;
+        Ok(SessionStartOutput::context(context))
+    }
+}
+
+fn main() -> ExitCode {
+    run(BpContextHook::new())
+}

--- a/symposium-hook/examples/block_destructive.rs
+++ b/symposium-hook/examples/block_destructive.rs
@@ -4,15 +4,14 @@ use symposium_hook::{HookHandler, PreToolUseInput, PreToolUseOutput, run};
 struct BlockDestructive;
 
 impl HookHandler for BlockDestructive {
-    fn pre_tool_use(&self, event: &PreToolUseInput) -> anyhow::Result<PreToolUseOutput> {
-        if event.tool_name == "Bash" {
-            if let Some(cmd) = event.tool_input.get("command").and_then(|v| v.as_str()) {
-                if cmd.contains("rm -rf") {
-                    return Ok(PreToolUseOutput::deny(
-                        "Destructive rm -rf commands are not allowed",
-                    ));
-                }
-            }
+    async fn pre_tool_use(&self, event: &PreToolUseInput) -> anyhow::Result<PreToolUseOutput> {
+        if event.tool_name == "Bash"
+            && let Some(cmd) = event.tool_input.get("command").and_then(|v| v.as_str())
+            && cmd.contains("rm -rf")
+        {
+            return Ok(PreToolUseOutput::deny(
+                "Destructive rm -rf commands are not allowed",
+            ));
         }
         Ok(PreToolUseOutput::default())
     }

--- a/symposium-hook/examples/inject_context.rs
+++ b/symposium-hook/examples/inject_context.rs
@@ -4,7 +4,10 @@ use symposium_hook::{HookHandler, SessionStartInput, SessionStartOutput, run};
 struct InjectContext;
 
 impl HookHandler for InjectContext {
-    fn session_start(&self, _event: &SessionStartInput) -> anyhow::Result<SessionStartOutput> {
+    async fn session_start(
+        &self,
+        _event: &SessionStartInput,
+    ) -> anyhow::Result<SessionStartOutput> {
         Ok(SessionStartOutput::context(
             "This project uses tokio 1.x for async. Prefer spawn over block_on.",
         ))

--- a/symposium-hook/src/lib.rs
+++ b/symposium-hook/src/lib.rs
@@ -13,7 +13,7 @@
 //! struct MyHook;
 //!
 //! impl HookHandler for MyHook {
-//!     fn pre_tool_use(&self, event: &PreToolUseInput) -> anyhow::Result<PreToolUseOutput> {
+//!     async fn pre_tool_use(&self, event: &PreToolUseInput) -> anyhow::Result<PreToolUseOutput> {
 //!         if event.tool_name == "Bash" {
 //!             Ok(PreToolUseOutput::context("Remember: prefer non-destructive commands"))
 //!         } else {
@@ -106,7 +106,7 @@ impl Input {
             Input::UserPromptSubmit(_) | Input::SessionStart(_) => return true,
         };
 
-        regex::Regex::new(matcher).map_or(false, |re| re.is_match(tool_name))
+        regex::Regex::new(matcher).is_ok_and(|re| re.is_match(tool_name))
     }
 }
 
@@ -413,17 +413,17 @@ impl SessionStartOutput {
 /// Default dispatch logic: matches on the event variant and calls the
 /// corresponding method on the handler, wrapping the result in the appropriate
 /// `Output` variant.
-pub fn default_handle_event(
+pub async fn default_handle_event(
     handler: &(impl HookHandler + ?Sized),
     input: &Input,
 ) -> anyhow::Result<Output> {
     match input {
-        Input::PreToolUse(event) => Ok(Output::PreToolUse(handler.pre_tool_use(event)?)),
-        Input::PostToolUse(event) => Ok(Output::PostToolUse(handler.post_tool_use(event)?)),
-        Input::UserPromptSubmit(event) => {
-            Ok(Output::UserPromptSubmit(handler.user_prompt_submit(event)?))
-        }
-        Input::SessionStart(event) => Ok(Output::SessionStart(handler.session_start(event)?)),
+        Input::PreToolUse(event) => Ok(Output::PreToolUse(handler.pre_tool_use(event).await?)),
+        Input::PostToolUse(event) => Ok(Output::PostToolUse(handler.post_tool_use(event).await?)),
+        Input::UserPromptSubmit(event) => Ok(Output::UserPromptSubmit(
+            handler.user_prompt_submit(event).await?,
+        )),
+        Input::SessionStart(event) => Ok(Output::SessionStart(handler.session_start(event).await?)),
     }
 }
 
@@ -431,28 +431,29 @@ pub fn default_handle_event(
 ///
 /// Override the methods for the events you care about. The defaults return
 /// the default (empty) output for each event type.
+#[allow(async_fn_in_trait)] // Hook handlers run on a single-threaded runtime; Send is not needed.
 pub trait HookHandler {
     /// Dispatch an input event to the appropriate handler method.
     ///
     /// The default implementation calls [`default_handle_event`], which matches
     /// on the event variant, calls the corresponding method, and wraps the
     /// result in the appropriate `Output` variant.
-    fn handle_event(&self, input: &Input) -> anyhow::Result<Output> {
-        default_handle_event(self, input)
+    async fn handle_event(&self, input: &Input) -> anyhow::Result<Output> {
+        default_handle_event(self, input).await
     }
 
     /// Called before the agent invokes a tool.
-    fn pre_tool_use(&self, _event: &PreToolUseInput) -> anyhow::Result<PreToolUseOutput> {
+    async fn pre_tool_use(&self, _event: &PreToolUseInput) -> anyhow::Result<PreToolUseOutput> {
         Ok(PreToolUseOutput::default())
     }
 
     /// Called after a tool completes.
-    fn post_tool_use(&self, _event: &PostToolUseInput) -> anyhow::Result<PostToolUseOutput> {
+    async fn post_tool_use(&self, _event: &PostToolUseInput) -> anyhow::Result<PostToolUseOutput> {
         Ok(PostToolUseOutput::default())
     }
 
     /// Called when the user submits a prompt.
-    fn user_prompt_submit(
+    async fn user_prompt_submit(
         &self,
         _event: &UserPromptSubmitInput,
     ) -> anyhow::Result<UserPromptSubmitOutput> {
@@ -460,7 +461,10 @@ pub trait HookHandler {
     }
 
     /// Called when an agent session begins.
-    fn session_start(&self, _event: &SessionStartInput) -> anyhow::Result<SessionStartOutput> {
+    async fn session_start(
+        &self,
+        _event: &SessionStartInput,
+    ) -> anyhow::Result<SessionStartOutput> {
         Ok(SessionStartOutput::default())
     }
 }
@@ -474,6 +478,14 @@ pub trait HookHandler {
 /// - Non-empty output → exit 0, JSON on stdout.
 /// - `Err(...)` → exit 1, error message on stderr.
 pub fn run(handler: impl HookHandler) -> ExitCode {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("failed to create tokio runtime");
+    rt.block_on(run_async(handler))
+}
+
+async fn run_async(handler: impl HookHandler) -> ExitCode {
     let mut input_str = String::new();
     if std::io::stdin().read_to_string(&mut input_str).is_err() {
         return ExitCode::FAILURE;
@@ -487,7 +499,7 @@ pub fn run(handler: impl HookHandler) -> ExitCode {
         }
     };
 
-    let output = match handler.handle_event(&input) {
+    let output = match handler.handle_event(&input).await {
         Ok(o) => o,
         Err(e) => {
             eprintln!("symposium-hook: handler error: {e}");

--- a/symposium-install/Cargo.toml
+++ b/symposium-install/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "symposium-install"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "Acquisition and caching of tool binaries for symposium plugins"
+repository = "https://github.com/symposium-dev/symposium"
+
+[features]
+clap = ["dep:clap"]
+
+[dependencies]
+anyhow = "1"
+bytes = "1"
+chrono = "0.4"
+clap = { version = "4", features = ["derive"], optional = true }
+flate2 = "1.0"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tar = "0.4"
+tempfile = "3.6"
+tokio = { version = "1", features = ["macros", "rt"] }
+tracing = "0.1"

--- a/symposium-install/src/git.rs
+++ b/symposium-install/src/git.rs
@@ -1,6 +1,6 @@
-//! Git-sourced plugin artifacts: GitHub URL parsing, API client, and cache management.
+//! Git-sourced plugin artifacts: URL parsing, API client, and cache management.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 
@@ -9,44 +9,89 @@ use crate::{InstallContext, UpdateLevel};
 /// Minimum interval between freshness checks for cached sources.
 const DEBOUNCE_DURATION: std::time::Duration = std::time::Duration::from_secs(60);
 
-/// A parsed GitHub repository reference.
+// ── Public parsed-URL type ──────────────────────────────────────────────
+
+/// A parsed git source URL.
+///
+/// Different URL forms that refer to the same logical repository (e.g.,
+/// `https://github.com/foo/bar` and `git@github.com:foo/bar.git`) parse
+/// to the same variant with the same fields, enabling deduplication.
 #[non_exhaustive]
-#[derive(Debug, Clone, PartialEq)]
-pub struct GitHubSource {
-    /// Repository owner (e.g. `"symposium-dev"`).
-    pub owner: String,
-    /// Repository name (e.g. `"symposium"`).
-    pub repo: String,
-    /// Branch, tag, or commit ref. Empty string means default branch.
-    pub git_ref: String,
-    /// Path within the repo. Empty string means repo root.
-    pub path: String,
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize)]
+pub enum GitSource {
+    /// A GitHub-hosted repository.
+    GitHub {
+        /// Repository owner (e.g. `"symposium-dev"`).
+        owner: String,
+        /// Repository name (e.g. `"symposium"`).
+        repo: String,
+        /// Branch, tag, or commit ref. Empty string means default branch.
+        git_ref: String,
+        /// Path within the repo. Empty string means repo root.
+        subpath: String,
+    },
 }
 
-impl GitHubSource {
+impl GitSource {
+    /// A normalized identity string suitable for use in `SkillOrigin`.
+    ///
+    /// Two URLs that refer to the same logical repository produce the same
+    /// `repo_id`, regardless of URL form.
+    pub fn repo_id(&self) -> String {
+        match self {
+            GitSource::GitHub { owner, repo, .. } => format!("{owner}/{repo}"),
+        }
+    }
+
+    /// The intra-repo subpath (the portion after `tree/<ref>/` in a GitHub URL).
+    /// Empty string if the URL points at the repo root.
+    pub fn subpath(&self) -> &str {
+        match self {
+            GitSource::GitHub { subpath, .. } => subpath,
+        }
+    }
+
     /// Filesystem-safe cache directory name.
-    pub fn cache_key(&self) -> String {
-        let mut key = format!("{}--{}", self.owner, self.repo);
-        if !self.git_ref.is_empty() {
-            key.push_str(&format!("@{}", self.git_ref));
+    fn cache_key(&self) -> String {
+        match self {
+            GitSource::GitHub {
+                owner,
+                repo,
+                git_ref,
+                subpath,
+            } => {
+                let mut key = format!("{owner}--{repo}");
+                if !git_ref.is_empty() {
+                    key.push_str(&format!("@{git_ref}"));
+                }
+                if !subpath.is_empty() {
+                    let path_slug = subpath.replace('/', "--");
+                    key.push_str(&format!("--{path_slug}"));
+                }
+                key
+            }
         }
-        if !self.path.is_empty() {
-            let path_slug = self.path.replace('/', "--");
-            key.push_str(&format!("--{}", path_slug));
-        }
-        key
     }
 }
 
-/// Parse a GitHub URL into its components.
+/// Parse a git URL into a structured [`GitSource`].
 ///
-/// Accepts:
+/// Currently recognizes GitHub URLs:
 /// - `https://github.com/owner/repo`
 /// - `https://github.com/owner/repo/tree/branch/path/to/dir`
-pub fn parse_github_url(url: &str) -> Result<GitHubSource> {
-    let stripped = url
-        .strip_prefix("https://github.com/")
-        .with_context(|| format!("not a GitHub URL: {url}"))?;
+pub fn parse_git_url(url: &str) -> Result<GitSource> {
+    // Normalize: case-insensitive host matching
+    let lower = url.to_lowercase();
+    if lower.starts_with("https://github.com/") {
+        return parse_github_https(url);
+    }
+    bail!("unrecognized git URL: {url}")
+}
+
+/// Parse an `https://github.com/...` URL.
+fn parse_github_https(url: &str) -> Result<GitSource> {
+    // Strip the prefix case-insensitively
+    let stripped = &url["https://github.com/".len()..];
 
     // Remove trailing slash
     let stripped = stripped.trim_end_matches('/');
@@ -55,26 +100,26 @@ pub fn parse_github_url(url: &str) -> Result<GitHubSource> {
 
     match parts.len() {
         // owner/repo
-        2 => Ok(GitHubSource {
+        2 => Ok(GitSource::GitHub {
             owner: parts[0].to_string(),
             repo: parts[1].to_string(),
             git_ref: String::new(),
-            path: String::new(),
+            subpath: String::new(),
         }),
         // owner/repo/tree/ref[/path...]
         n if n >= 4 && parts[2] == "tree" => {
             // rest is "branch/path/to/dir" — first segment is the ref, rest is path
             // But branches can contain slashes... we take the first segment as the ref.
             let rest = parts[3];
-            let (git_ref, path) = match rest.split_once('/') {
+            let (git_ref, subpath) = match rest.split_once('/') {
                 Some((r, p)) => (r.to_string(), p.to_string()),
                 None => (rest.to_string(), String::new()),
             };
-            Ok(GitHubSource {
+            Ok(GitSource::GitHub {
                 owner: parts[0].to_string(),
                 repo: parts[1].to_string(),
                 git_ref,
-                path,
+                subpath,
             })
         }
         _ => bail!("cannot parse GitHub URL: {url}"),
@@ -98,15 +143,17 @@ impl GitHubClient {
     }
 
     /// Resolve the commit SHA for a given ref (branch, tag, or "HEAD").
-    async fn resolve_commit_sha(&self, source: &GitHubSource) -> Result<String> {
-        let git_ref = if source.git_ref.is_empty() {
-            "HEAD"
-        } else {
-            &source.git_ref
-        };
+    async fn resolve_commit_sha(&self, source: &GitSource) -> Result<String> {
+        let GitSource::GitHub {
+            owner,
+            repo,
+            git_ref,
+            ..
+        } = source;
+        let ref_str = if git_ref.is_empty() { "HEAD" } else { git_ref };
         let url = format!(
             "https://api.github.com/repos/{}/{}/commits/{}",
-            source.owner, source.repo, git_ref
+            owner, repo, ref_str
         );
 
         let resp = self
@@ -131,15 +178,17 @@ impl GitHubClient {
     }
 
     /// Download the repository tarball for a given ref.
-    async fn download_tarball(&self, source: &GitHubSource) -> Result<bytes::Bytes> {
-        let git_ref = if source.git_ref.is_empty() {
-            "HEAD"
-        } else {
-            &source.git_ref
-        };
+    async fn download_tarball(&self, source: &GitSource) -> Result<bytes::Bytes> {
+        let GitSource::GitHub {
+            owner,
+            repo,
+            git_ref,
+            ..
+        } = source;
+        let ref_str = if git_ref.is_empty() { "HEAD" } else { git_ref };
         let url = format!(
             "https://api.github.com/repos/{}/{}/tarball/{}",
-            source.owner, source.repo, git_ref
+            owner, repo, ref_str
         );
 
         let resp = self
@@ -195,20 +244,45 @@ impl GitCacheManager {
     /// Use `"plugins"` for individual skill git sources,
     /// `"plugin-sources"` for plugin source repositories.
     pub fn new(ctx: &InstallContext, subdir: &str) -> Self {
-        let cache_dir = ctx.cache_dir().join(subdir);
+        Self::from_cache_dir(&ctx.cache_dir().join(subdir))
+    }
+
+    /// Create a cache manager rooted at an already-resolved directory.
+    pub fn from_cache_dir(cache_dir: &Path) -> Self {
         Self {
-            cache_dir,
+            cache_dir: cache_dir.to_path_buf(),
             client: GitHubClient::new(),
         }
     }
 
-    /// Parse a GitHub URL and fetch/cache the repository.
+    /// Compute the expected cache directory for a URL without fetching.
+    ///
+    /// Returns `None` if the URL cannot be parsed.
+    pub fn cache_path_for_url(&self, url: &str) -> Option<PathBuf> {
+        let source = parse_git_url(url).ok()?;
+        Some(self.cache_dir.join(source.cache_key()))
+    }
+
+    /// Parse a git URL and fetch/cache the repository.
     ///
     /// This is the primary entry point — it parses the URL into a
-    /// [`GitHubSource`] internally and delegates to the cache logic.
+    /// [`GitSource`] internally and delegates to the cache logic.
     pub async fn fetch_url(&self, url: &str, update: UpdateLevel) -> Result<PathBuf> {
-        let source = parse_github_url(url)?;
-        self.get_or_fetch(&source, url, update).await
+        let source = parse_git_url(url)?;
+        self.fetch(&source, url, update).await
+    }
+
+    /// Like [`fetch_url`](Self::fetch_url), but also returns the parsed
+    /// [`GitSource`] for callers that need the structured representation
+    /// (e.g. to build a `SkillOrigin`).
+    pub async fn fetch_url_parsed(
+        &self,
+        url: &str,
+        update: UpdateLevel,
+    ) -> Result<(PathBuf, GitSource)> {
+        let source = parse_git_url(url)?;
+        let path = self.fetch(&source, url, update).await?;
+        Ok((path, source))
     }
 
     /// Get the cached plugin directory, downloading or updating as needed.
@@ -217,9 +291,9 @@ impl GitCacheManager {
     /// - `None`: skip API calls if cache was fetched within `DEBOUNCE_DURATION`
     /// - `Check`: always call the API to check freshness, download only if stale
     /// - `Fetch`: always re-download regardless of staleness
-    pub async fn get_or_fetch(
+    async fn fetch(
         &self,
-        source: &GitHubSource,
+        source: &GitSource,
         source_url: &str,
         update: UpdateLevel,
     ) -> Result<PathBuf> {
@@ -298,7 +372,7 @@ impl GitCacheManager {
 
     async fn fetch_and_cache_with_sha(
         &self,
-        source: &GitHubSource,
+        source: &GitSource,
         source_url: &str,
         plugin_dir: &std::path::Path,
         meta_path: &std::path::Path,
@@ -323,16 +397,16 @@ impl GitCacheManager {
         extract_tarball(&tarball, temp_dir.path())?;
 
         // If a subpath is specified, we need to find and move just that subtree
-        let source_dir = if source.path.is_empty() {
+        let subpath = source.subpath();
+        let source_dir = if subpath.is_empty() {
             temp_dir.path().to_path_buf()
         } else {
-            let sub = temp_dir.path().join(&source.path);
+            let sub = temp_dir.path().join(subpath);
             if !sub.is_dir() {
                 bail!(
-                    "path '{}' not found in repository {}/{}",
-                    source.path,
-                    source.owner,
-                    source.repo
+                    "path '{}' not found in repository {}",
+                    subpath,
+                    source.repo_id()
                 );
             }
             sub

--- a/symposium-install/src/git.rs
+++ b/symposium-install/src/git.rs
@@ -4,15 +4,18 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result, bail};
 
-use crate::plugins::UpdateLevel;
+use crate::{InstallContext, UpdateLevel};
 
 /// Minimum interval between freshness checks for cached sources.
 const DEBOUNCE_DURATION: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// A parsed GitHub repository reference.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct GitHubSource {
+    /// Repository owner (e.g. `"symposium-dev"`).
     pub owner: String,
+    /// Repository name (e.g. `"symposium"`).
     pub repo: String,
     /// Branch, tag, or commit ref. Empty string means default branch.
     pub git_ref: String,
@@ -60,9 +63,9 @@ pub fn parse_github_url(url: &str) -> Result<GitHubSource> {
         }),
         // owner/repo/tree/ref[/path...]
         n if n >= 4 && parts[2] == "tree" => {
-            let rest = parts[3];
             // rest is "branch/path/to/dir" — first segment is the ref, rest is path
             // But branches can contain slashes... we take the first segment as the ref.
+            let rest = parts[3];
             let (git_ref, path) = match rest.split_once('/') {
                 Some((r, p)) => (r.to_string(), p.to_string()),
                 None => (rest.to_string(), String::new()),
@@ -81,12 +84,12 @@ pub fn parse_github_url(url: &str) -> Result<GitHubSource> {
 // --- GitHub API client ---
 
 /// Client for GitHub REST API operations.
-pub struct GitHubClient {
+struct GitHubClient {
     client: reqwest::Client,
 }
 
 impl GitHubClient {
-    pub fn new() -> Self {
+    fn new() -> Self {
         let client = reqwest::Client::builder()
             .user_agent("cargo-agents")
             .build()
@@ -95,7 +98,7 @@ impl GitHubClient {
     }
 
     /// Resolve the commit SHA for a given ref (branch, tag, or "HEAD").
-    pub async fn resolve_commit_sha(&self, source: &GitHubSource) -> Result<String> {
+    async fn resolve_commit_sha(&self, source: &GitHubSource) -> Result<String> {
         let git_ref = if source.git_ref.is_empty() {
             "HEAD"
         } else {
@@ -128,7 +131,7 @@ impl GitHubClient {
     }
 
     /// Download the repository tarball for a given ref.
-    pub async fn download_tarball(&self, source: &GitHubSource) -> Result<bytes::Bytes> {
+    async fn download_tarball(&self, source: &GitHubSource) -> Result<bytes::Bytes> {
         let git_ref = if source.git_ref.is_empty() {
             "HEAD"
         } else {
@@ -167,10 +170,14 @@ impl GitHubClient {
 // --- Plugin cache manager ---
 
 /// Metadata stored alongside cached plugin artifacts.
+#[non_exhaustive]
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct PluginCacheMeta {
+    /// The resolved commit SHA that was fetched.
     pub commit_sha: String,
+    /// RFC 3339 timestamp of when this cache entry was last fetched.
     pub fetched_at: String,
+    /// The original URL that produced this cache entry.
     pub source_url: String,
 }
 
@@ -187,12 +194,21 @@ impl GitCacheManager {
     ///
     /// Use `"plugins"` for individual skill git sources,
     /// `"plugin-sources"` for plugin source repositories.
-    pub fn new(sym: &crate::config::Symposium, subdir: &str) -> Self {
-        let cache_dir = sym.cache_dir().join(subdir);
+    pub fn new(ctx: &InstallContext, subdir: &str) -> Self {
+        let cache_dir = ctx.cache_dir().join(subdir);
         Self {
             cache_dir,
             client: GitHubClient::new(),
         }
+    }
+
+    /// Parse a GitHub URL and fetch/cache the repository.
+    ///
+    /// This is the primary entry point — it parses the URL into a
+    /// [`GitHubSource`] internally and delegates to the cache logic.
+    pub async fn fetch_url(&self, url: &str, update: UpdateLevel) -> Result<PathBuf> {
+        let source = parse_github_url(url)?;
+        self.get_or_fetch(&source, url, update).await
     }
 
     /// Get the cached plugin directory, downloading or updating as needed.

--- a/symposium-install/src/lib.rs
+++ b/symposium-install/src/lib.rs
@@ -1,10 +1,73 @@
-use anyhow::{Context, Result, bail};
-use serde::{Deserialize, Serialize};
+//! Acquisition and caching of tool binaries for symposium plugins.
+//!
+//! This crate provides the machinery to install cargo binaries and clone GitHub
+//! repositories into a local cache. It is used by both the main `symposium`
+//! binary and by hook handlers that need to invoke external tools.
+#![deny(missing_docs)]
+
 use std::path::{Path, PathBuf};
 
-use crate::config::Symposium;
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
 
-pub(crate) mod git;
+pub mod git;
+
+/// Minimal context needed for acquisition.
+///
+/// Replaces the full `Symposium` config struct — hook handlers construct this
+/// directly from environment or hardcoded paths.
+#[derive(Debug, Clone)]
+pub struct InstallContext {
+    cache_dir: PathBuf,
+    cargo_bin: Option<PathBuf>,
+}
+
+impl InstallContext {
+    /// Create a new context rooted at the given cache directory.
+    ///
+    /// Acquired binaries and cloned repositories are stored under this path.
+    pub fn new(cache_dir: PathBuf) -> Self {
+        Self {
+            cache_dir,
+            cargo_bin: None,
+        }
+    }
+
+    /// Override the cargo binary used for `cargo install` / `cargo binstall`.
+    ///
+    /// If not set, the plain `"cargo"` from `$PATH` is used.
+    pub fn with_cargo_bin(mut self, path: PathBuf) -> Self {
+        self.cargo_bin = Some(path);
+        self
+    }
+
+    /// The root directory where cached artifacts are stored.
+    pub fn cache_dir(&self) -> &Path {
+        &self.cache_dir
+    }
+
+    /// Build a [`Command`](std::process::Command) for the configured cargo binary.
+    pub fn cargo_command(&self) -> std::process::Command {
+        match &self.cargo_bin {
+            Some(path) => std::process::Command::new(path),
+            None => std::process::Command::new("cargo"),
+        }
+    }
+}
+
+/// Controls how aggressively cached sources are updated.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Default)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+pub enum UpdateLevel {
+    /// Debounced: skip the API check if fetched recently.
+    #[default]
+    None,
+    /// Always check freshness via API, but only download if stale.
+    Check,
+    /// Always re-download regardless of staleness.
+    Fetch,
+}
 
 /// How to acquire bits onto disk.
 ///
@@ -13,14 +76,18 @@ pub(crate) mod git;
 /// `script` (which resolve relative to the acquired source). An installation
 /// can omit `Source` entirely — in that case `executable` / `script` are
 /// taken as paths on disk and `install_commands` does any setup.
+#[non_exhaustive]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "source", rename_all = "lowercase")]
 pub enum Source {
+    /// Install via `cargo install` or `cargo binstall`.
     Cargo(CargoSource),
+    /// Clone from a GitHub repository.
     Github(GithubSource),
 }
 
 /// A binary obtained by `cargo install` (with optional binstall fast-path).
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CargoSource {
@@ -38,17 +105,53 @@ pub struct CargoSource {
     pub git: Option<String>,
 }
 
+impl CargoSource {
+    /// Create a source for the given crate name, defaulting to the latest
+    /// stable version from crates.io.
+    pub fn new(crate_name: impl Into<String>) -> Self {
+        Self {
+            crate_name: crate_name.into(),
+            version: None,
+            git: None,
+        }
+    }
+
+    /// Pin to a specific version (e.g. `"1.2.3"`).
+    pub fn with_version(mut self, version: impl Into<String>) -> Self {
+        self.version = Some(version.into());
+        self
+    }
+
+    /// Install from a git repository URL instead of crates.io.
+    ///
+    /// When set, an `executable` hint is required since crates.io is not
+    /// consulted to discover binary names.
+    pub fn with_git(mut self, git_url: impl Into<String>) -> Self {
+        self.git = Some(git_url.into());
+        self
+    }
+}
+
 /// A directory of files acquired from a GitHub repository (or subtree).
 /// The file to run inside the cloned tree is picked by `executable` /
 /// `script` on the installation or hook.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GithubSource {
+    /// The GitHub URL to clone.
     #[serde(alias = "git")]
     pub url: String,
 }
 
-pub(crate) fn platform_binary_exe(binary_name: &str) -> String {
+impl GithubSource {
+    /// Create a source for the given GitHub URL.
+    pub fn new(url: impl Into<String>) -> Self {
+        Self { url: url.into() }
+    }
+}
+
+fn platform_binary_exe(binary_name: &str) -> String {
     if cfg!(windows) {
         format!("{}.exe", binary_name)
     } else {
@@ -81,7 +184,7 @@ struct CratesIoCrate {
 }
 
 /// Query crates.io for binary names of a crate
-pub async fn query_crate_binaries(
+async fn query_crate_binaries(
     crate_name: &str,
     version: Option<&str>,
 ) -> Result<(String, Vec<String>)> {
@@ -142,27 +245,27 @@ pub async fn query_crate_binaries(
 }
 
 /// Install a crate using cargo binstall (fast) or cargo install (fallback).
-pub(crate) async fn install_cargo_crate(
-    sym: &crate::config::Symposium,
+async fn install_cargo_crate(
+    ctx: &InstallContext,
     crate_name: &str,
     version: &str,
     binary_name: Option<String>,
     cache_dir: PathBuf,
     git: Option<String>,
 ) -> Result<()> {
-    let sym = sym.clone();
+    let ctx = ctx.clone();
     let crate_name = crate_name.to_string();
     let version = version.to_string();
 
     tokio::task::spawn_blocking(move || {
-        install_cargo_crate_sync(&sym, &crate_name, &version, binary_name, &cache_dir, git)
+        install_cargo_crate_sync(&ctx, &crate_name, &version, binary_name, &cache_dir, git)
     })
     .await
     .context("Cargo install task panicked")?
 }
 
 fn install_cargo_crate_sync(
-    sym: &crate::config::Symposium,
+    ctx: &InstallContext,
     crate_name: &str,
     version: &str,
     binary_name: Option<String>,
@@ -195,7 +298,7 @@ fn install_cargo_crate_sync(
         binstall_args.push(git);
     }
     binstall_args.extend([cache_dir.to_str().unwrap(), &crate_spec]);
-    let binstall_result = sym.cargo_command().args(binstall_args).output();
+    let binstall_result = ctx.cargo_command().args(binstall_args).output();
 
     let binary_path = binary_name
         .as_ref()
@@ -231,7 +334,7 @@ fn install_cargo_crate_sync(
         args.push(git);
     }
     args.extend([cache_dir.to_str().unwrap(), &crate_spec]);
-    let install_result = sym
+    let install_result = ctx
         .cargo_command()
         .args(args)
         .output()
@@ -249,8 +352,8 @@ fn install_cargo_crate_sync(
     Ok(())
 }
 
-pub fn get_binary_cache_dir(sym: &Symposium, krate: &str, version: &str) -> Result<PathBuf> {
-    let path = sym.cache_dir().join("binaries").join(krate).join(version);
+fn get_binary_cache_dir(ctx: &InstallContext, krate: &str, version: &str) -> Result<PathBuf> {
+    let path = ctx.cache_dir().join("binaries").join(krate).join(version);
     Ok(path)
 }
 
@@ -269,13 +372,10 @@ fn git_cache_version(git_url: &str, version: Option<&str>) -> String {
 /// Acquire a cargo installation: install if missing, return the cache dir
 /// plus the resolved binary name (when discoverable from crates.io).
 async fn acquire_cargo(
-    sym: &Symposium,
+    ctx: &InstallContext,
     cargo: &CargoSource,
     executable_hint: Option<&str>,
 ) -> Result<(PathBuf, Option<String>)> {
-    // For git sources, we don't consult crates.io. Cache key folds in the URL
-    // and the user's version (if any). The user must specify `executable`
-    // since we have no other way to pick a binary.
     if let Some(git_url) = cargo.git.as_deref() {
         let resolved = match executable_hint {
             Some(name) => name.to_string(),
@@ -286,11 +386,11 @@ async fn acquire_cargo(
             ),
         };
         let cache_version = git_cache_version(git_url, cargo.version.as_deref());
-        let cache_dir = get_binary_cache_dir(sym, &cargo.crate_name, &cache_version)?;
+        let cache_dir = get_binary_cache_dir(ctx, &cargo.crate_name, &cache_version)?;
         let probe = cache_dir.join("bin").join(platform_binary_exe(&resolved));
         if !probe.exists() {
             install_cargo_crate(
-                sym,
+                ctx,
                 &cargo.crate_name,
                 cargo.version.as_deref().unwrap_or(""),
                 Some(resolved.clone()),
@@ -318,15 +418,15 @@ async fn acquire_cargo(
         },
     };
 
-    let cache_dir = get_binary_cache_dir(sym, &cargo.crate_name, &version)?;
+    let cache_dir = get_binary_cache_dir(ctx, &cargo.crate_name, &version)?;
     let probe_path = resolved
         .as_ref()
         .map(|n| cache_dir.join("bin").join(platform_binary_exe(n)));
 
-    let already = probe_path.as_ref().map_or(false, |p| p.exists());
+    let already = probe_path.as_ref().is_some_and(|p| p.exists());
     if !already {
         install_cargo_crate(
-            sym,
+            ctx,
             &cargo.crate_name,
             &version,
             resolved.clone(),
@@ -341,20 +441,19 @@ async fn acquire_cargo(
 
 /// Acquire a github source: returns the cache directory containing the repo
 /// (or its requested subtree).
-pub(crate) async fn acquire_github(sym: &Symposium, git: &GithubSource) -> Result<PathBuf> {
-    let git_url = &git.url;
-    let source = crate::installation::git::parse_github_url(git_url)?;
-    let cache_mgr = crate::installation::git::GitCacheManager::new(sym, "plugins");
-    cache_mgr
-        .get_or_fetch(&source, git_url, crate::plugins::UpdateLevel::Check)
-        .await
+async fn acquire_github(ctx: &InstallContext, git: &GithubSource) -> Result<PathBuf> {
+    let cache_mgr = crate::git::GitCacheManager::new(ctx, "plugins");
+    cache_mgr.fetch_url(&git.url, UpdateLevel::Check).await
 }
 
 /// Acquired source — where files ended up on disk, plus the kind so
 /// `executable` / `script` can be resolved correctly relative to it.
+#[non_exhaustive]
 #[derive(Debug)]
 pub struct AcquiredSource {
+    /// Root directory where the acquired files reside.
     pub base: PathBuf,
+    /// How the source was acquired (affects path resolution).
     pub kind: AcquiredKind,
     /// For cargo, the binary name we ended up with (from `executable_hint`
     /// or by inferring the crate's sole binary). Used as the fallback when
@@ -362,15 +461,29 @@ pub struct AcquiredSource {
     pub resolved_executable: Option<String>,
 }
 
+/// How an [`AcquiredSource`] was obtained.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AcquiredKind {
+    /// Installed via `cargo install` / `cargo binstall`.
     Cargo,
+    /// Cloned from a GitHub repository.
     Github,
 }
 
 impl AcquiredSource {
+    /// Path to the executable, using `resolved_executable` as the name.
+    /// Use [`Self::executable_named`] to specify the executable name from the outside.
+    ///
+    /// Returns `None` if no executable name was resolved (e.g., a GitHub
+    /// source with no hint).
+    pub fn executable(&self) -> Option<PathBuf> {
+        let name = self.resolved_executable.as_deref()?;
+        Some(self.executable_named(name))
+    }
+
     /// Path of an `executable` declared on installation/hook.
-    pub fn resolve_executable(&self, name: &str) -> PathBuf {
+    pub fn executable_named(&self, name: &str) -> PathBuf {
         match self.kind {
             AcquiredKind::Cargo => self.base.join("bin").join(platform_binary_exe(name)),
             AcquiredKind::Github => self.base.join(name.trim_start_matches("./")),
@@ -378,7 +491,7 @@ impl AcquiredSource {
     }
 
     /// Path of a `script` declared on installation/hook.
-    pub fn resolve_script(&self, name: &str) -> PathBuf {
+    pub fn script_named(&self, name: &str) -> PathBuf {
         match self.kind {
             AcquiredKind::Cargo => self.base.join("bin").join(name.trim_start_matches("./")),
             AcquiredKind::Github => self.base.join(name.trim_start_matches("./")),
@@ -392,13 +505,13 @@ impl AcquiredSource {
 /// `executable_hint` is only used for cargo (to pick which binary to install
 /// for multi-binary crates, or as the binary name when using a git source).
 pub async fn acquire_source(
-    sym: &Symposium,
+    ctx: &InstallContext,
     source: &Source,
     executable_hint: Option<&str>,
 ) -> Result<AcquiredSource> {
     match source {
         Source::Cargo(c) => {
-            let (base, resolved) = acquire_cargo(sym, c, executable_hint).await?;
+            let (base, resolved) = acquire_cargo(ctx, c, executable_hint).await?;
             Ok(AcquiredSource {
                 base,
                 kind: AcquiredKind::Cargo,
@@ -406,7 +519,7 @@ pub async fn acquire_source(
             })
         }
         Source::Github(g) => Ok(AcquiredSource {
-            base: acquire_github(sym, g).await?,
+            base: acquire_github(ctx, g).await?,
             kind: AcquiredKind::Github,
             resolved_executable: None,
         }),
@@ -414,6 +527,7 @@ pub async fn acquire_source(
 }
 
 /// What an installation resolves to once acquired.
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum Runnable {
     /// Run as a binary: `path args...`.


### PR DESCRIPTION
## What does this PR do?

Move the installation/acquisition machinery (Source, AcquiredSource, acquire_source, GitCacheManager, etc.) into a new `symposium-install` crate. The goal is to make it possible for hook handlers or other executions to acquire tool binaries without depending on the full symposium config/sync/plugin stack.

symposium-hook: HookHandler trait methods are now async; run() spins up a tokio current-thread runtime. Adds acquire_helper example showing how to lazily install and invoke a cargo binary from a hook.

There's also a drive-by fix to the test cases, restructuring the interactive prompts to avoid a TTY hang with --add-agent is passed by skipping interactive prompts in CLI-driven mode.



<!-- Explain the purpose, key logic, etc. -->

<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

<!-- Symposium is an AI project. We encourage the use of agentic tooling! We do however require disclosure. The disclosure helps us to calibrate our reviews. See our [PR disclosure policy](https://symposium-dev.github.io/symposium/design/governance.html#pr-disclosure-policy). -->

<!-- Remove the items that do not apply. -->

* The AI tool authored large parts of the code

**Questions for reviewers.**

<!-- Any specific areas of uncertainty or things you'd like reviewers to look at? -->

</details>
