### PR TITLE
Predicate Caching Impl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod sync;
 
 pub(crate) mod crate_sources;
 pub(crate) mod predicate;
+pub(crate) mod predicate_cache;
 pub(crate) mod skills;
 
 pub use symposium_install::UpdateLevel;

--- a/src/predicate.rs
+++ b/src/predicate.rs
@@ -25,10 +25,15 @@
 use std::path::Path;
 use std::process::Command;
 
+use std::sync::Arc;
+
 use anyhow::{Context, Result, bail};
 use symposium_sdk::predicate::CustomPredicateEvent;
 
 use crate::pm::PackageId;
+use crate::predicate_cache::{
+    CacheEntry, CacheTtl, Fingerprints, PredicateCache, WatchSet, cache_key, now_ms,
+};
 
 /// Names reserved for builtin predicates. Custom predicates must not use
 /// these. `crate` is retired syntax but stays reserved so a custom predicate
@@ -66,6 +71,12 @@ pub struct PredicateContext<'a> {
     used_names: std::collections::HashSet<String>,
     custom_entries: std::collections::HashMap<String, ResolvedPredicateEntry>,
     custom_cache: std::collections::HashMap<(String, String), CustomPredicateResult>,
+    /// The current (possibly mutated) view of the on-disk cache.
+    disk_cache: Option<Arc<PredicateCache>>,
+    /// The load-time snapshot. `Arc::ptr_eq(&disk_cache, &disk_cache_original)`
+    /// stays true until the first mutation goes through `Arc::make_mut`, so
+    /// "was this modified?" is derived from the data, not a separate flag.
+    disk_cache_original: Option<Arc<PredicateCache>>,
 }
 
 impl<'a> PredicateContext<'a> {
@@ -76,6 +87,8 @@ impl<'a> PredicateContext<'a> {
             used_names: std::collections::HashSet::new(),
             custom_entries: std::collections::HashMap::new(),
             custom_cache: std::collections::HashMap::new(),
+            disk_cache: None,
+            disk_cache_original: None,
         }
     }
 
@@ -107,6 +120,30 @@ impl<'a> PredicateContext<'a> {
             .contains(&crate::crate_sources::normalize_crate_name(plugin_name))
     }
 
+    /// Load a persistent cache from disk and attach it to this context.
+    /// Missing / malformed cache files yield an empty cache (see
+    /// [`PredicateCache::load`]).
+    pub fn with_disk_cache(mut self, cache_path: &Path) -> Self {
+        let loaded = Arc::new(PredicateCache::load(cache_path));
+        self.disk_cache_original = Some(Arc::clone(&loaded));
+        self.disk_cache = Some(loaded);
+        self
+    }
+
+    /// Persist the disk cache back to `cache_path`. No-op if this context
+    /// was not built with `with_disk_cache` or the cache was not modified.
+    pub fn persist_disk_cache(&mut self, cache_path: &Path) -> Result<()> {
+        let (Some(current), Some(original)) = (&self.disk_cache, &self.disk_cache_original) else {
+            return Ok(());
+        };
+        if Arc::ptr_eq(current, original) {
+            return Ok(());
+        }
+        current.save(cache_path)?;
+        self.disk_cache_original = Some(Arc::clone(current));
+        Ok(())
+    }
+
     /// Stamp whether the plugin about to be evaluated arrived via workspace
     /// membership. Call before evaluating each plugin's predicate sets; the
     /// value applies to all of that plugin's nested components (groups,
@@ -116,16 +153,63 @@ impl<'a> PredicateContext<'a> {
     }
 
     /// Evaluate a custom predicate by name and argument, returning the cached
-    /// result if already computed.
+    /// result if already computed. Consults the in-memory cache first, then
+    /// the on-disk cache (when present). On miss, spawns the predicate and
+    /// updates both caches according to the emitted watch events.
     fn evaluate_custom(&mut self, name: &str, arg: &str) -> bool {
-        let key = (name.to_string(), arg.to_string());
-        if let Some(result) = self.custom_cache.get(&key) {
+        let mem_key = (name.to_string(), arg.to_string());
+        if let Some(result) = self.custom_cache.get(&mem_key) {
             return result.passed;
         }
+
+        let disk_key = cache_key(name, arg);
+        if let Some(cache) = &self.disk_cache {
+            if let Some(entry) = cache.get(&disk_key) {
+                if !entry.is_time_expired(now_ms())
+                    && Fingerprints::capture(&watch_set_from_entry(entry)) == entry.fingerprints
+                {
+                    // Disk hit. Populate the in-memory cache with a result
+                    // that has no events; the events belong to the run that
+                    // originally produced this entry.
+                    let passed = entry.result;
+                    self.custom_cache.insert(
+                        mem_key,
+                        CustomPredicateResult {
+                            passed,
+                            events: Vec::new(),
+                        },
+                    );
+                    return passed;
+                }
+            }
+        }
+
         let result = run_custom_predicate(&self.custom_entries, name, arg);
         let passed = result.passed;
-        self.custom_cache.insert(key, result);
+
+        if let Some(cache_arc) = self.disk_cache.as_mut() {
+            let cache = Arc::make_mut(cache_arc);
+            let set = WatchSet::from_events(&result.events);
+            if !matches!(set.cache_ttl, CacheTtl::Never) {
+                cache.put(disk_key, CacheEntry::from_result(passed, &set));
+            } else {
+                // Explicit no-cache: drop any stale entry we might have had.
+                cache.entries.remove(&cache_key(name, arg));
+            }
+        }
+
+        self.custom_cache.insert(mem_key, result);
         passed
+    }
+}
+
+/// Recompute the watch set from a stored cache entry so we can capture
+/// fresh fingerprints and compare them against the stored ones.
+fn watch_set_from_entry(entry: &CacheEntry) -> WatchSet {
+    WatchSet {
+        files: entry.fingerprints.files.keys().cloned().collect(),
+        env: entry.fingerprints.env.keys().cloned().collect(),
+        cache_ttl: CacheTtl::Forever,
     }
 }
 
