### PR TITLE
RFD: PM interface, cargo PM, and discovery & sync

### DIFF
--- a/md/SUMMARY.md
+++ b/md/SUMMARY.md
@@ -85,5 +85,8 @@
   - [Accepted](./rfds/accepted.md) <!-- put accepted rfds in this section; the file goes in the rfds directory -->
     - [Registry-centric plugin distribution](./rfds/registry-centric-plugins/README.md)
       - [Plugin model](./rfds/registry-centric-plugins/plugin-model/README.md)
+      - [PM interface](./rfds/registry-centric-plugins/pm-interface/README.md)
+      - [Cargo PM](./rfds/registry-centric-plugins/cargo-pm/README.md)
+      - [Discovery & sync](./rfds/registry-centric-plugins/discovery-sync/README.md)
   - [Completed](./rfds/completed.md) <!-- move completed rfds to this section -->
     - [RFD Process](./rfds/rfd-process/README.md)

--- a/md/rfds/registry-centric-plugins/README.md
+++ b/md/rfds/registry-centric-plugins/README.md
@@ -302,8 +302,8 @@ The tradeoff is that some plugins don't have a natural "home" in a language-spec
 We plan follow-up RFDs with more details on each component:
 
 - **[Plugin model](./plugin-model/README.md)** — what a plugin is, `Symposium.toml` structure, defaults (skill discovery, implicit installations), predicates, chained plugins, installed vs. active.
-- **PM interface + Cargo PM** — the JSON-RPC protocol for PM binaries, error semantics, caching contract. The cargo PM specifically: `resolve` schema, `fetch` via cargo toolchain, `list-deps` from `Cargo.lock`.
-- **Discovery & sync** — the two-phase discovery algorithm (`list-deps` on all PMs, then `search` on all PMs for each dep), hook-triggered notification, prompt UX, auto-install configuration.
+- **[PM interface](./pm-interface/README.md) + [Cargo PM](./cargo-pm/README.md)** — the JSON-RPC protocol for PM binaries, error semantics, caching contract. The cargo PM specifically: `resolve` schema, `fetch` via cargo toolchain, `list-deps` from `Cargo.lock`.
+- **[Discovery & sync](./discovery-sync/README.md)** — the two-phase discovery algorithm (`list-deps` on all PMs, then `search` on all PMs for each dep), hook-triggered notification, prompt UX, auto-install configuration.
 - **User-managed plugins** — `symposium use`/`remove`/`status` commands, config file format, version requirement syntax, global vs. workspace-local scoping.
 
 ### Future work

