### PR TITLE
refactor: switch custom predicate stdout to JSONL

### DIFF
--- a/src/predicate.rs
+++ b/src/predicate.rs
@@ -870,31 +870,85 @@ fn run_custom_predicate(
     }
 }
 
-/// Parse witness JSON from custom predicate stdout.
+/// Parse witness JSON Lines from custom predicate stdout.
 ///
-/// Returns `None` if stdout is non-empty but not valid witness JSON (the
-/// predicate should be treated as failed). Returns `Some(vec![])` for empty
-/// stdout (pass, no witness crates). Returns `Some(crates)` on valid JSON.
+/// Each non-blank line must be a JSON object with exactly one key identifying
+/// the record type. Known record types are processed; unknown types emit a
+/// warning and are skipped (forward compatibility). A malformed line (invalid
+/// JSON, zero keys, multiple keys, or bad field values) causes the predicate
+/// to be treated as failed.
 fn parse_witness_stdout(predicate_name: &str, stdout: &[u8]) -> Option<Vec<SelectedCrate>> {
-    use symposium_sdk::predicate::PredicateOutput;
-
     if stdout.is_empty() {
         return Some(Vec::new());
     }
 
-    let output: PredicateOutput = match serde_json::from_slice(stdout) {
-        Ok(o) => o,
-        Err(e) => {
+    let text = match std::str::from_utf8(stdout) {
+        Ok(s) => s,
+        Err(_) => {
             tracing::warn!(
                 predicate = predicate_name,
-                error = %e,
-                "custom predicate stdout is not valid witness JSON — treating as failed"
+                "custom predicate stdout is not valid UTF-8 — treating as failed"
             );
             return None;
         }
     };
 
-    Some(output.selected_crates)
+    let mut crates = Vec::new();
+
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let obj: serde_json::Map<String, serde_json::Value> = match serde_json::from_str(line) {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!(
+                    predicate = predicate_name,
+                    error = %e,
+                    line,
+                    "custom predicate stdout line is not valid JSON — treating as failed"
+                );
+                return None;
+            }
+        };
+
+        if obj.len() != 1 {
+            tracing::warn!(
+                predicate = predicate_name,
+                line,
+                "custom predicate stdout line must have exactly one key — treating as failed"
+            );
+            return None;
+        }
+
+        let (key, value) = obj.into_iter().next().unwrap();
+        match key.as_str() {
+            "selectedCrate" => {
+                let sc: SelectedCrate = match serde_json::from_value(value) {
+                    Ok(sc) => sc,
+                    Err(e) => {
+                        tracing::warn!(
+                            predicate = predicate_name,
+                            error = %e,
+                            "custom predicate selectedCrate record is malformed — treating as failed"
+                        );
+                        return None;
+                    }
+                };
+                crates.push(sc);
+            }
+            unknown => {
+                tracing::warn!(
+                    predicate = predicate_name,
+                    key = unknown,
+                    "unknown predicate record type, skipping"
+                );
+            }
+        }
+    }
+
+    Some(crates)
 }
 
 #[cfg(test)]