@@ -1417,6 +1501,132 @@ mod tests {
                 arg: "hello".into()
             }
         );
+    }
+
+    // --- Disk cache integration tests ---
+
+    fn ctx_with_disk_cache<'a>(
+        deps: &'a [PackageId],
+        entries: std::collections::HashMap<String, ResolvedPredicateEntry>,
+        cache_path: &Path,
+    ) -> PredicateContext<'a> {
+        PredicateContext::with_custom_predicates(deps, entries).with_disk_cache(cache_path)
+    }
+
+    fn entries_for(
+        name: &str,
+        script_path: &Path,
+    ) -> std::collections::HashMap<String, ResolvedPredicateEntry> {
+        let mut map = std::collections::HashMap::new();
+        map.insert(
+            name.to_string(),
+            ResolvedPredicateEntry {
+                runnable: symposium_install::Runnable::Script(script_path.to_path_buf()),
+                args: vec![],
+            },
+        );
+        map
+    }
+
+    #[test]
+    fn disk_cache_hit_avoids_second_spawn() {
+        use std::io::Write;
+        // Script writes one line to counter_path on every run and emits no
+        // events → cached indefinitely.
+        let counter = tempfile::NamedTempFile::new().unwrap();
+        let counter_path = counter.path().to_path_buf();
+        let script = tempfile::Builder::new().suffix(".sh").tempfile().unwrap();
+        writeln!(
+            script.as_file(),
+            "#!/bin/sh\necho ran >> {}\nexit 0",
+            counter_path.display()
+        )
+        .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let cache_path = crate::predicate_cache::PredicateCache::path_for_workspace(
+            dir.path(),
+            workspace.path(),
+        );
+
+        // First eval: fresh context populates the disk cache.
+        {
+            let mut ctx =
+                ctx_with_disk_cache(&[], entries_for("always", script.path()), &cache_path);
+            let pred = Predicate::Custom {
+                name: "always".into(),
+                arg: "x".into(),
+            };
+            assert!(pred.evaluate(&mut ctx));
+            ctx.persist_disk_cache(&cache_path).unwrap();
+        }
+
+        // Second eval: brand-new context (no in-memory carryover) reads the
+        // disk cache and must not spawn the script again.
+        {
+            let mut ctx =
+                ctx_with_disk_cache(&[], entries_for("always", script.path()), &cache_path);
+            let pred = Predicate::Custom {
+                name: "always".into(),
+                arg: "x".into(),
+            };
+            assert!(pred.evaluate(&mut ctx));
+        }
+
+        let runs = std::fs::read_to_string(&counter_path).unwrap();
+        assert_eq!(runs.lines().count(), 1, "predicate should spawn once");
+    }
+
+    #[test]
+    fn disk_cache_time_expired_entry_respawns() {
+        use std::io::Write;
+        // Script emits WatchTime(1) so any subsequent read after 1ms wall
+        // clock is stale and must respawn.
+        let counter = tempfile::NamedTempFile::new().unwrap();
+        let counter_path = counter.path().to_path_buf();
+        let script = tempfile::Builder::new().suffix(".sh").tempfile().unwrap();
+        writeln!(
+            script.as_file(),
+            "#!/bin/sh\necho ran >> {}\nprintf '{{\"watchTime\":1}}\\n'\nexit 0",
+            counter_path.display()
+        )
+        .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let cache_path = crate::predicate_cache::PredicateCache::path_for_workspace(
+            dir.path(),
+            workspace.path(),
+        );
+
+        // First eval populates the cache with a 1ms TTL.
+        {
+            let mut ctx =
+                ctx_with_disk_cache(&[], entries_for("ticking", script.path()), &cache_path);
+            let pred = Predicate::Custom {
+                name: "ticking".into(),
+                arg: "x".into(),
+            };
+            assert!(pred.evaluate(&mut ctx));
+            ctx.persist_disk_cache(&cache_path).unwrap();
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        // Second eval: entry has expired, script must spawn again.
+        {
+            let mut ctx =
+                ctx_with_disk_cache(&[], entries_for("ticking", script.path()), &cache_path);
+            let pred = Predicate::Custom {
+                name: "ticking".into(),
+                arg: "x".into(),
+            };
+            assert!(pred.evaluate(&mut ctx));
+        }
+
+        let runs = std::fs::read_to_string(&counter_path).unwrap();
+        assert_eq!(runs.lines().count(), 2, "predicate should spawn twice");
     }
 
     // --- Predicate event parser tests ---

--- a/src/predicate.rs
+++ b/src/predicate.rs
@@ -26,6 +26,7 @@ use std::path::Path;
 use std::process::Command;
 
 use anyhow::{Context, Result, bail};
+use symposium_sdk::predicate::CustomPredicateEvent;
 
 use crate::pm::PackageId;
 
@@ -724,9 +725,15 @@ fn join(preds: &[Predicate]) -> String {
 
 /// Cached result of a custom predicate invocation. A custom predicate is a
 /// boolean gate: it passes iff the command exits 0.
+///
+/// `events` holds every well-formed [`CustomPredicateEvent`] the predicate
+/// emitted on stdout. Wiring these into cache invalidation is deferred to a
+/// follow-up PR; today the events are captured for observability only.
 #[derive(Debug, Clone)]
 pub struct CustomPredicateResult {
     pub passed: bool,
+    #[allow(dead_code)] // consumed by the cache in a follow-up PR
+    pub events: Vec<CustomPredicateEvent>,
 }
 
 /// A resolved custom predicate entry ready for invocation.
@@ -744,7 +751,10 @@ fn run_custom_predicate(
 ) -> CustomPredicateResult {
     let Some(entry) = entries.get(name) else {
         tracing::warn!(predicate = name, "custom predicate not found in registry");
-        return CustomPredicateResult { passed: false };
+        return CustomPredicateResult {
+            passed: false,
+            events: Vec::new(),
+        };
     };
 
     let mut full_args: Vec<&str> = entry.args.iter().map(|s| s.as_str()).collect();
@@ -767,11 +777,10 @@ fn run_custom_predicate(
                     "custom predicate stderr"
                 );
             }
-            // FIXME: custom predicates are a boolean gate today — stdout is
-            // ignored. Future: let a predicate set plugin/component fields via
-            // its output (see `symposium_sdk::predicate`).
+            let events = parse_predicate_events(name, &output.stdout);
             CustomPredicateResult {
                 passed: output.status.success(),
+                events,
             }
         }
         Err(e) => {
@@ -780,9 +789,48 @@ fn run_custom_predicate(
                 error = %e,
                 "failed to spawn custom predicate"
             );
-            CustomPredicateResult { passed: false }
+            CustomPredicateResult {
+                passed: false,
+                events: Vec::new(),
+            }
         }
     }