--- a/md/rfds/registry-centric-plugins/cargo-pm/README.md
+++ b/md/rfds/registry-centric-plugins/cargo-pm/README.md
@@ -1,0 +1,162 @@
+# The `cargo` PM
+
+## TL;DR
+
+- The `cargo` PM bridges crates.io (and alternative Rust registries) to Symposium's plugin system.
+- It is a separate binary (`symposium-pm-cargo`) communicating with Symposium via JSON-RPC over stdio.
+- `resolve` takes an opaque TOML value using cargo's dependency format.
+- `fetch` leverages the existing cargo toolchain to obtain crate sources.
+- `list-deps` reads `Cargo.toml`/`Cargo.lock` to report direct workspace dependencies.
+- Every crate is implicitly a plugin — no opt-in required.
+
+## Motivation
+
+Most Symposium users today are Rust developers. Their project dependencies live on crates.io. The cargo PM makes these dependencies discoverable as plugin sources — if `serde` ships skills, or if a recommendations entry references `serde`, the cargo PM is what connects the dots.
+
+## Change in a nutshell
+
+In the cargo PM, **every crate is a plugin**. No opt-in is required. A crate can optionally include a `Symposium.toml` at its root directory for explicit configuration — but if absent, an empty one is synthesized and [plugin defaults](../plugin-model/README.md) apply (which discovers `skills/` and `.agents/skills/` directories).
+
+This means a crate author can ship skills by simply adding a `skills/` directory:
+
+```
+my-crate/
+├── Cargo.toml
+├── src/
+│   └── lib.rs
+└── skills/
+    └── my-crate-usage/
+        └── SKILL.md
+```
+
+No `Symposium.toml` needed. When a user depends on `my-crate`, the cargo PM's `list-deps` reports it, discovery finds the plugin content (via defaults), and the skills are offered for installation.
+
+## Detailed plans
+
+### Package-ids
+
+The cargo PM defines package-ids as `(cargo, $crate-name, $version)`. For example: `(cargo, serde, 1.0.210)`, `(cargo, tokio, 1.38.0)`.
+
+### `resolve` schema
+
+Symposium passes the TOML value from `source.cargo = { ... }` to the cargo PM uninterpreted. The cargo PM accepts the same format cargo uses for dependency specifications — crate names as keys, version requirements as values:
+
+```toml
+[[plugins]]
+source.cargo = { serde-skills = "1" }
+
+[[plugins]]
+source.cargo = { foo = "1.*", bar = "2.0" }
+```
+
+`resolve` queries the registry index and returns one package-id per resolved crate:
+
+```
+source.cargo = { serde-skills = "1.*" }
+→ resolve → [(cargo, serde-skills, 1.2.3)]
+```
+
+### `search` behavior
+
+`search` receives a package-id tuple (from another PM's `list-deps` result, passed during discovery). If the tuple's `pm` field is `cargo`, it searches the cargo registry for matching crates with Symposium plugin content.
+
+**How we detect plugin content in a crate:**
+
+1. **`Symposium.toml` at crate root** — explicit opt-in.
+2. **Presence of `skills/` directory** — implicit. Convention-based discovery.
+3. **Keyword convention** — crate authors add a `symposium-plugin` keyword. Search filters on this.
+
+If the tuple's `pm` field is not `cargo`, return empty.
+
+### `fetch` behavior
+
+Given a package-id like `(cargo, serde-skills, 1.2.3)`:
+
+1. Use the existing cargo toolchain to obtain crate sources — leveraging `~/.cargo/registry/src/` (the unpacked source cache) or triggering `cargo fetch` if needed.
+2. Locate the unpacked crate source in cargo's cache.
+3. The crate root directory is the plugin directory (defaults apply to discover skills, etc.).
+4. Copy (or symlink) the plugin root into the destination path provided by Symposium.
+
+This approach ensures compatibility with users who have custom registry configurations, alternative registries, or corporate mirrors — we go through cargo rather than around it.
+
+### `list-deps` behavior
+
+Reads the workspace to report direct Rust dependencies.
+
+**Input:** workspace root directory (where `Cargo.toml` lives).
+
+**Strategy:**
+
+1. If `Cargo.lock` exists, read it — it has exact versions for all resolved dependencies. Return direct dependencies (those listed in workspace members' `[dependencies]`, `[dev-dependencies]`, `[build-dependencies]`).
+2. If no lockfile, fall back to reading `Cargo.toml` manifests for dependency names (without exact versions).
+
+**Output:** set of package-id tuples, e.g., `[(cargo, serde, 1.0.210), (cargo, tokio, 1.38.0)]`.
+
+**Workspace handling:**
+- For a workspace with multiple members, union all members' direct dependencies.
+- Path dependencies within the workspace are excluded (those are the user's own crates, not external deps).
+- Dev-dependencies are included (they're still dependencies the user works with).
+
+**Performance:**
+- Parse `Cargo.lock` directly (it's a TOML file). No `cargo metadata` invocation.
+- Cache results keyed on `Cargo.lock` mtime.
+- If `Cargo.lock` hasn't changed, return cached results immediately.
+
+### Chained plugins for independent release
+
+If a crate author wants to release plugin content on a separate schedule from their library, they add a `Symposium.toml` to their crate with a chained plugin:
+
+```toml
+# In widget-lib's Symposium.toml
+[[plugins]]
+source.cargo = { widget-symposium = "1" }
+```
+
+This tells Symposium: "when this plugin is loaded, also load `widget-symposium`." The chained plugin can be published and updated independently.
+
+### Alternative registries
+
+The cargo PM defaults to crates.io but can be configured to use alternative registries. Configuration mechanism TBD — likely via cargo's own registry configuration in `~/.cargo/config.toml`, which the cargo PM inherits naturally since it uses the cargo toolchain.
+
+## Frequently asked questions
+
+### Why keys in `source.cargo` rather than `name`/`version` fields?
+
+The key-value style (`{ foo = "1.0", bar = "2.0" }`) mirrors how `[dependencies]` works in `Cargo.toml`, which is familiar to Rust users. It also naturally supports multiple crates per entry.
+
+### How does `search` know which crates have plugin content without downloading them all?
+
+Three approaches, in order of preference:
+1. **Keyword convention** — crate authors add a `symposium-plugin` keyword. Search filters on this.
+2. **Registry metadata** — if crates.io exposes enough metadata to detect `Symposium.toml` or `skills/` presence.
+3. **Recommendations fallback** — for crates found via recommendations, we already know they have content.
+
+### Why not use `[package.metadata.symposium]` in Cargo.toml?
+
+We use `Symposium.toml` as the single configuration mechanism across all ecosystems. This avoids splitting plugin configuration between ecosystem-specific manifest files and keeps things consistent — whether your plugin comes from cargo, npm, or git, the configuration lives in `Symposium.toml`.
+
+## Implementation plan and status
+
+### Step 1: `list-deps` from Cargo.lock
+
+Parse `Cargo.lock` directly for dependency names and versions. Handle workspace members, exclude path deps. Mtime-based caching.
+
+- [ ] PR: cargo PM `list-deps`
+
+### Step 2: `resolve` with registry index
+
+Query the crates.io index (or alternative registry) to resolve version requirements to exact versions.
+
+- [ ] PR: cargo PM `resolve`
+
+### Step 3: `fetch` via cargo toolchain
+
+Leverage cargo's registry cache to locate crate sources. Copy to dest.
+
+- [ ] PR: cargo PM `fetch`
+
+### Step 4: `search` with plugin detection
+
+Search the registry, filter for plugin content (via keyword or metadata), rank results.
+
+- [ ] PR: cargo PM `search`

--- a/md/rfds/registry-centric-plugins/discovery-sync/README.md
+++ b/md/rfds/registry-centric-plugins/discovery-sync/README.md
@@ -1,0 +1,207 @@
+# Discovery & sync
+
+## TL;DR
+
+- `symposium sync` resolves installed plugins, discovers new ones from workspace dependencies, prompts the user, fetches, evaluates predicates, and wires active content into agent directories.
+- Discovery calls `list-deps` on all PMs, then passes each result as a query to `search` on all PMs.
+- A session-start hook notifies users of available extensions without auto-installing.
+
+## Motivation
+
+Users shouldn't have to manually find and install plugins for every crate they depend on. Discovery bridges the gap: when you add `serde` to your `Cargo.toml`, Symposium notices and offers relevant extensions. The sync pipeline ensures everything stays consistent.
+
+## Change in a nutshell
+
+User adds `axum` to their project. On next agent session start, they see:
+
+```
+New extensions available for 1 dependency. Run `symposium sync` to review.
+```
+
+They run `symposium sync`:
+
+```
+New extensions available:
+
+  [1] (cargo, axum-agents, 0.5.1) — Route documentation and testing skills
+      (because you depend on axum)
+
+Install? [1,all,none]: 1
+✓ Installed (cargo, axum-agents, 0.5.1)
+✓ Synced 2 skills: axum-routing, axum-testing
+```
+
+## Detailed plans
+
+### The discovery algorithm
+
+The core discovery loop:
+
+1. **Call `list-deps` on all PMs.** Each PM reports the workspace's dependencies in its ecosystem. For example, the cargo PM returns `[(cargo, serde, 1.0.210), (cargo, tokio, 1.38.0)]`. PMs that don't have a concept of workspace deps (git, path, recommendations) return empty.
+
+2. **For each dependency, call `search` on all PMs.** The full package-id tuple is passed as the query. Each PM decides how to match:
+   - The cargo PM: if `pm = cargo`, search the registry for matching plugin crates. Otherwise, return empty.
+   - The recommendations PM: match on `(pm, name)`, ignoring version. If it has a `cargo/serde/` directory, it returns that as a match.
+   - The git PM: returns empty (not searchable).
+
+3. **Filter out already-installed plugins.** Compare search results against what's already in config.
+
+4. **Prompt the user.** Present new discoveries and let them choose which to install.
+
+5. **Record choices.** Accepted plugins are added to config. Declined plugins are recorded as dismissed.
+
+This two-phase approach (list-deps → search) is what lets the recommendations PM "advise" on other PMs' dependencies without needing its own `list-deps` to return anything.
+
+### The sync pipeline
+
+`symposium sync` runs the full pipeline:
+
+```
+1. Resolve config       → installed plugin package-ids (exact versions)
+2. Discover deps        → candidate plugin package-ids (via list-deps + search)
+3. Prompt/auto-install  → updated installed set
+4. Fetch                → populate cache
+5. Evaluate predicates  → active set
+6. Sync to agent dirs   → skills, hooks, MCP servers wired in
+```
+
+#### Step 1: Resolve config
+
+Read `~/.symposium/config.toml`. For each entry, call the PM's `resolve` to get the current best match.
+
+#### Step 2: Discover deps
+
+Run the discovery algorithm described above.
+
+#### Step 3: Prompt or auto-install
+
+Present new discoveries to the user:
+
+```
+New extensions available:
+
+  [1] (cargo, serde-skills, 1.2.3) — Schema-aware serialization helpers
+      (because you depend on serde)
+
+  [2] (cargo, axum-agents, 0.5.1) — Route documentation and testing skills
+      (because you depend on axum)
+
+Install? [1,2,all,none]:
+```
+
+If `auto-sync = true` in config, skip the prompt and install all.
+
+Selected plugins are added to config. Declined plugins are recorded as dismissed.
+
+#### Step 4: Fetch
+
+For each installed plugin, call `fetch` on its PM to populate the cache. Chained plugins declared in a plugin's `Symposium.toml` are fetched transitively.
+
+Fetching happens in parallel across PMs and packages.
+
+#### Step 5: Evaluate predicates
+
+For each cached plugin, evaluate its predicates against the workspace:
+- `workspace()` → is this directory part of the workspace?
+- `depends-on(cargo, axum, 0.7)` → check if cargo's `list-deps` included axum
+- etc.
+
+Plugins that pass are *active*. Plugins that don't pass are installed but dormant.
+
+#### Step 6: Sync to agent dirs
+
+Copy active skills/hooks/MCP servers into agent directories. Same change-awareness as today:
+- Compare source and destination content
+- Only write when files differ
+- Clean up stale entries from deactivated/removed plugins
+
+### Hook-triggered notification
+
+On session start, a lightweight check runs:
+
+1. Use cached `list-deps` results (from lockfile mtime — no network calls).
+2. Call `search` on all PMs with each dep.
+3. If new matches exist, include in hook response:
+   ```
+   New extensions available for 3 dependencies. Run `symposium sync` to review.
+   ```
+
+The hook does NOT install anything. It only notifies. Installation goes through `symposium sync`.
+
+### Auto-install configuration
+
+```toml
+# In ~/.symposium/config.toml
+
+# Install all discoveries without prompting
+auto-sync = true
+
+# Or per-PM granularity:
+[auto-sync]
+recommendations = true   # auto-install from recommendations
+cargo = false            # prompt for crates.io discoveries
+```
+
+### Dismissed discoveries
+
+When a user says "none" to a discovery, it's suppressed until:
+- The plugin's version changes (a new release might be more relevant)
+- The user explicitly searches for it via `symposium use`
+
+Dismissals are tracked in state (`~/.symposium/state.toml`).
+
+### Debouncing and caching
+
+- `list-deps` results are cached based on lockfile mtime. No cargo invocation if `Cargo.lock` hasn't changed.
+- Discovery search results are cached with a 24-hour TTL.
+- The session-start hook path uses cached results exclusively — no network calls during hook handling.
+
+## Frequently asked questions
+
+### Why not auto-install by default?
+
+Installing code without consent is a security concern. Users should see what's being proposed and approve it. The `auto-sync = true` opt-in is for users who trust the recommendations set and want zero friction.
+
+### Why only direct dependencies?
+
+Transitive deps are numerous and usually not relevant to the user's workflow. Direct deps keep discovery focused.
+
+### What if `list-deps` is slow?
+
+The cargo PM's `list-deps` reads `Cargo.lock` directly (fast parse). The result is cached on lockfile mtime. In the common case (lock unchanged), `list-deps` is a no-op.
+
+### Can discovery be disabled entirely?
+
+Yes: `auto-sync = false` (the default) means you only get notified, never auto-installed. To suppress even the notification, set `discovery = false` in config.
+
+## Implementation plan and status
+
+### Step 1: Sync pipeline skeleton
+
+Wire up the pipeline with the path PM initially to validate the flow end-to-end.
+
+- [ ] PR: sync pipeline with path PM
+
+### Step 2: Discovery algorithm
+
+Implement `list-deps` → `search` loop across all PMs. 
+
+- [ ] PR: discovery algorithm
+
+### Step 3: Prompt UX
+
+Present discoveries, record choices (accept/dismiss).
+
+- [ ] PR: discovery prompt
+
+### Step 4: Hook notification
+
+Add discovery check to session-start hook. Use cached results only.
+
+- [ ] PR: session start notification
+
+### Step 5: Auto-install and dismissal
+
+Add `auto-sync` config, per-PM granularity, and dismissed-discovery tracking.
+
+- [ ] PR: auto-install + dismissal state

--- a/md/rfds/registry-centric-plugins/pm-interface/README.md
+++ b/md/rfds/registry-centric-plugins/pm-interface/README.md
@@ -1,0 +1,239 @@
+# PM interface
+
+## TL;DR
+
+- Define a four-operation interface (`resolve`, `search`, `fetch`, `list-deps`) that all package managers implement.
+- PMs are separate binaries communicating via JSON-RPC over stdio.
+- Only `path` is built into the Symposium binary; `cargo`, `git`, and future PMs are external.
+
+## Motivation
+
+Symposium needs to fetch plugins from multiple ecosystems without hard-coding each one. The PM interface is the seam: implement four operations and your ecosystem becomes a plugin source. This lets us ship cargo support today, add npm/pypi later, and let enterprises plug in internal registries — all without changing core.
+
+## Change in a nutshell
+
+A PM is a separate binary that speaks JSON-RPC over stdio. Here's the cargo PM responding to `resolve`:
+
+```toml
+# User writes in Symposium.toml:
+[[plugins]]
+source.cargo = { serde-skills = "1" }
+```
+
+Symposium passes `{ "serde-skills": "1" }` to the cargo PM's `resolve` method. It queries crates.io and returns `(cargo, serde-skills, 1.2.3)`.
+
+Then `fetch((cargo, serde-skills, 1.2.3))` downloads the crate and unpacks the plugin directory into cache.
+
+## Detailed plans
+
+### Package-ids
+
+A **package-id** is a tuple `(pm, name, version)` where all three components are PM-defined strings. There is no mandated string-serialized format — the tuple is the identity.
+
+Examples:
+- `(cargo, serde, 1.0.210)`
+- `(git, git@github.com:rtk-ai/rtk#main, abc123def)`
+- `(recommendations, cargo/serde, 0.1.0)`
+
+In the JSON-RPC protocol, a package-id is represented as:
+
+```json
+{ "pm": "cargo", "name": "serde", "version": "1.0.210" }
+```
+
+### The protocol
+
+PMs are separate binaries invoked by Symposium. Communication uses JSON-RPC over stdio (the same pattern as MCP servers). Each PM binary is long-lived — Symposium spawns it once and sends multiple requests.
+
+The protocol defines four methods:
+
+#### `resolve`
+
+```json
+// Request
+{ "method": "resolve", "params": { "value": { "serde-skills": "1" } } }
+
+// Response
+{ "result": [{ "pm": "cargo", "name": "serde-skills", "version": "1.2.3" }] }
+```
+
+Takes the opaque TOML value from `source.<pm> = { ... }` (passed as JSON). Returns a set of package-ids.
+
+- Cargo PM: `{ "serde-skills": "1" }` → queries registry → `(cargo, serde-skills, 1.2.3)`
+- Git PM: `{ "url": "...", "branch": "main" }` → resolves ref → `(git, git@github.com:org/repo#main, abc123)`
+- Path PM (built-in, not JSON-RPC): `{ "path": "./my-plugin" }` → canonicalizes
+
+May involve network calls. Deterministic given same registry state.
+
+#### `search`
+
+```json
+// Request
+{ "method": "search", "params": { "query": { "pm": "cargo", "name": "serde", "version": "1.0.210" } } }
+
+// Response
+{ "result": [{ "id": { "pm": "cargo", "name": "serde-skills", "version": "1.2.3" }, "description": "..." }] }
+```
+
+Takes a package-id tuple (all fields provided — as returned by another PM's `list-deps`). Returns matching plugins from this PM's perspective.
+
+- Each PM decides which tuple components to match on. The recommendations PM ignores version; the cargo PM matches on name.
+- If the query's `pm` field doesn't relate to this PM, it may return empty.
+- Used during discovery: `list-deps` results are passed as queries to every PM's `search`.
+
+#### `fetch`
+
+```json
+// Request
+{ "method": "fetch", "params": { "id": { "pm": "cargo", "name": "serde-skills", "version": "1.2.3" }, "dest": "/home/user/.symposium/cache/cargo/serde-skills/1.2.3" } }
+
+// Response
+{ "result": { "path": "/home/user/.symposium/cache/cargo/serde-skills/1.2.3" } }
+```
+
+Downloads exact versioned content into the provided destination directory.
+
+Contract:
+- Same package-id always produces same content.
+- PM writes into `dest`, which Symposium provides.
+- If `dest` already has content, PM may skip (cache hit).
+
+#### `list-deps`
+
+```json
+// Request
+{ "method": "list_deps", "params": { "workspace": "/home/user/projects/my-app" } }
+
+// Response
+{ "result": [{ "pm": "cargo", "name": "serde", "version": "1.0.210" }, { "pm": "cargo", "name": "tokio", "version": "1.38.0" }] }
+```
+
+Inspects the workspace and reports dependencies relevant to this PM. Returns full package-id tuples.
+
+Contract:
+- Direct dependencies only (not transitive).
+- Must be fast — called on every sync. Read lockfiles, don't query the network.
+
+### Error handling
+
+Errors use JSON-RPC error codes:
+
+| Code | Meaning | Symposium behavior |
+|------|---------|-------------------|
+| -32001 | Not found | Skip gracefully, report in `status` |
+| -32002 | Network error | Retry with backoff, fall back to cache |
+| -32003 | Invalid input | Hard error at parse time |
+| -32004 | Auth required | Report to user with setup instructions |
+
+### PM lifecycle
+
+Symposium manages PM binaries as follows:
+
+1. PMs are installed as `[[installable]]` entries — from the recommendations repository or the user's root config.
+2. On first use, Symposium spawns the PM binary and connects via stdio.
+3. The PM stays alive for the duration of the sync/hook operation.
+4. Symposium may call methods concurrently (the PM should handle this or serialize internally).
+
+The `path` PM is the exception — it's built into the Symposium binary itself (since it just reads local directories and has no external dependencies).
+
+### Cache layout
+
+```
+~/.symposium/cache/
+├── cargo/
+│   └── serde-skills/
+│       └── 1.2.3/
+│           ├── Symposium.toml
+│           └── skills/
+├── git/
+│   └── github.com-org-repo/
+│       └── abc123/
+│           └── ...
+└── recommendations/
+    └── cargo/
+        └── serde/
+            └── ...
+```
+
+Cache is a pure optimization — deletable and rebuildable from config. Symposium owns the directory structure; PMs write content into the slot they're given.
+
+### Built-in PMs
+
+#### `path`
+
+Built into the Symposium binary. For local development and workspace-local plugins.
+
+- `resolve`: canonicalizes a path, returns `(path, /absolute/path, _)`.
+- `search`: returns empty (not a searchable registry).
+- `fetch`: no-op (content is already on disk).
+- `list-deps`: returns empty.
+
+### External PMs (shipped as installables)
+
+#### `cargo`
+
+Separate binary (`symposium-pm-cargo`). See the [cargo PM sub-RFD](../cargo-pm/README.md) for details.
+
+#### `git`
+
+Separate binary (`symposium-pm-git`). Resolves refs to commit SHAs, fetches repo content.
+
+#### `recommendations`
+
+Separate binary (`symposium-pm-recommendations`). Operates over the curated recommendations repository. See the main README's [recommendations manager section](../README.md#example-the-recommendations-manager) for structure.
+
+## Frequently asked questions
+
+### Why JSON-RPC over stdio?
+
+It's the same pattern used by MCP servers and LSP — well-understood, language-agnostic, and debuggable. We can use the `agent-client-protocol` SDK for the implementation. It also means PMs can be written in any language.
+
+### Why not compile PMs into the binary?
+
+Language-agnosticism. We want npm/pypi PMs eventually, and those may be best written in JS/Python. Even for Rust-based PMs, the binary boundary keeps the core small and lets PMs be updated independently.
+
+### Why is `path` the only built-in?
+
+It has no external dependencies and no protocol overhead would be justified for "return this local directory." Every other PM needs network access, registry-specific logic, or ecosystem tooling — better as separate binaries.
+
+### Who resolves version requirements — Symposium or the PM?
+
+The PM. When config says the user wants `serde-skills` version `1.*`, Symposium calls `resolve` with that constraint. The PM knows how to interpret version ranges for its ecosystem.
+
+## Implementation plan and status
+
+### Step 1: Define the JSON-RPC protocol schema
+
+Document the four methods, their request/response shapes, and error codes. Publish as a schema that PM authors can validate against.
+
+- [ ] PR: protocol schema definition
+
+### Step 2: Implement the `path` PM (built-in)
+
+Simplest case — validates the fetch/cache flow end-to-end without spawning an external process.
+
+- [ ] PR: path PM implementation + tests
+
+### Step 3: PM process management
+
+Spawning, stdio connection, JSON-RPC framing, lifecycle management (start on demand, keep alive during sync).
+
+- [ ] PR: PM process manager
+
+### Step 4: Implement `symposium-pm-cargo`
+
+First external PM. Port existing crate-fetch logic. Validates the full JSON-RPC round-trip.
+
+- [ ] PR: cargo PM binary + tests
+
+### Step 5: Implement `symposium-pm-git`
+
+Resolves refs, fetches repos. Validates a second external PM works with the protocol.
+
+- [ ] PR: git PM binary + tests
+
+### Step 6: Implement `symposium-pm-recommendations`
+
+Operates over the recommendations repository structure.
+
+- [ ] PR: recommendations PM binary + tests


### PR DESCRIPTION
## Summary

Adds three sub-RFDs as a follow-up to #253 and #257:

**PM interface:** JSON-RPC over stdio protocol for PM binaries. Package-id tuples, four operations (resolve/search/fetch/list-deps), error handling, cache layout. Only `path` is built-in; cargo/git/recommendations are separate binaries.

**Cargo PM:** Resolve schema using cargo's dependency format, fetch via cargo toolchain, list-deps from Cargo.lock, plugin detection in crates.

**Discovery & sync:** The two-phase algorithm (list-deps on all PMs → search on all PMs for each dep), prompt UX, auto-install config, hook-triggered notification, debouncing.

## Stacked on

- #253 (main RFD overview)
- #257 (plugin model)