@@ -1584,7 +1638,7 @@ mod tests {
 
     #[test]
     fn witness_custom_with_selected_crates() {
-        let json = r#"{"selectedCrates":[{"crate":"cli-battery-pack","version":"0.3.1"}]}"#;
+        let json = r#"{"selectedCrate":{"name":"cli-battery-pack","version":"0.3.1"}}"#;
         let (mut ctx, _script) = ctx_with_script_entry("bp", &format!("printf '{json}'"));
         let pred = Predicate::Custom {
             name: "bp".into(),
@@ -1625,26 +1679,31 @@ mod tests {
             name: "bp".into(),
             arg: "x".into(),
         };
-        // Invalid JSON on stdout causes the predicate to fail.
         assert!(!pred.evaluate(&mut ctx));
     }
 
     #[test]
     fn witness_custom_invalid_version_fails_predicate() {
-        let json = r#"{"selectedCrates":[{"crate":"good","version":"1.0.0"},{"crate":"bad","version":"not-semver"}]}"#;
-        let (mut ctx, _script) = ctx_with_script_entry("bp", &format!("printf '{json}'"));
+        let (mut ctx, _script) = ctx_with_script_entry(
+            "bp",
+            "printf '{\"selectedCrate\":{\"name\":\"good\",\"version\":\"1.0.0\"}}\n'\n\
+             printf '{\"selectedCrate\":{\"name\":\"bad\",\"version\":\"not-semver\"}}\n'",
+        );
         let pred = Predicate::Custom {
             name: "bp".into(),
             arg: "x".into(),
         };
-        // Any malformed entry fails the whole predicate.
         assert!(!pred.evaluate(&mut ctx));
     }
 
     #[test]
     fn witness_custom_multiple_crates() {
-        let json = r#"{"selectedCrates":[{"crate":"a","version":"1.0.0"},{"crate":"b","version":"2.0.0"},{"crate":"c","version":"3.0.0"}]}"#;
-        let (mut ctx, _script) = ctx_with_script_entry("bp", &format!("printf '{json}'"));
+        let (mut ctx, _script) = ctx_with_script_entry(
+            "bp",
+            "printf '{\"selectedCrate\":{\"name\":\"a\",\"version\":\"1.0.0\"}}\n'\n\
+             printf '{\"selectedCrate\":{\"name\":\"b\",\"version\":\"2.0.0\"}}\n'\n\
+             printf '{\"selectedCrate\":{\"name\":\"c\",\"version\":\"3.0.0\"}}\n'",
+        );
         let pred = Predicate::Custom {
             name: "bp".into(),
             arg: "x".into(),
@@ -1654,5 +1713,58 @@ mod tests {
         assert_eq!(witness[0].0, "a");
         assert_eq!(witness[1].0, "b");
         assert_eq!(witness[2].0, "c");
+    }
+
+    #[test]
+    fn witness_custom_unknown_record_type_is_skipped() {
+        let (mut ctx, _script) = ctx_with_script_entry(
+            "bp",
+            "printf '{\"futureFeature\":{\"x\":1}}\n'\n\
+             printf '{\"selectedCrate\":{\"name\":\"serde\",\"version\":\"1.0.0\"}}\n'",
+        );
+        let pred = Predicate::Custom {
+            name: "bp".into(),
+            arg: "x".into(),
+        };
+        let witness = pred.witness(&mut ctx).unwrap();
+        assert_eq!(witness.len(), 1);
+        assert_eq!(witness[0].0, "serde");
+    }
+
+    #[test]
+    fn witness_custom_empty_object_fails_predicate() {
+        let (mut ctx, _script) = ctx_with_script_entry("bp", "printf '{}'");
+        let pred = Predicate::Custom {
+            name: "bp".into(),
+            arg: "x".into(),
+        };
+        assert!(!pred.evaluate(&mut ctx));
+    }
+
+    #[test]
+    fn witness_custom_blank_lines_are_skipped() {
+        let (mut ctx, _script) = ctx_with_script_entry(
+            "bp",
+            "printf '\\n'\n\
+             printf '{\"selectedCrate\":{\"name\":\"tokio\",\"version\":\"1.40.0\"}}\n'\n\
+             printf '\\n'",
+        );
+        let pred = Predicate::Custom {
+            name: "bp".into(),
+            arg: "x".into(),
+        };
+        let witness = pred.witness(&mut ctx).unwrap();
+        assert_eq!(witness.len(), 1);
+        assert_eq!(witness[0].0, "tokio");
+    }
+
+    #[test]
+    fn witness_custom_multiple_keys_fails_predicate() {
+        let (mut ctx, _script) = ctx_with_script_entry("bp", "printf '{\"keyA\":1,\"keyB\":2}'");
+        let pred = Predicate::Custom {
+            name: "bp".into(),
+            arg: "x".into(),
+        };
+        assert!(!pred.evaluate(&mut ctx));
     }
 }

--- a/symposium-sdk/src/lib.rs
+++ b/symposium-sdk/src/lib.rs
@@ -30,20 +30,14 @@
 //!
 //! A custom predicate binary receives its argument via CLI args, and signals
 //! pass/fail via exit code. To participate in crate-sourced skill resolution,
-//! it prints witness JSON to stdout:
+//! it emits JSON Lines records to stdout using [`PredicateEmitter`]:
 //!
 //! ```no_run
-//! use symposium_sdk::predicate::{PredicateOutput, SelectedCrate};
+//! use symposium_sdk::predicate::PredicateEmitter;
 //!
-//! let output = PredicateOutput {
-//!     selected_crates: vec![
-//!         SelectedCrate {
-//!             crate_name: "my-crate".into(),
-//!             version: semver::Version::new(1, 0, 0),
-//!         },
-//!     ],
-//! };
-//! println!("{}", serde_json::to_string(&output).unwrap());
+//! PredicateEmitter::stdout()
+//!     .selected_crate("my-crate", &semver::Version::new(1, 0, 0))
+//!     .unwrap();
 //! ```
 
 pub mod dirs;

--- a/symposium-sdk/src/predicate.rs
+++ b/symposium-sdk/src/predicate.rs
@@ -2,47 +2,24 @@
 //!
 //! A custom predicate binary communicates its result via:
 //! - **Exit code**: 0 = pass, non-zero = fail.
-//! - **Stdout** (optional): JSON witness output naming crates that should be
-//!   fetched for `source = "crate"` skill resolution.
+//! - **Stdout** (optional): JSON Lines output, one record per line, naming
+//!   crates that should be fetched for `source = "crate"` skill resolution.
 //!
-//! If stdout is empty, the predicate passes without contributing any witness
-//! crates. If stdout contains JSON, it must conform to [`PredicateOutput`].
-//! Malformed JSON causes the predicate to be treated as failed.
+//! Each line is a tagged JSON object with exactly one key identifying the
+//! record type. Unknown record types are warned and skipped (forward
+//! compatibility). Malformed lines cause the predicate to be treated as
+//! failed.
+//!
+//! Use [`PredicateEmitter`] to write records from a Rust predicate binary.
+
+use std::io::{self, Write};
 
 use serde::{Deserialize, Serialize};
-
-/// The JSON structure a custom predicate prints to stdout to report witness
-/// crates.
-///
-/// # Example
-///
-/// ```
-/// use symposium_sdk::predicate::{PredicateOutput, SelectedCrate};
-///
-/// let output = PredicateOutput {
-///     selected_crates: vec![
-///         SelectedCrate {
-///             crate_name: "serde".into(),
-///             version: semver::Version::new(1, 0, 210),
-///         },
-///     ],
-/// };
-/// assert!(serde_json::to_string(&output).unwrap().contains("selectedCrates"));
-/// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PredicateOutput {
-    /// The crates selected by this predicate. Each entry names a crate whose
-    /// source will be fetched for skill discovery.
-    pub selected_crates: Vec<SelectedCrate>,
-}
 
 /// A crate selected by a custom predicate's witness output.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SelectedCrate {
-    /// The crate name (e.g. `"serde"`, `"cli-battery-pack"`).
     pub crate_name: String,
-    /// The exact version to fetch.
     pub version: semver::Version,
 }
 
@@ -50,7 +27,7 @@ impl Serialize for SelectedCrate {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use serde::ser::SerializeStruct;
         let mut s = serializer.serialize_struct("SelectedCrate", 2)?;
-        s.serialize_field("crate", &self.crate_name)?;
+        s.serialize_field("name", &self.crate_name)?;
         s.serialize_field("version", &self.version.to_string())?;
         s.end()
     }
@@ -60,7 +37,7 @@ impl<'de> Deserialize<'de> for SelectedCrate {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         #[derive(Deserialize)]
         struct Raw {
-            #[serde(rename = "crate")]
+            #[serde(rename = "name")]
             crate_name: String,
             version: String,
         }
@@ -73,11 +50,63 @@ impl<'de> Deserialize<'de> for SelectedCrate {
     }
 }
 
-impl PredicateOutput {
-    /// Create an empty output (pass, no witness crates).
-    pub fn empty() -> Self {
+/// Emits predicate output records to stdout (or any writer) in JSON Lines format.
+///
+/// Each call to a method like [`selected_crate`](PredicateEmitter::selected_crate)
+/// writes one line to the underlying writer.
+///
+/// # Example
+///
+/// ```no_run
+/// use symposium_sdk::predicate::PredicateEmitter;
+///
+/// PredicateEmitter::stdout()
+///     .selected_crate("serde", &semver::Version::new(1, 0, 217)).unwrap()
+///     .selected_crate("tokio", &semver::Version::new(1, 40, 0)).unwrap();
+/// ```
+pub struct PredicateEmitter<W: Write> {
+    writer: W,
+}
+
+impl PredicateEmitter<io::Stdout> {
+    pub fn stdout() -> Self {
         Self {
-            selected_crates: Vec::new(),
+            writer: io::stdout(),
         }
+    }
+}
+
+impl<W: Write> PredicateEmitter<W> {
+    pub fn new(writer: W) -> Self {
+        Self { writer }
+    }
+
+    /// Emitting this record causes Symposium to fetch `name@version` as a
+    /// crate source for `source = "crate"` skill groups.
+    pub fn selected_crate(
+        &mut self,
+        name: &str,
+        version: &semver::Version,
+    ) -> io::Result<&mut Self> {
+        #[derive(Serialize)]
+        struct Record<'a> {
+            #[serde(rename = "selectedCrate")]
+            selected_crate: Inner<'a>,
+        }
+        #[derive(Serialize)]
+        struct Inner<'a> {
+            name: &'a str,
+            version: String,
+        }
+        let record = Record {
+            selected_crate: Inner {
+                name,
+                version: version.to_string(),
+            },
+        };
+        let line = serde_json::to_string(&record)
+            .expect("PredicateEmitter record serialization is infallible");
+        writeln!(self.writer, "{line}")?;
+        Ok(self)
     }
 }

--- a/tests/custom_predicates.rs
+++ b/tests/custom_predicates.rs
@@ -243,8 +243,8 @@ async fn sync_custom_predicate_cross_plugin_fails() {
     .unwrap();
 }
 
-/// A custom predicate that returns witness JSON drives `source = "crate"` resolution.
-/// The predicate script outputs `{"selectedCrates": [...]}` naming bp-crate,
+/// A custom predicate that returns witness JSON Lines drives `source = "crate"` resolution.
+/// The predicate script outputs a `selectedCrate` record naming bp-crate,
 /// and the skill from that crate's skills/ directory gets installed.
 #[tokio::test]
 async fn sync_custom_predicate_witness_drives_crate_source() {
@@ -255,7 +255,7 @@ async fn sync_custom_predicate_witness_drives_crate_source() {
             let script_path = ctx.tempdir.join("bp-checker.sh");
             write_script(
                 &script_path,
-                r#"printf '{"selectedCrates":[{"crate":"bp-crate","version":"0.2.0"}]}'"#,
+                r#"printf '{"selectedCrate":{"name":"bp-crate","version":"0.2.0"}}\n'"#,
             );
 
             ctx.symposium(&["init", "--add-agent", "claude"]).await?;


### PR DESCRIPTION
## What does this PR do?

- Switch custom predicate stdout protocol from a single JSON object (`{"selectedCrates": [...]}`) to JSON Lines ie. one tagged record per line
- Replace `PredicateOutput` struct in `symposium-sdk` with a streaming `PredicateEmitter` API
- Rename the wire field from `"crate"` to `"name"` inside `selectedCrate` records for consistency
- This enables adding future record types (e.g. `watchedFile` for cache invalidation) without breaking the schema
- unknown keys are skipped for, not rejected for forward compatibility as this is a breaking change to `symposium-sdk`

#### Wire format
Each non-blank stdout line is a JSON object with exactly one key:
```json
{"selectedCrate": {"name": "serde", "version": "1.0.217"}}
{"selectedCrate": {"name": "tokio", "version": "1.40.0"}}
```


<details>

<summary>Disclosure questions</summary>

**AI disclosure.**

<!-- Symposium is an AI project. We encourage the use of agentic tooling! We do however require disclosure. The disclosure helps us to calibrate our reviews. See our [PR disclosure policy](https://symposium-dev.github.io/symposium/design/governance.html#pr-disclosure-policy). -->

<!-- Remove the items that do not apply. -->

* The AI tool authored small parts of the code (e.g., autocomplete, comments)

**Questions for reviewers.**

<!-- Any specific areas of uncertainty or things you'd like reviewers to look at? -->

</details>