+}
+
+/// Parse a predicate's stdout as a JSON Lines stream of
+/// [`CustomPredicateEvent`]s. Blank lines are skipped. A line that is not
+/// valid UTF-8 or not a known event is logged and skipped so unknown record
+/// types do not break older Symposium versions.
+fn parse_predicate_events(predicate_name: &str, stdout: &[u8]) -> Vec<CustomPredicateEvent> {
+    let text = match std::str::from_utf8(stdout) {
+        Ok(s) => s,
+        Err(_) => {
+            tracing::warn!(
+                predicate = predicate_name,
+                "custom predicate stdout is not valid UTF-8; discarding events"
+            );
+            return Vec::new();
+        }
+    };
+
+    let mut events = Vec::new();
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<CustomPredicateEvent>(line) {
+            Ok(event) => events.push(event),
+            Err(e) => {
+                tracing::warn!(
+                    predicate = predicate_name,
+                    error = %e,
+                    line,
+                    "unknown custom predicate event; skipping"
+                );
+            }
+        }
+    }
+    events
 }
 
 #[cfg(test)]
@@ -1369,5 +1417,31 @@ mod tests {
                 arg: "hello".into()
             }
         );
+    }
+
+    // --- Predicate event parser tests ---
+
+    #[test]
+    fn parse_predicate_events_skips_blank_and_unknown_lines() {
+        let stdout = concat!(
+            "\n",
+            r#"{"watchFile":"a"}"#,
+            "\n",
+            r#"{"watchFuture":42}"#,
+            "\n",
+            "   \n",
+            r#"{"watchTime":0}"#,
+            "\n",
+        );
+        let events = parse_predicate_events("foo", stdout.as_bytes());
+        assert_eq!(events.len(), 2);
+        assert!(matches!(&events[0], CustomPredicateEvent::WatchFile(_)));
+        assert!(matches!(&events[1], CustomPredicateEvent::WatchTime(0)));
+    }
+
+    #[test]
+    fn parse_predicate_events_invalid_utf8_returns_empty() {
+        let events = parse_predicate_events("foo", &[0xFF, 0xFE, 0xFD]);
+        assert!(events.is_empty());
     }
 }

--- a/src/predicate_cache.rs
+++ b/src/predicate_cache.rs
@@ -16,10 +16,9 @@
 //! typically expands to `~/.symposium/cache`. The cache is discarded on
 //! Symposium version upgrade via the `version` tag written into each file.
 //!
-//! Wiring this cache into `run_custom_predicate` is deferred to a follow-up
-//! commit; today the types are used only through their tests.
-
-#![allow(dead_code)] // consumed by the evaluator in the next commit
+//! The cache is consumed by [`crate::predicate::PredicateContext`] via
+//! [`PredicateContext::with_disk_cache`](crate::predicate::PredicateContext::with_disk_cache)
+//! and [`PredicateContext::persist_disk_cache`](crate::predicate::PredicateContext::persist_disk_cache).
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
@@ -127,20 +126,17 @@ impl FileFingerprint {
         match fs::metadata(path) {
             Ok(meta) => Self {
                 size: Some(meta.len()),
-                mtime_ns: meta
-                    .modified()
-                    .ok()
-                    .and_then(|t| {
-                        t.duration_since(std::time::UNIX_EPOCH)
-                            .ok()
-                            .map(|d| d.as_nanos() as i128)
-                            .or_else(|| {
-                                std::time::UNIX_EPOCH
-                                    .duration_since(t)
-                                    .ok()
-                                    .map(|d| -(d.as_nanos() as i128))
-                            })
-                    }),
+                mtime_ns: meta.modified().ok().and_then(|t| {
+                    t.duration_since(std::time::UNIX_EPOCH)
+                        .ok()
+                        .map(|d| d.as_nanos() as i128)
+                        .or_else(|| {
+                            std::time::UNIX_EPOCH
+                                .duration_since(t)
+                                .ok()
+                                .map(|d| -(d.as_nanos() as i128))
+                        })
+                }),
             },
             Err(_) => Self::default(),
         }
@@ -241,7 +237,9 @@ impl PredicateCache {
         let mut hasher = Sha256::new();
         hasher.update(canonical.as_os_str().as_encoded_bytes());
         let digest = hex_encode(&hasher.finalize());
-        cache_dir.join(PREDICATES_SUBDIR).join(format!("{digest}.json"))
+        cache_dir
+            .join(PREDICATES_SUBDIR)
+            .join(format!("{digest}.json"))
     }
 
     /// Read the cache from disk. Missing files, malformed JSON, or a schema
@@ -292,13 +290,13 @@ impl PredicateCache {
             fs::create_dir_all(parent)
                 .with_context(|| format!("creating cache directory {}", parent.display()))?;
         }
-        let serialized = serde_json::to_vec_pretty(self)
-            .context("serializing predicate cache")?;
+        let serialized = serde_json::to_vec_pretty(self).context("serializing predicate cache")?;
         // Atomic replace: write to a sibling temp file, fsync, rename.
         let dir = path.parent().unwrap_or_else(|| Path::new("."));
         let mut tmp = tempfile::NamedTempFile::new_in(dir)
             .with_context(|| format!("creating temp file in {}", dir.display()))?;
-        tmp.write_all(&serialized).context("writing predicate cache")?;
+        tmp.write_all(&serialized)
+            .context("writing predicate cache")?;
         tmp.as_file_mut().sync_all().ok();
         tmp.persist(path)
             .map_err(|e| e.error)

--- a/src/predicate_cache.rs
+++ b/src/predicate_cache.rs
@@ -1,0 +1,179 @@
+//! Watch sets and fingerprints for custom predicate caching.
+//!
+//! A predicate emits [`CustomPredicateEvent`]s naming inputs whose changes
+//! invalidate its result. Those events are unioned into a [`WatchSet`]. When
+//! the predicate runs, we take a [`Fingerprints`] snapshot of the watched
+//! inputs; on the next sync we compare a fresh snapshot to the stored one and
+//! reuse the cached result while they match.
+//!
+//! This module is data-model only. It does not spawn processes, read the cache
+//! file, or wire results into evaluation. Those live in follow-up commits.
+
+#![allow(dead_code)] // wired into cache read/write in the next commit
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use symposium_sdk::predicate::CustomPredicateEvent;
+
+/// The union of watched inputs and cache lifetime derived from one predicate
+/// execution.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WatchSet {
+    pub files: BTreeSet<PathBuf>,
+    pub env: BTreeSet<String>,
+    pub cache_ttl: CacheTtl,
+}
+
+/// How long the predicate result may be cached, independent of file / env
+/// invalidation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheTtl {
+    /// No `WatchTime` events were emitted; the result never becomes stale by
+    /// time alone.
+    Forever,
+    /// The shortest `WatchTime(N>0)` reported by the predicate.
+    For(Duration),
+    /// `WatchTime(0)` was emitted; the result must not be cached.
+    Never,
+}
+
+impl Default for CacheTtl {
+    fn default() -> Self {
+        Self::Forever
+    }
+}
+
+impl WatchSet {
+    /// Union every event from a single predicate execution into one set.
+    pub fn from_events(events: &[CustomPredicateEvent]) -> Self {
+        let mut set = Self::default();
+        for event in events {
+            match event {
+                CustomPredicateEvent::WatchFile(path) => {
+                    set.files.insert(path.clone());
+                }
+                CustomPredicateEvent::WatchEnv(name) => {
+                    set.env.insert(name.clone());
+                }
+                CustomPredicateEvent::WatchTime(0) => {
+                    set.cache_ttl = CacheTtl::Never;
+                }
+                CustomPredicateEvent::WatchTime(ms) => {
+                    let next = Duration::from_millis(*ms);
+                    set.cache_ttl = match set.cache_ttl {
+                        CacheTtl::Never => CacheTtl::Never,
+                        CacheTtl::Forever => CacheTtl::For(next),
+                        CacheTtl::For(current) => CacheTtl::For(current.min(next)),
+                    };
+                }
+                _ => {}
+            }
+        }
+        set
+    }
+}
+
+/// Snapshot of the watched inputs at a point in time. Two snapshots that
+/// compare equal mean nothing observable to the cache has changed.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Fingerprints {
+    pub files: BTreeMap<PathBuf, FileFingerprint>,
+    pub env: BTreeMap<String, Option<String>>,
+}
+
+/// A file's `mtime` in nanoseconds and byte size. Both are `None` when the
+/// file is missing so an absent → present transition invalidates the entry.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FileFingerprint {
+    pub mtime_ns: Option<i128>,
+    pub size: Option<u64>,
+}
+
+impl FileFingerprint {
+    /// Fingerprint a file on disk. Missing files, unreadable metadata, and
+    /// metadata without a usable timestamp all resolve to a deterministic
+    /// `None`-only state; predicates fail to their conservative branch when
+    /// the file transitions to a readable state.
+    pub fn of(path: &Path) -> Self {
+        match fs::metadata(path) {
+            Ok(meta) => Self {
+                size: Some(meta.len()),
+                mtime_ns: meta
+                    .modified()
+                    .ok()
+                    .and_then(|t| {
+                        t.duration_since(std::time::UNIX_EPOCH)
+                            .ok()
+                            .map(|d| d.as_nanos() as i128)
+                            .or_else(|| {
+                                std::time::UNIX_EPOCH
+                                    .duration_since(t)
+                                    .ok()
+                                    .map(|d| -(d.as_nanos() as i128))
+                            })
+                    }),
+            },
+            Err(_) => Self::default(),
+        }
+    }
+}
+
+impl Fingerprints {
+    /// Capture fingerprints for every input in `set`. Non-existent files and
+    /// missing env vars are stored as their "absent" fingerprint so future
+    /// appearances count as an invalidating change.
+    pub fn capture(set: &WatchSet) -> Self {
+        let files = set
+            .files
+            .iter()
+            .map(|path| (path.clone(), FileFingerprint::of(path)))
+            .collect();
+        let env = set
+            .env
+            .iter()
+            .map(|name| (name.clone(), std::env::var(name).ok()))
+            .collect();
+        Self { files, env }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn watch_time_zero_produces_never_ttl() {
+        let events = vec![
+            CustomPredicateEvent::WatchTime(60_000),
+            CustomPredicateEvent::WatchTime(0),
+        ];
+        let set = WatchSet::from_events(&events);
+        assert_eq!(set.cache_ttl, CacheTtl::Never);
+    }
+
+    #[test]
+    fn fingerprint_changes_when_file_grows() {
+        use std::io::Write;
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(tmp.as_file(), "one").unwrap();
+
+        let set = WatchSet {
+            files: [tmp.path().to_path_buf()].into_iter().collect(),
+            ..WatchSet::default()
+        };
+        let before = Fingerprints::capture(&set);
+
+        // Wait long enough for the mtime to move on filesystems with 1s
+        // resolution and grow the file so `size` shifts even when mtime does
+        // not advance.
+        std::thread::sleep(std::time::Duration::from_millis(1_100));
+        writeln!(tmp.as_file(), "two").unwrap();
+        tmp.as_file().sync_all().unwrap();
+
+        let after = Fingerprints::capture(&set);
+        assert_ne!(before, after);
+    }
+}

--- a/src/predicate_cache.rs
+++ b/src/predicate_cache.rs
@@ -1,22 +1,46 @@
-//! Watch sets and fingerprints for custom predicate caching.
+//! Watch sets, fingerprints, and on-disk cache for custom predicate results.
 //!
 //! A predicate emits [`CustomPredicateEvent`]s naming inputs whose changes
 //! invalidate its result. Those events are unioned into a [`WatchSet`]. When
 //! the predicate runs, we take a [`Fingerprints`] snapshot of the watched
-//! inputs; on the next sync we compare a fresh snapshot to the stored one and
-//! reuse the cached result while they match.
+//! inputs and store the result in a [`PredicateCache`]; on the next sync we
+//! compare a fresh snapshot to the stored one and reuse the cached result
+//! while they match.
 //!
-//! This module is data-model only. It does not spawn processes, read the cache
-//! file, or wire results into evaluation. Those live in follow-up commits.
+//! Each workspace gets its own cache file at
+//! `<cache_dir>/predicates/<hash>.json`, where `<hash>` is a SHA-256 digest of
+//! the canonicalized workspace root. This isolation is what lets two
+//! workspaces on the same machine share a predicate string (for example
+//! `depends-on(serde)`) without stepping on each other's cached answers.
+//! `cache_dir` is resolved by [`symposium_sdk::dirs::SymposiumDirs`] and
+//! typically expands to `~/.symposium/cache`. The cache is discarded on
+//! Symposium version upgrade via the `version` tag written into each file.
+//!
+//! Wiring this cache into `run_custom_predicate` is deferred to a follow-up
+//! commit; today the types are used only through their tests.
 
-#![allow(dead_code)] // wired into cache read/write in the next commit
+#![allow(dead_code)] // consumed by the evaluator in the next commit
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use symposium_sdk::predicate::CustomPredicateEvent;
+
+/// Current schema version of the on-disk cache. Bump when the file layout
+/// changes; existing cache files with a different version are treated as
+/// empty.
+const CACHE_SCHEMA_VERSION: u32 = 1;
+
+/// Subdirectory of `SymposiumDirs::cache_dir` that holds one predicate cache
+/// file per workspace.
+const PREDICATES_SUBDIR: &str = "predicates";
 
 /// The union of watched inputs and cache lifetime derived from one predicate
 /// execution.
@@ -78,15 +102,17 @@ impl WatchSet {
 
 /// Snapshot of the watched inputs at a point in time. Two snapshots that
 /// compare equal mean nothing observable to the cache has changed.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Fingerprints {
+    #[serde(default)]
     pub files: BTreeMap<PathBuf, FileFingerprint>,
+    #[serde(default)]
     pub env: BTreeMap<String, Option<String>>,
 }
 
 /// A file's `mtime` in nanoseconds and byte size. Both are `None` when the
 /// file is missing so an absent → present transition invalidates the entry.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FileFingerprint {
     pub mtime_ns: Option<i128>,
     pub size: Option<u64>,
@@ -140,6 +166,171 @@ impl Fingerprints {
     }
 }
 
+/// One cached predicate result. Serialized as an entry inside
+/// [`PredicateCache::entries`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CacheEntry {
+    /// Exit-status result (`true` = passed).
+    pub result: bool,
+    /// Fingerprints of every watched file and env var at the time the result
+    /// was captured.
+    pub fingerprints: Fingerprints,
+    /// Wall-clock deadline in milliseconds since the Unix epoch. `None` means
+    /// the entry never becomes stale by time alone.
+    #[serde(default)]
+    pub stale_at_ms: Option<u64>,
+}
+
+impl CacheEntry {
+    /// Build an entry from a result and a `WatchSet`. `WatchSet` with
+    /// `CacheTtl::Never` produces an entry with `stale_at_ms = Some(0)`, but
+    /// the caller is expected to skip persisting such an entry entirely.
+    pub fn from_result(result: bool, set: &WatchSet) -> Self {
+        let stale_at_ms = match set.cache_ttl {
+            CacheTtl::Forever => None,
+            CacheTtl::Never => Some(0),
+            CacheTtl::For(d) => now_ms().checked_add(d.as_millis() as u64),
+        };
+        Self {
+            result,
+            fingerprints: Fingerprints::capture(set),
+            stale_at_ms,
+        }
+    }
+
+    /// True if the entry's TTL has already elapsed at wall-clock `now_ms`.
+    pub fn is_time_expired(&self, now: u64) -> bool {
+        match self.stale_at_ms {
+            Some(deadline) => now >= deadline,
+            None => false,
+        }
+    }
+}
+
+/// On-disk cache of custom predicate results.
+///
+/// Cache entries are keyed by the normalized predicate invocation
+/// (`name(arg)`). The cache is discarded when the schema version on disk
+/// differs from [`CACHE_SCHEMA_VERSION`], so a Symposium upgrade that changes
+/// the layout automatically invalidates existing entries.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PredicateCache {
+    version: u32,
+    #[serde(default)]
+    pub entries: BTreeMap<String, CacheEntry>,
+}
+
+impl Default for PredicateCache {
+    fn default() -> Self {
+        Self {
+            version: CACHE_SCHEMA_VERSION,
+            entries: BTreeMap::new(),
+        }
+    }
+}
+
+impl PredicateCache {
+    /// Return the cache file path for the given workspace. The filename is a
+    /// SHA-256 digest of the canonicalized workspace root, so different
+    /// workspaces on the same machine never collide even when they use the
+    /// same predicate string.
+    pub fn path_for_workspace(cache_dir: &Path, workspace_root: &Path) -> PathBuf {
+        let canonical = workspace_root
+            .canonicalize()
+            .unwrap_or_else(|_| workspace_root.to_path_buf());
+        let mut hasher = Sha256::new();
+        hasher.update(canonical.as_os_str().as_encoded_bytes());
+        let digest = hex_encode(&hasher.finalize());
+        cache_dir.join(PREDICATES_SUBDIR).join(format!("{digest}.json"))
+    }
+
+    /// Read the cache from disk. Missing files, malformed JSON, or a schema
+    /// version mismatch all yield an empty cache; the on-disk error case is
+    /// deliberately non-fatal because a stale cache must never break sync.
+    pub fn load(path: &Path) -> Self {
+        let bytes = match fs::read(path) {
+            Ok(bytes) => bytes,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Self::default(),
+            Err(err) => {
+                tracing::warn!(?path, error = %err, "failed to read predicate cache");
+                return Self::default();
+            }
+        };
+        match serde_json::from_slice::<Self>(&bytes) {
+            Ok(cache) if cache.version == CACHE_SCHEMA_VERSION => cache,
+            Ok(cache) => {
+                tracing::info!(
+                    ?path,
+                    stored = cache.version,
+                    current = CACHE_SCHEMA_VERSION,
+                    "predicate cache schema version mismatch; discarding"
+                );
+                Self::default()
+            }
+            Err(err) => {
+                tracing::warn!(?path, error = %err, "failed to parse predicate cache");
+                Self::default()
+            }
+        }
+    }
+
+    /// Look up an entry by its normalized predicate key.
+    pub fn get(&self, key: &str) -> Option<&CacheEntry> {
+        self.entries.get(key)
+    }
+
+    /// Insert or replace an entry for `key`.
+    pub fn put(&mut self, key: impl Into<String>, entry: CacheEntry) {
+        self.entries.insert(key.into(), entry);
+    }
+
+    /// Persist the cache atomically at `path`. Parents are created as needed.
+    /// Errors bubble up because a failed write indicates a real problem, but
+    /// the caller may downgrade to a warning to avoid failing the outer sync.
+    pub fn save(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("creating cache directory {}", parent.display()))?;
+        }
+        let serialized = serde_json::to_vec_pretty(self)
+            .context("serializing predicate cache")?;
+        // Atomic replace: write to a sibling temp file, fsync, rename.
+        let dir = path.parent().unwrap_or_else(|| Path::new("."));
+        let mut tmp = tempfile::NamedTempFile::new_in(dir)
+            .with_context(|| format!("creating temp file in {}", dir.display()))?;
+        tmp.write_all(&serialized).context("writing predicate cache")?;
+        tmp.as_file_mut().sync_all().ok();
+        tmp.persist(path)
+            .map_err(|e| e.error)
+            .with_context(|| format!("persisting predicate cache to {}", path.display()))?;
+        Ok(())
+    }
+}
+
+/// Normalized cache key for a predicate invocation. `arg` may be the empty
+/// string, matching the parser's convention.
+pub fn cache_key(name: &str, arg: &str) -> String {
+    format!("{name}({arg})")
+}
+
+/// Current wall-clock time in milliseconds since the Unix epoch. Falls back
+/// to `0` if the system clock is before the epoch (should never happen).
+pub fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Lowercase hex encoding without pulling in the `hex` crate.
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -175,5 +366,53 @@ mod tests {
 
         let after = Fingerprints::capture(&set);
         assert_ne!(before, after);
+    }
+
+    #[test]
+    fn cache_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let path = PredicateCache::path_for_workspace(dir.path(), workspace.path());
+
+        let entry = CacheEntry {
+            result: true,
+            fingerprints: Fingerprints {
+                files: [(
+                    PathBuf::from("CargoBrazil.toml"),
+                    FileFingerprint {
+                        mtime_ns: Some(1_700_000_000_000_000_000),
+                        size: Some(42),
+                    },
+                )]
+                .into_iter()
+                .collect(),
+                env: [("LAMBDA_ENV".to_string(), Some("prod".to_string()))]
+                    .into_iter()
+                    .collect(),
+            },
+            stale_at_ms: Some(1_700_000_060_000),
+        };
+        let mut cache = PredicateCache::default();
+        cache.put("depends-on(lambda)", entry.clone());
+        cache.save(&path).unwrap();
+
+        let loaded = PredicateCache::load(&path);
+        assert_eq!(loaded.get("depends-on(lambda)"), Some(&entry));
+    }
+
+    #[test]
+    fn cache_version_mismatch_yields_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let path = PredicateCache::path_for_workspace(dir.path(), workspace.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            br#"{"version": 999, "entries": {"stale": {"result": true, "fingerprints": {}}}}"#,
+        )
+        .unwrap();
+
+        let loaded = PredicateCache::load(&path);
+        assert!(loaded.entries.is_empty());
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -304,12 +304,17 @@ pub async fn sync(sym: &Symposium, deps: &Arc<WorkspaceDeps>, update: UpdateLeve
     let custom_entries = resolve_custom_predicate_entries(sym, &registry, update).await;
 
     // Resolve the workspace once and build the predicate context shared by
-    // skill resolution and MCP-server filtering.
+    // skill resolution and MCP-server filtering. Attach the on-disk cache so
+    // custom predicate results survive across sync runs; results are persisted
+    // at the end of this evaluation pass.
     let dep_ids = crate::pm::workspace_dep_ids(sym, deps).await;
     let used_names = sym.config.plugins.used_names_in(&project_root);
+    let predicate_cache_path =
+        crate::predicate_cache::PredicateCache::path_for_workspace(sym.cache_dir(), &project_root);
     let mut ctx =
         crate::predicate::PredicateContext::with_custom_predicates(&dep_ids, custom_entries)
-            .with_used_names(&used_names);
+            .with_used_names(&used_names)
+            .with_disk_cache(&predicate_cache_path);
 
     // The active plugin set: registry plugins plus the crate-sourced plugins
     // reached through `[[plugins]]` chained references and dependency
@@ -347,6 +352,13 @@ pub async fn sync(sym: &Symposium, deps: &Arc<WorkspaceDeps>, update: UpdateLeve
         if p.applies(&mut ctx) {
             mcp_servers.extend(p.plugin.applicable_mcp_servers(&mut ctx));
         }
+    }
+    if let Err(e) = ctx.persist_disk_cache(&predicate_cache_path) {
+        tracing::warn!(
+            path = %predicate_cache_path.display(),
+            error = %e,
+            "failed to persist predicate cache"
+        );
     }
 
     let server_names: Vec<&str> = mcp_servers

--- a/symposium-sdk/src/env.rs
+++ b/symposium-sdk/src/env.rs
@@ -1,0 +1,20 @@
+//! Environment-variable helpers that emit predicate cache events.
+//!
+//! Use [`var`] instead of [`std::env::var`] from a custom predicate so that
+//! reading a variable also declares a dependency on its value. Symposium
+//! fingerprints the value at read time and invalidates the cached predicate
+//! result if the value changes.
+
+use std::env;
+
+use crate::predicate::PredicateEmitter;
+
+/// Read the value of the environment variable `name` and emit a
+/// [`CustomPredicateEvent::WatchEnv`] on stdout so Symposium invalidates the
+/// cached predicate result when the value changes.
+///
+/// [`CustomPredicateEvent::WatchEnv`]: crate::predicate::CustomPredicateEvent::WatchEnv
+pub fn var(name: &str) -> Result<String, env::VarError> {
+    let _ = PredicateEmitter::stdout().watch_env(name);
+    env::var(name)
+}

--- a/symposium-sdk/src/fs.rs
+++ b/symposium-sdk/src/fs.rs
@@ -1,0 +1,22 @@
+//! Filesystem helpers that emit predicate cache events.
+//!
+//! Use these wrappers instead of [`std::fs`] from a custom predicate so that
+//! reading a file also declares a dependency on its contents. Symposium
+//! fingerprints the file (`mtime + size`) at read time and invalidates the
+//! cached predicate result when the fingerprint changes.
+
+use std::io;
+use std::path::Path;
+
+use crate::predicate::PredicateEmitter;
+
+/// Read `path` to a string and emit a
+/// [`CustomPredicateEvent::WatchFile`] on stdout so Symposium invalidates the
+/// cached predicate result when the file changes.
+///
+/// [`CustomPredicateEvent::WatchFile`]: crate::predicate::CustomPredicateEvent::WatchFile
+pub fn read_to_string(path: impl AsRef<Path>) -> io::Result<String> {
+    let path = path.as_ref();
+    let _ = PredicateEmitter::stdout().watch_file(path.to_path_buf());
+    std::fs::read_to_string(path)
+}

--- a/symposium-sdk/src/lib.rs
+++ b/symposium-sdk/src/lib.rs
@@ -29,12 +29,14 @@
 //! # Custom predicates
 //!
 //! A custom predicate binary receives its argument via CLI args and signals
-//! pass/fail via exit code — that is the whole contract today.
+//! pass/fail via exit code. It may also stream [`CustomPredicateEvent`]s on
+//! stdout to describe the inputs whose changes should invalidate its cached
+//! result. Prefer the [`env::var`] and [`fs::read_to_string`] helpers, which
+//! report their inputs automatically.
 //!
-//! FIXME: [`predicate::PredicateEmitter`] is a reserved stdout channel for a
-//! custom predicate to set fields on the plugin (or component) it gates. It was
-//! originally built to name crates for the retired `source = "crate"`
-//! resolution and is currently ignored; see the [`predicate`] module docs.
+//! [`CustomPredicateEvent`]: predicate::CustomPredicateEvent
 
+pub mod env;
+pub mod fs;
 pub mod hook;
 pub mod predicate;

--- a/symposium-sdk/src/predicate.rs
+++ b/symposium-sdk/src/predicate.rs
@@ -1,26 +1,50 @@
 //! Types for custom predicate output.
 //!
-//! FIXME: this witness/emitter channel is currently **unused**. It was built to
-//! let a custom predicate name crates to fetch for the retired `source =
-//! "crate"` skill resolution; custom predicates are now a boolean gate only
-//! (pass/fail via exit code), and Symposium ignores their stdout. The intended
-//! future use is to let a custom predicate **set fields on the plugin (or
-//! component) it gates** — contributing values back into the manifest — through
-//! a channel like this. Until that lands, [`PredicateEmitter`] / [`SelectedCrate`]
-//! have no effect.
-//!
 //! A custom predicate binary communicates its result via:
 //! - **Exit code**: 0 = pass, non-zero = fail.
-//! - **Stdout**: reserved for the future use above; currently ignored.
+//! - **Stdout**: a JSON Lines stream of [`CustomPredicateEvent`] records. See
+//!   the predicate-caching RFD for how Symposium uses these events to cache
+//!   predicate results.
 //!
 //! Use [`PredicateEmitter`] to write records from a Rust predicate binary.
 
 use std::io::{self, Write};
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-/// A crate named by a custom predicate's witness output. Currently unused — see
-/// the module-level FIXME.
+/// A record emitted by a custom predicate on stdout. Each event describes an
+/// input whose change should invalidate the predicate's cached result.
+///
+/// The variants are intentionally granular so new watch kinds can be added
+/// without breaking existing predicate binaries. Older Symposium versions
+/// ignore unknown records; older predicates that emit no events are treated as
+/// having no changing inputs and are cached indefinitely.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub enum CustomPredicateEvent {
+    /// The predicate's result depends on the contents of this file. Symposium
+    /// invalidates the cached result if the file's fingerprint changes.
+    WatchFile(PathBuf),
+
+    /// The predicate's result depends on the value of this environment
+    /// variable. Symposium fingerprints the value at read time.
+    WatchEnv(String),
+
+    /// The predicate's result becomes stale after this many milliseconds.
+    /// `WatchTime(0)` disables caching entirely.
+    WatchTime(u64),
+
+    /// A crate named by a custom predicate's witness output. Retained for
+    /// backward compatibility with the retired `source = "crate"` skill
+    /// resolution; currently ignored by Symposium.
+    SelectedCrate(SelectedCrate),
+}
+
+/// A crate named by a custom predicate's witness output. Retained for
+/// backward compatibility with the retired `source = "crate"` skill
+/// resolution; currently ignored by Symposium.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SelectedCrate {
     pub crate_name: String,
@@ -85,33 +109,43 @@ impl<W: Write> PredicateEmitter<W> {
         Self { writer }
     }
 
+    /// Emit a raw [`CustomPredicateEvent`]. Prefer the typed helpers below.
+    pub fn emit(&mut self, event: &CustomPredicateEvent) -> io::Result<&mut Self> {
+        let line = serde_json::to_string(event)
+            .expect("PredicateEmitter record serialization is infallible");
+        writeln!(self.writer, "{line}")?;
+        Ok(self)
+    }
+
+    /// Declare that the predicate's result depends on `path`. Symposium
+    /// invalidates the cached result when the file's fingerprint changes.
+    pub fn watch_file(&mut self, path: impl Into<PathBuf>) -> io::Result<&mut Self> {
+        self.emit(&CustomPredicateEvent::WatchFile(path.into()))
+    }
+
+    /// Declare that the predicate's result depends on the value of the given
+    /// environment variable.
+    pub fn watch_env(&mut self, name: impl Into<String>) -> io::Result<&mut Self> {
+        self.emit(&CustomPredicateEvent::WatchEnv(name.into()))
+    }
+
+    /// Declare that the predicate's result is only valid for `millis`
+    /// milliseconds. `watch_time(0)` disables caching.
+    pub fn watch_time(&mut self, millis: u64) -> io::Result<&mut Self> {
+        self.emit(&CustomPredicateEvent::WatchTime(millis))
+    }
+
     /// Historically caused Symposium to fetch `name@version` for `source =
     /// "crate"` skill groups; that resolution was retired, so this record is
-    /// currently ignored (see the module-level FIXME).
+    /// currently ignored.
     pub fn selected_crate(
         &mut self,
         name: &str,
         version: &semver::Version,
     ) -> io::Result<&mut Self> {
-        #[derive(Serialize)]
-        struct Record<'a> {
-            #[serde(rename = "selectedCrate")]
-            selected_crate: Inner<'a>,
-        }
-        #[derive(Serialize)]
-        struct Inner<'a> {
-            name: &'a str,
-            version: String,
-        }
-        let record = Record {
-            selected_crate: Inner {
-                name,
-                version: version.to_string(),
-            },
-        };
-        let line = serde_json::to_string(&record)
-            .expect("PredicateEmitter record serialization is infallible");
-        writeln!(self.writer, "{line}")?;
-        Ok(self)
+        self.emit(&CustomPredicateEvent::SelectedCrate(SelectedCrate {
+            crate_name: name.to_string(),
+            version: version.clone(),
+        }))
     }
 }


### PR DESCRIPTION
## What does this PR do?
Implements the [predicate-caching RFD (#262)](https://github.com/symposium-dev/symposium/pull/262). Custom predicates now emit`Watch{File,Env,Time}` JSONL events on stdout. Symposium caches their exit-coderesult in `~/.symposium/cache/predicates/<workspace-hash>.json` and skips
re-evaluation until a watched file, env var, or TTL becomes stale.

Three granular events on a `#[non_exhaustive]` `CustomPredicateEvent` enum

- `WatchFile(PathBuf)` result depends on this file's `mtime + size`.
- `WatchEnv(String)` result depends on this env var's current value.
- `WatchTime(u64)` result becomes stale after this many milliseconds.
- `WatchTime(0)` disables caching.

Exit status still determines pass/fail. Events only control cache lifetime.

#### Cache layout
Per-workspace cache file at `<SymposiumDirs::cache_dir>/predicates/<sha256(canonical workspace_root)>.json`
I think isolating by workspace prevents two projects on the same machine that emit the same predicate string from stepping on each other's cached answers. Schema version tag invalidates on Symposium upgrade.

#### Note
- Built-ins (path_exists, env, shell) stay uncached for now. `path_exists` is one stat, env is one hashmap lookup and the cache check would cost the same as just running them, so caching them doesn't buy anything.  If it's useful to route them through the cache for observability, happy to add.


<details>
<summary>Disclosure questions</summary>

**AI disclosure.**

<!-- Symposium is an AI project. We encourage the use of agentic tooling! We do however require disclosure. The disclosure helps us to calibrate our reviews. See our [PR disclosure policy](https://symposium-dev.github.io/symposium/design/governance.html#pr-disclosure-policy). -->

<!-- Remove the items that do not apply. -->

* I used an AI tool for research, autocomplete, or in other minimal ways
* The AI tool authored small parts of the code (e.g., autocomplete, comments)
* The AI tool authored large parts of the code
* Other: (explain)

**Questions for reviewers.**

<!-- Any specific areas of uncertainty or things you'd like reviewers to look at? -->

</details>
